### PR TITLE
Move from seelog to glog

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ import (
 
 	"github.com/asim/go-micro/server"
 	example "github.com/asim/go-micro/template/proto/example"
-	log "github.com/cihub/seelog"
+	log "github.com/golang/glog"
 )
 
 type Example struct{}
 
 func (e *Example) Call(ctx context.Context, req *example.Request, rsp *example.Response) error {
-	log.Debug("Received Example.Call request")
+	log.Info("Received Example.Call request")
 
 	rsp.Msg = proto.String(server.Id + ": Hello " + req.GetName())
 
@@ -87,10 +87,9 @@ func (e *Example) Call(ctx context.Context, req *example.Request, rsp *example.R
 package main
 
 import (
-	"log"
-
 	"github.com/asim/go-micro/server"
 	"github.com/asim/go-micro/template/handler"
+	log "github.com/golang/glog"
 )
 
 func main() {
@@ -110,7 +109,6 @@ func main() {
 	if err := server.Run(); err != nil {
 		log.Fatal(err)
 	}
-
 }
 ```
 

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/asim/go-micro/errors"
-	log "github.com/cihub/seelog"
+	log "github.com/golang/glog"
 	rpc "github.com/youtube/vitess/go/rpcplus"
 	js "github.com/youtube/vitess/go/rpcplus/jsonrpc"
 	pb "github.com/youtube/vitess/go/rpcplus/pbrpc"
@@ -32,8 +32,8 @@ var (
 func executeRequestSafely(c *serverContext, r *http.Request) {
 	defer func() {
 		if x := recover(); x != nil {
-			log.Criticalf("Panicked on request: %v", r)
-			log.Criticalf("%v: %v", x, string(debug.Stack()))
+			log.Warningf("Panicked on request: %v", r)
+			log.Warningf("%v: %v", x, string(debug.Stack()))
 			err := errors.InternalServerError("go.micro.server", "Unexpected error")
 			c.WriteHeader(500)
 			c.Write([]byte(err.Error()))
@@ -153,7 +153,7 @@ func (s *RpcServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *RpcServer) Init() error {
-	log.Debugf("Rpc handler %s", RpcPath)
+	log.Infof("Rpc handler %s", RpcPath)
 	http.Handle(RpcPath, s)
 	return nil
 }
@@ -184,7 +184,7 @@ func (s *RpcServer) Start() error {
 		return err
 	}
 
-	log.Debugf("Listening on %s", l.Addr().String())
+	log.Infof("Listening on %s", l.Addr().String())
 
 	s.mtx.Lock()
 	s.address = l.Addr().String()

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,7 @@ import (
 	"code.google.com/p/go-uuid/uuid"
 	"github.com/asim/go-micro/registry"
 	"github.com/asim/go-micro/store"
-	log "github.com/cihub/seelog"
+	log "github.com/golang/glog"
 )
 
 type Server interface {
@@ -39,6 +39,7 @@ func init() {
 }
 
 func Init() error {
+	defer log.Flush()
 	flag.Parse()
 
 	switch flagRegistry {
@@ -88,25 +89,25 @@ func Run() error {
 	node := registry.NewNode(Id, host, port)
 	service := registry.NewService(Name, node)
 
-	log.Debugf("Registering %s", node.Id())
+	log.Infof("Registering %s", node.Id())
 	registry.Register(service)
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
-	log.Debugf("Received signal %s", <-ch)
+	log.Infof("Received signal %s", <-ch)
 
-	log.Debugf("Deregistering %s", node.Id())
+	log.Infof("Deregistering %s", node.Id())
 	registry.Deregister(service)
 
 	return Stop()
 }
 
 func Start() error {
-	log.Debugf("Starting server %s id %s", Name, Id)
+	log.Infof("Starting server %s id %s", Name, Id)
 	return DefaultServer.Start()
 }
 
 func Stop() error {
-	log.Debugf("Stopping server")
+	log.Infof("Stopping server")
 	return DefaultServer.Stop()
 }

--- a/server/server_context.go
+++ b/server/server_context.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/asim/go-micro/client"
-	log "github.com/cihub/seelog"
+	log "github.com/golang/glog"
 )
 
 var ctxs = struct {
@@ -109,7 +109,7 @@ func (c *serverContext) Write(b []byte) (int, error) {
 
 func (c *serverContext) WriteHeader(code int) {
 	if c.outCode != 0 {
-		log.Errorf("WriteHeader called multiple times on request.")
+		log.Error("WriteHeader called multiple times on request.")
 		return
 	}
 	c.outCode = code

--- a/template/handler/example.go
+++ b/template/handler/example.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/asim/go-micro/server"
 	example "github.com/asim/go-micro/template/proto/example"
-	log "github.com/cihub/seelog"
+	log "github.com/golang/glog"
 )
 
 type Example struct{}
 
 func (e *Example) Call(ctx context.Context, req *example.Request, rsp *example.Response) error {
-	log.Debug("Received Example.Call request")
+	log.Info("Received Example.Call request")
 
 	rsp.Msg = proto.String(server.Id + ": Hello " + req.GetName())
 

--- a/template/main.go
+++ b/template/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"log"
-
 	"github.com/asim/go-micro/server"
 	"github.com/asim/go-micro/template/handler"
+	log "github.com/golang/glog"
 )
 
 func main() {
@@ -24,5 +23,4 @@ func main() {
 	if err := server.Run(); err != nil {
 		log.Fatal(err)
 	}
-
 }


### PR DESCRIPTION
Some `seelog` pros
- ?

Some `seelog` cons
- Not intuitive API
  - No log.Fatal
  - `seelog.Critical` is just another log level
- Inefficiency
  - `seelog.Critical` and `seelog.Error` always returns useless error structure
  - Benchmarks are the proof

Some `glog` pros
- Much more efficiency
- API is much more intuitive
- Authors of glog are also authors of Go
- Apache 2.0 License

Some `glog` cons
- It's not as fancy

`seelog` output

```
1416690099281057746 [Debug] Rpc handler /_rpc
1416690099281092588 [Debug] Starting server go.micro.service.template id go.micro.service.template-c0bfcb44-728a-11e4-b099-68a86d0d36b6
1416690099281192941 [Debug] Listening on [::]:58264
1416690099281215346 [Debug] Registering go.micro.service.template-c0bfcb44-728a-11e4-b099-68a86d0d36b6
```

`glog` output

```
I0131 15:33:50.961335   13294 rpc_server.go:156] Rpc handler /_rpc
I0131 15:33:51.543554   13294 server.go:106] Starting server my.test.service id my.test.service-2caa899b-a956-11e4-b50b-5404a63901c6
I0131 15:33:51.543686   13294 rpc_server.go:187] Listening on [::]:45646
I0131 15:33:51.543737   13294 server.go:92] Registering my.test.service-2caa899b-a956-11e4-b50b-5404a63901c6
```

Of course it is possible to change log format.

Some [benchmarks](https://gist.github.com/crackcomm/e9d64988bee0596d5b6e) to consider.

```
BenchmarkSeelogErrorf     200000         14671 ns/op         426 B/op         14 allocs/op
BenchmarkSeelogInfof      100000         12938 ns/op         402 B/op         12 allocs/op
BenchmarkGlogInfof        300000          5170 ns/op          16 B/op          1 allocs/op
```

In my opinion all of this comprises into a strong argument for moving towards `glog`.
And of course I think I don't have to explain why logging and a standard format
is really important.

If I didn't point out some important pros/cons - please do. 
