### PR TITLE
Change uuid library

### DIFF
--- a/broker/http/http.go
+++ b/broker/http/http.go
@@ -3,7 +3,7 @@ package http
 // This is a hack
 
 import (
-	"github.com/myodc/go-micro/broker"
+	"github.com/kynrai/go-micro/broker"
 )
 
 func NewBroker(addrs []string, opt ...broker.Option) broker.Broker {

--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/satori/go.uuid"
 	log "github.com/golang/glog"
-	"github.com/myodc/go-micro/errors"
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/errors"
+	"github.com/kynrai/go-micro/registry"
 )
 
 type httpBroker struct {

--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/satori/go.uuid"
 	log "github.com/golang/glog"
 	"github.com/myodc/go-micro/errors"
 	"github.com/myodc/go-micro/registry"
@@ -47,7 +47,7 @@ func newHttpBroker(addrs []string, opt ...Option) Broker {
 	}
 
 	return &httpBroker{
-		id:          "broker-" + uuid.NewUUID().String(),
+		id:          "broker-" + uuid.NewV4().String(),
 		address:     addr,
 		subscribers: make(map[string][]*httpSubscriber),
 		unsubscribe: make(chan *httpSubscriber),
@@ -171,7 +171,7 @@ func (h *httpBroker) Disconnect() error {
 
 func (h *httpBroker) Init() error {
 	if len(h.id) == 0 {
-		h.id = "broker-" + uuid.NewUUID().String()
+		h.id = "broker-" + uuid.NewV4().String()
 	}
 
 	http.Handle(DefaultSubPath, h)
@@ -219,7 +219,7 @@ func (h *httpBroker) Subscribe(topic string, handler Handler) (Subscriber, error
 	}
 
 	subscriber := &httpSubscriber{
-		id:    uuid.NewUUID().String(),
+		id:    uuid.NewV4().String(),
 		topic: topic,
 		ch:    h.unsubscribe,
 		fn:    handler,

--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/apcera/nats"
-	"github.com/myodc/go-micro/broker"
+	"github.com/kynrai/go-micro/broker"
 )
 
 type nbroker struct {

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -1,7 +1,7 @@
 package rabbitmq
 
 import (
-	"github.com/myodc/go-micro/broker"
+	"github.com/kynrai/go-micro/broker"
 	"github.com/streadway/amqp"
 )
 

--- a/client/options.go
+++ b/client/options.go
@@ -1,9 +1,9 @@
 package client
 
 import (
-	"github.com/myodc/go-micro/broker"
-	"github.com/myodc/go-micro/registry"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/broker"
+	"github.com/kynrai/go-micro/registry"
+	"github.com/kynrai/go-micro/transport"
 )
 
 type options struct {

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/myodc/go-micro/broker"
-	c "github.com/myodc/go-micro/context"
-	"github.com/myodc/go-micro/errors"
-	"github.com/myodc/go-micro/registry"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/broker"
+	c "github.com/kynrai/go-micro/context"
+	"github.com/kynrai/go-micro/errors"
+	"github.com/kynrai/go-micro/registry"
+	"github.com/kynrai/go-micro/transport"
 
 	rpc "github.com/youtube/vitess/go/rpcplus"
 

--- a/client/rpc_codec.go
+++ b/client/rpc_codec.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/transport"
 	rpc "github.com/youtube/vitess/go/rpcplus"
 	js "github.com/youtube/vitess/go/rpcplus/jsonrpc"
 	pb "github.com/youtube/vitess/go/rpcplus/pbrpc"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	thttp "github.com/kynrai/go-micro/transport/http"
 	tnats "github.com/kynrai/go-micro/transport/nats"
 	trmq "github.com/kynrai/go-micro/transport/rabbitmq"
+	"flag"
 )
 
 var (
@@ -145,6 +146,7 @@ func Setup(c *cli.Context) error {
 }
 
 func Init() {
+	flag.Parse()
 	cli.AppHelpTemplate = `
 GLOBAL OPTIONS:
    {{range .Flags}}{{.}}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,26 +8,26 @@ import (
 	"text/template"
 
 	"github.com/codegangsta/cli"
-	"github.com/myodc/go-micro/broker"
-	"github.com/myodc/go-micro/client"
-	"github.com/myodc/go-micro/registry"
-	"github.com/myodc/go-micro/server"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/broker"
+	"github.com/kynrai/go-micro/client"
+	"github.com/kynrai/go-micro/registry"
+	"github.com/kynrai/go-micro/server"
+	"github.com/kynrai/go-micro/transport"
 
 	// brokers
-	"github.com/myodc/go-micro/broker/http"
-	"github.com/myodc/go-micro/broker/nats"
-	"github.com/myodc/go-micro/broker/rabbitmq"
+	"github.com/kynrai/go-micro/broker/http"
+	"github.com/kynrai/go-micro/broker/nats"
+	"github.com/kynrai/go-micro/broker/rabbitmq"
 
 	// registries
-	"github.com/myodc/go-micro/registry/consul"
-	"github.com/myodc/go-micro/registry/etcd"
-	"github.com/myodc/go-micro/registry/kubernetes"
+	"github.com/kynrai/go-micro/registry/consul"
+	"github.com/kynrai/go-micro/registry/etcd"
+	"github.com/kynrai/go-micro/registry/kubernetes"
 
 	// transport
-	thttp "github.com/myodc/go-micro/transport/http"
-	tnats "github.com/myodc/go-micro/transport/nats"
-	trmq "github.com/myodc/go-micro/transport/rabbitmq"
+	thttp "github.com/kynrai/go-micro/transport/http"
+	tnats "github.com/kynrai/go-micro/transport/nats"
+	trmq "github.com/kynrai/go-micro/transport/rabbitmq"
 )
 
 var (

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"fmt"
 
-	"github.com/myodc/go-micro/client"
-	"github.com/myodc/go-micro/cmd"
-	c "github.com/myodc/go-micro/context"
-	example "github.com/myodc/go-micro/examples/server/proto/example"
+	"github.com/kynrai/go-micro/client"
+	"github.com/kynrai/go-micro/cmd"
+	c "github.com/kynrai/go-micro/context"
+	example "github.com/kynrai/go-micro/examples/server/proto/example"
 	"golang.org/x/net/context"
 )
 

--- a/examples/pubsub/main.go
+++ b/examples/pubsub/main.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/myodc/go-micro/broker"
-	"github.com/myodc/go-micro/cmd"
+	"github.com/kynrai/go-micro/broker"
+	"github.com/kynrai/go-micro/cmd"
 )
 
 var (

--- a/examples/server/handler/example.go
+++ b/examples/server/handler/example.go
@@ -2,9 +2,9 @@ package handler
 
 import (
 	log "github.com/golang/glog"
-	c "github.com/myodc/go-micro/context"
-	example "github.com/myodc/go-micro/examples/server/proto/example"
-	"github.com/myodc/go-micro/server"
+	c "github.com/kynrai/go-micro/context"
+	example "github.com/kynrai/go-micro/examples/server/proto/example"
+	"github.com/kynrai/go-micro/server"
 
 	"golang.org/x/net/context"
 )

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	log "github.com/golang/glog"
-	"github.com/myodc/go-micro/cmd"
-	"github.com/myodc/go-micro/examples/server/handler"
-	"github.com/myodc/go-micro/examples/server/subscriber"
-	"github.com/myodc/go-micro/server"
+	"github.com/kynrai/go-micro/cmd"
+	"github.com/kynrai/go-micro/examples/server/handler"
+	"github.com/kynrai/go-micro/examples/server/subscriber"
+	"github.com/kynrai/go-micro/server"
 )
 
 func main() {

--- a/examples/server/subscriber/subscriber.go
+++ b/examples/server/subscriber/subscriber.go
@@ -2,7 +2,7 @@ package subscriber
 
 import (
 	log "github.com/golang/glog"
-	example "github.com/myodc/go-micro/examples/server/proto/example"
+	example "github.com/kynrai/go-micro/examples/server/proto/example"
 	"golang.org/x/net/context"
 )
 

--- a/registry/consul/consul.go
+++ b/registry/consul/consul.go
@@ -3,7 +3,7 @@ package consul
 // This is a hack
 
 import (
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 func NewRegistry(addrs []string, opt ...registry.Option) registry.Registry {

--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 var (

--- a/registry/etcd/watcher.go
+++ b/registry/etcd/watcher.go
@@ -2,7 +2,7 @@ package etcd
 
 import (
 	"github.com/coreos/go-etcd/etcd"
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 type etcdWatcher struct {

--- a/registry/kubernetes/kubernetes.go
+++ b/registry/kubernetes/kubernetes.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"sync"
 
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 
-	k8s "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	k8s "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 type kregistry struct {

--- a/registry/kubernetes/watcher.go
+++ b/registry/kubernetes/watcher.go
@@ -3,11 +3,11 @@ package kubernetes
 import (
 	"net"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	"github.com/myodc/go-micro/registry"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+	"github.com/kynrai/go-micro/registry"
 )
 
 type watcher struct {

--- a/server/extractor.go
+++ b/server/extractor.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 func extractValue(v reflect.Type) *registry.Value {

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 type Handler interface {

--- a/server/health_checker.go
+++ b/server/health_checker.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/myodc/go-micro/server/proto/health"
+	"github.com/kynrai/go-micro/server/proto/health"
 	"golang.org/x/net/context"
 )
 

--- a/server/options.go
+++ b/server/options.go
@@ -1,9 +1,9 @@
 package server
 
 import (
-	"github.com/myodc/go-micro/broker"
-	"github.com/myodc/go-micro/registry"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/broker"
+	"github.com/kynrai/go-micro/registry"
+	"github.com/kynrai/go-micro/transport"
 )
 
 type options struct {

--- a/server/rpc_codec.go
+++ b/server/rpc_codec.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/transport"
 	rpc "github.com/youtube/vitess/go/rpcplus"
 	js "github.com/youtube/vitess/go/rpcplus/jsonrpc"
 	pb "github.com/youtube/vitess/go/rpcplus/pbrpc"

--- a/server/rpc_handler.go
+++ b/server/rpc_handler.go
@@ -3,7 +3,7 @@ package server
 import (
 	"reflect"
 
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/registry"
 )
 
 type rpcHandler struct {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/myodc/go-micro/broker"
-	c "github.com/myodc/go-micro/context"
-	"github.com/myodc/go-micro/registry"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/broker"
+	c "github.com/kynrai/go-micro/context"
+	"github.com/kynrai/go-micro/registry"
+	"github.com/kynrai/go-micro/transport"
 
 	log "github.com/golang/glog"
 	rpc "github.com/youtube/vitess/go/rpcplus"

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/satori/go.uuid"
 	log "github.com/golang/glog"
 )
 
@@ -28,7 +28,7 @@ var (
 	DefaultAddress        = ":0"
 	DefaultName           = "go-server"
 	DefaultVersion        = "1.0.0"
-	DefaultId             = uuid.NewUUID().String()
+	DefaultId             = uuid.NewV4().String()
 	DefaultServer  Server = newRpcServer()
 )
 

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/myodc/go-micro/broker"
-	c "github.com/myodc/go-micro/context"
-	"github.com/myodc/go-micro/registry"
+	"github.com/kynrai/go-micro/broker"
+	c "github.com/kynrai/go-micro/context"
+	"github.com/kynrai/go-micro/registry"
 	"golang.org/x/net/context"
 )
 

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -3,7 +3,7 @@ package http
 // This is a hack
 
 import (
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/transport"
 )
 
 func NewTransport(addrs []string, opt ...transport.Option) transport.Transport {

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/apcera/nats"
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/transport"
 )
 
 type ntport struct {

--- a/transport/rabbitmq/rabbitmq.go
+++ b/transport/rabbitmq/rabbitmq.go
@@ -9,7 +9,7 @@ import (
 	uuid "github.com/nu7hatch/gouuid"
 	"github.com/streadway/amqp"
 
-	"github.com/myodc/go-micro/transport"
+	"github.com/kynrai/go-micro/transport"
 )
 
 type rmqtport struct {


### PR DESCRIPTION
Switch to using a different UUID library before code.google shuts down

I am not entirely sure on the version of UUID required by these methods but the proposed library supports them all. Whichever library is used, such as the one used in the rabbitmq module, code.google needs to change
