### PR TITLE
TTL for Service Registration

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package micro
 
 import (
+	"time"
+
 	"github.com/micro/cli"
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/client"
@@ -19,6 +21,10 @@ type Options struct {
 	Server    server.Server
 	Registry  registry.Registry
 	Transport transport.Transport
+
+	// Registration options
+	RegisterTTL      time.Duration
+	RegisterInterval time.Duration
 
 	// Before and After funcs
 	BeforeStart []func() error
@@ -114,6 +120,18 @@ func Flags(flags ...cli.Flag) Option {
 func Action(a func(*cli.Context)) Option {
 	return func(o *Options) {
 		o.Cmd.App().Action = a
+	}
+}
+
+func RegisterTTL(t time.Duration) Option {
+	return func(o *Options) {
+		o.RegisterTTL = t
+	}
+}
+
+func RegisterInterval(t time.Duration) Option {
+	return func(o *Options) {
+		o.RegisterInterval = t
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -22,8 +22,7 @@ type Options struct {
 	Registry  registry.Registry
 	Transport transport.Transport
 
-	// Registration options
-	RegisterTTL      time.Duration
+	// Register loop interval
 	RegisterInterval time.Duration
 
 	// Before and After funcs
@@ -125,7 +124,7 @@ func Action(a func(*cli.Context)) Option {
 
 func RegisterTTL(t time.Duration) Option {
 	return func(o *Options) {
-		o.RegisterTTL = t
+		o.Server.Init(server.RegisterTTL(t))
 	}
 }
 

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -161,17 +161,26 @@ func (c *consulRegistry) Deregister(s *Service) error {
 
 	node := s.Nodes[0]
 
-	_, err := c.Client.Catalog().Deregister(&consul.CatalogDeregistration{
+	if _, err := c.Client.Catalog().Deregister(&consul.CatalogDeregistration{
 		Node:      node.Id,
 		Address:   node.Address,
 		ServiceID: node.Id,
-	}, nil)
-	return err
+		CheckID:   node.Id,
+	}, nil); err != nil {
+		return err
+	}
+
+	return c.Client.Agent().ServiceDeregister(node.Id)
 }
 
-func (c *consulRegistry) Register(s *Service) error {
+func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
 	if len(s.Nodes) == 0 {
 		return errors.New("Require at least one node")
+	}
+
+	var options RegisterOptions
+	for _, o := range opts {
+		o(&options)
 	}
 
 	node := s.Nodes[0]
@@ -191,15 +200,37 @@ func (c *consulRegistry) Register(s *Service) error {
 			Tags:    tags,
 			Address: node.Address,
 		},
+		Check: &consul.AgentCheck{
+			Node: node.Id,
+			CheckID:     node.Id,
+			Name:        s.Name,
+			ServiceID:   node.Id,
+			ServiceName: s.Name,
+			Status:      "passing",
+		},
 	}, nil); err != nil {
 		return err
 	}
 
-	return nil
+	if options.TTL <= time.Duration(0) {
+		return nil
+	}
+
+	// this is cruft
+	return c.Client.Agent().ServiceRegister(&consul.AgentServiceRegistration{
+		ID: node.Id,
+		Name: s.Name,
+		Tags: tags,
+		Port: node.Port,
+		Address: node.Address,
+		Check: &consul.AgentServiceCheck{
+			TTL: fmt.Sprintf("%v", options.TTL),
+		},
+	})
 }
 
 func (c *consulRegistry) GetService(name string) ([]*Service, error) {
-	rsp, _, err := c.Client.Catalog().Service(name, "", nil)
+	rsp, _, err := c.Client.Health().Service(name, "", true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -207,37 +238,37 @@ func (c *consulRegistry) GetService(name string) ([]*Service, error) {
 	serviceMap := map[string]*Service{}
 
 	for _, s := range rsp {
-		if s.ServiceName != name {
+		if s.Service.Service != name {
 			continue
 		}
 
 		// version is now a tag
-		version, found := decodeVersion(s.ServiceTags)
+		version, found := decodeVersion(s.Service.Tags)
 		// service ID is now the node id
-		id := s.ServiceID
+		id := s.Service.ID
 		// key is always the version
 		key := version
 		// address is service address
-		address := s.ServiceAddress
+		address := s.Service.Address
 
 		// if we can't get the new type of version
 		// use old the old ways
 		if !found {
 			// id was set as node
-			id = s.Node
+			id = s.Node.Node
 			// key was service id
-			key = s.ServiceID
+			key = s.Service.ID
 			// version was service id
-			version = s.ServiceID
+			version = s.Service.ID
 			// address was address
-			address = s.Address
+			address = s.Node.Address
 		}
 
 		svc, ok := serviceMap[key]
 		if !ok {
 			svc = &Service{
-				Endpoints: decodeEndpoints(s.ServiceTags),
-				Name:      s.ServiceName,
+				Endpoints: decodeEndpoints(s.Service.Tags),
+				Name:      s.Service.Service,
 				Version:   version,
 			}
 			serviceMap[key] = svc
@@ -246,8 +277,8 @@ func (c *consulRegistry) GetService(name string) ([]*Service, error) {
 		svc.Nodes = append(svc.Nodes, &Node{
 			Id:       id,
 			Address:  address,
-			Port:     s.ServicePort,
-			Metadata: decodeMetadata(s.ServiceTags),
+			Port:     s.Service.Port,
+			Metadata: decodeMetadata(s.Service.Tags),
 		})
 	}
 

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -53,7 +53,7 @@ func (m *MockRegistry) ListServices() ([]*registry.Service, error) {
 	return []*registry.Service{}, nil
 }
 
-func (m *MockRegistry) Register(s *registry.Service) error {
+func (m *MockRegistry) Register(s *registry.Service, opts ...registry.RegisterOption) error {
 	return nil
 }
 

--- a/registry/options.go
+++ b/registry/options.go
@@ -44,7 +44,7 @@ func TLSConfig(t *tls.Config) Option {
 	}
 }
 
-func WithTTL(t time.Duration) RegisterOption {
+func RegisterTTL(t time.Duration) RegisterOption {
 	return func(o *RegisterOptions) {
 		o.TTL = t
 	}

--- a/registry/options.go
+++ b/registry/options.go
@@ -17,6 +17,13 @@ type Options struct {
 	Context context.Context
 }
 
+type RegisterOptions struct {
+	TTL time.Duration
+	// Other options for implementations of the interface
+	// can be stored in a context
+	Context context.Context
+}
+
 func Timeout(t time.Duration) Option {
 	return func(o *Options) {
 		o.Timeout = t
@@ -34,5 +41,11 @@ func Secure(b bool) Option {
 func TLSConfig(t *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = t
+	}
+}
+
+func WithTTL(t time.Duration) RegisterOption {
+	return func(o *RegisterOptions) {
+		o.TTL = t
 	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,7 +1,7 @@
 package registry
 
 type Registry interface {
-	Register(*Service) error
+	Register(*Service, ...RegisterOption) error
 	Deregister(*Service) error
 	GetService(string) ([]*Service, error)
 	ListServices() ([]*Service, error)
@@ -11,6 +11,8 @@ type Registry interface {
 
 type Option func(*Options)
 
+type RegisterOption func(*RegisterOptions)
+
 var (
 	DefaultRegistry = newConsulRegistry([]string{})
 )
@@ -19,8 +21,8 @@ func NewRegistry(addrs []string, opt ...Option) Registry {
 	return newConsulRegistry(addrs, opt...)
 }
 
-func Register(s *Service) error {
-	return DefaultRegistry.Register(s)
+func Register(s *Service, opts ...RegisterOption) error {
+	return DefaultRegistry.Register(s, opts...)
 }
 
 func Deregister(s *Service) error {

--- a/server/options.go
+++ b/server/options.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/codec"
 	"github.com/micro/go-micro/registry"
@@ -30,6 +32,10 @@ type Options struct {
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
+}
+
+type RegisterOptions struct {
+	TTL time.Duration
 }
 
 func newOptions(opt ...Option) Options {
@@ -165,5 +171,12 @@ func WrapHandler(w HandlerWrapper) Option {
 func WrapSubscriber(w SubscriberWrapper) Option {
 	return func(o *Options) {
 		o.SubWrappers = append(o.SubWrappers, w)
+	}
+}
+
+// Register the service with a TTL
+func RegisterTTL(t time.Duration) RegisterOption {
+	return func(o *RegisterOptions) {
+		o.TTL = t
 	}
 }

--- a/server/options.go
+++ b/server/options.go
@@ -26,16 +26,14 @@ type Options struct {
 	HdlrWrappers []HandlerWrapper
 	SubWrappers  []SubscriberWrapper
 
+	RegisterTTL time.Duration
+
 	// Debug Handler which can be set by a user
 	DebugHandler debug.DebugHandler
 
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
-}
-
-type RegisterOptions struct {
-	TTL time.Duration
 }
 
 func newOptions(opt ...Option) Options {
@@ -160,6 +158,13 @@ func Metadata(md map[string]string) Option {
 	}
 }
 
+// Register the service with a TTL
+func RegisterTTL(t time.Duration) Option {
+	return func(o *Options) {
+		o.RegisterTTL = t
+	}
+}
+
 // Adds a handler Wrapper to a list of options passed into the server
 func WrapHandler(w HandlerWrapper) Option {
 	return func(o *Options) {
@@ -171,12 +176,5 @@ func WrapHandler(w HandlerWrapper) Option {
 func WrapSubscriber(w SubscriberWrapper) Option {
 	return func(o *Options) {
 		o.SubWrappers = append(o.SubWrappers, w)
-	}
-}
-
-// Register the service with a TTL
-func RegisterTTL(t time.Duration) RegisterOption {
-	return func(o *RegisterOptions) {
-		o.TTL = t
 	}
 }

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -155,15 +155,7 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 	return nil
 }
 
-func (s *rpcServer) Register(opts ...RegisterOption) error {
-	var options RegisterOptions
-	for _, o := range opts {
-		o(&options)
-	}
-
-	// create registry options
-	rOpts := []registry.RegisterOption{registry.WithTTL(options.TTL)}
-
+func (s *rpcServer) Register() error {
 	// parse address for host, port
 	config := s.Options()
 	var advt, host string
@@ -228,6 +220,9 @@ func (s *rpcServer) Register(opts ...RegisterOption) error {
 	}
 
 	log.Infof("Registering node: %s", node.Id)
+	// create registry options
+	rOpts := []registry.RegisterOption{registry.RegisterTTL(config.RegisterTTL)}
+
 	if err := config.Registry.Register(service, rOpts...); err != nil {
 		return err
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -155,7 +155,15 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 	return nil
 }
 
-func (s *rpcServer) Register() error {
+func (s *rpcServer) Register(opts ...RegisterOption) error {
+	var options RegisterOptions
+	for _, o := range opts {
+		o(&options)
+	}
+
+	// create registry options
+	rOpts := []registry.RegisterOption{registry.WithTTL(options.TTL)}
+
 	// parse address for host, port
 	config := s.Options()
 	var advt, host string
@@ -220,7 +228,7 @@ func (s *rpcServer) Register() error {
 	}
 
 	log.Infof("Registering node: %s", node.Id)
-	if err := config.Registry.Register(service); err != nil {
+	if err := config.Registry.Register(service, rOpts...); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,7 @@ type Server interface {
 	NewHandler(interface{}, ...HandlerOption) Handler
 	NewSubscriber(string, interface{}, ...SubscriberOption) Subscriber
 	Subscribe(Subscriber) error
-	Register(...RegisterOption) error
+	Register() error
 	Deregister() error
 	Start() error
 	Stop() error
@@ -85,8 +85,6 @@ type Option func(*Options)
 type HandlerOption func(*HandlerOptions)
 
 type SubscriberOption func(*SubscriberOptions)
-
-type RegisterOption func(*RegisterOptions)
 
 var (
 	DefaultAddress        = ":0"

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,7 @@ type Server interface {
 	NewHandler(interface{}, ...HandlerOption) Handler
 	NewSubscriber(string, interface{}, ...SubscriberOption) Subscriber
 	Subscribe(Subscriber) error
-	Register() error
+	Register(...RegisterOption) error
 	Deregister() error
 	Start() error
 	Stop() error
@@ -85,6 +85,8 @@ type Option func(*Options)
 type HandlerOption func(*HandlerOptions)
 
 type SubscriberOption func(*SubscriberOptions)
+
+type RegisterOption func(*RegisterOptions)
 
 var (
 	DefaultAddress        = ":0"

--- a/service.go
+++ b/service.go
@@ -1,7 +1,6 @@
 package micro
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -42,9 +41,7 @@ func (s *service) run(exit chan bool) {
 	for {
 		select {
 		case <-t.C:
-			fmt.Println("heartbeat")
 			if err := s.opts.Server.Register(server.RegisterTTL(s.opts.RegisterTTL)); err != nil {
-				fmt.Println("FUCK", err)
 			}
 		case <-exit:
 			t.Stop()

--- a/service.go
+++ b/service.go
@@ -41,8 +41,7 @@ func (s *service) run(exit chan bool) {
 	for {
 		select {
 		case <-t.C:
-			if err := s.opts.Server.Register(server.RegisterTTL(s.opts.RegisterTTL)); err != nil {
-			}
+			s.opts.Server.Register()
 		case <-exit:
 			t.Stop()
 			return
@@ -102,7 +101,7 @@ func (s *service) Start() error {
 		return err
 	}
 
-	if err := s.opts.Server.Register(server.RegisterTTL(s.opts.RegisterTTL)); err != nil {
+	if err := s.opts.Server.Register(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Allow services to be registered with a TTL. Top level init also provides an interval to reregister automatically.
