### PR TITLE
DebugHandler: add default health checker.

### DIFF
--- a/server/debug_handler.go
+++ b/server/debug_handler.go
@@ -5,7 +5,15 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Debug struct{}
+type (
+	HealthChecker interface {
+		Health(ctx context.Context, req *health.Request, rsp *health.Response) error
+	}
+
+	Debug struct{}
+)
+
+var DefaultHealthChecker HealthChecker = new(Debug)
 
 func (d *Debug) Health(ctx context.Context, req *health.Request, rsp *health.Response) error {
 	rsp.Status = "ok"
@@ -13,5 +21,5 @@ func (d *Debug) Health(ctx context.Context, req *health.Request, rsp *health.Res
 }
 
 func registerHealthChecker(s Server) {
-	s.Handle(s.NewHandler(&Debug{}))
+	s.Handle(s.NewHandler(DefaultHealthChecker))
 }


### PR DESCRIPTION
By using a DefaultHealthChecker - as with a DefaultName, DefaultServer,
... - it is possible to overwrite the default implementation. This means
we can now do extra actions in our health check that is necessary for
the applications specific needs.
