### PR TITLE
Add Service in a Wrapper available to handlers

### DIFF
--- a/service.go
+++ b/service.go
@@ -26,9 +26,15 @@ func newService(opts ...Option) Service {
 		},
 	}
 
-	return &service{
+	s := &service{
 		opts: options,
 	}
+
+	s.opts.Server.Init(
+		server.WrapHandler(serverWrapper(s)),
+	)
+
+	return s
 }
 
 func (s *service) run(exit chan bool) {

--- a/wrapper.go
+++ b/wrapper.go
@@ -3,6 +3,7 @@ package micro
 import (
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/metadata"
+	"github.com/micro/go-micro/server"
 
 	"golang.org/x/net/context"
 )
@@ -25,4 +26,13 @@ func (c *clientWrapper) Stream(ctx context.Context, req client.Request, opts ...
 func (c *clientWrapper) Publish(ctx context.Context, p client.Publication, opts ...client.PublishOption) error {
 	ctx = metadata.NewContext(ctx, c.headers)
 	return c.Client.Publish(ctx, p, opts...)
+}
+
+func serverWrapper(s Service) server.HandlerWrapper {
+	return func(fn server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) error {
+			ctx = NewContext(ctx, s)
+			return fn(ctx, req, rsp)
+		}
+	}
 }


### PR DESCRIPTION
This adds Service within a wrapper making it available to handlers. So they can do `service, ok :=  micro.FromContext(ctx)`. Not yet sure if it should be added as it it delves into the realm of the user.
