### PR TITLE
Debug: use the DebugHandler interface.

### DIFF
--- a/server/debug/debug.go
+++ b/server/debug/debug.go
@@ -18,7 +18,7 @@ type DebugHandler interface {
 type debug struct{}
 
 var (
-	DefaultDebugHandler = new(debug)
+	DefaultDebugHandler DebugHandler = new(debug)
 )
 
 func (d *debug) Health(ctx context.Context, req *proto.HealthRequest, rsp *proto.HealthResponse) error {


### PR DESCRIPTION
Without specifying the interface, DefaultDebugHandler has to be of type
*"github.com/micro/go-micro/server/debug".debug.
