### PR TITLE
Fix Consul WARN issues for tags

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -39,74 +38,6 @@ func newTransport(config *tls.Config) *http.Transport {
 		(*tr).CloseIdleConnections()
 	})
 	return t
-}
-
-func encodeEndpoints(en []*Endpoint) []string {
-	var tags []string
-	for _, e := range en {
-		if b, err := json.Marshal(e); err == nil {
-			tags = append(tags, "e="+string(b))
-		}
-	}
-	return tags
-}
-
-func decodeEndpoints(tags []string) []*Endpoint {
-	var en []*Endpoint
-	for _, tag := range tags {
-		if len(tag) == 0 || tag[0] != 'e' {
-			continue
-		}
-
-		var e *Endpoint
-		if err := json.Unmarshal([]byte(tag[2:]), &e); err == nil {
-			en = append(en, e)
-		}
-	}
-	return en
-}
-
-func encodeMetadata(md map[string]string) []string {
-	var tags []string
-	for k, v := range md {
-		if b, err := json.Marshal(map[string]string{
-			k: v,
-		}); err == nil {
-			tags = append(tags, "t="+string(b))
-		}
-	}
-	return tags
-}
-
-func decodeMetadata(tags []string) map[string]string {
-	md := make(map[string]string)
-	for _, tag := range tags {
-		if len(tag) == 0 || tag[0] != 't' {
-			continue
-		}
-
-		var kv map[string]string
-		if err := json.Unmarshal([]byte(tag[2:]), &kv); err == nil {
-			for k, v := range kv {
-				md[k] = v
-			}
-		}
-	}
-	return md
-}
-
-func encodeVersion(v string) string {
-	return "v=" + v
-}
-
-func decodeVersion(tags []string) (string, bool) {
-	for _, tag := range tags {
-		if len(tag) == 0 || tag[0] != 'v' {
-			continue
-		}
-		return tag[2:], true
-	}
-	return "", false
 }
 
 func newConsulRegistry(opts ...Option) Registry {

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -108,7 +108,7 @@ func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
 
 	tags := encodeMetadata(node.Metadata)
 	tags = append(tags, encodeEndpoints(s.Endpoints)...)
-	tags = append(tags, encodeVersion(s.Version))
+	tags = append(tags, encodeVersion(s.Version)...)
 
 	var check *consul.AgentServiceCheck
 

--- a/registry/encoding.go
+++ b/registry/encoding.go
@@ -45,6 +45,10 @@ func encodeEndpoints(en []*Endpoint) []string {
 	var tags []string
 	for _, e := range en {
 		if b, err := json.Marshal(e); err == nil {
+			// old encoding
+			// TODO: remove in 09/2016
+			tags = append(tags, "e="+string(b))
+			// new encoding
 			tags = append(tags, "e-"+encode(b))
 		}
 	}
@@ -84,6 +88,10 @@ func encodeMetadata(md map[string]string) []string {
 		if b, err := json.Marshal(map[string]string{
 			k: v,
 		}); err == nil {
+			// old encoding
+			// TODO: remove in 09/2016
+			tags = append(tags, "t="+string(b))
+			// new encoding
 			tags = append(tags, "t-"+encode(b))
 		}
 	}
@@ -120,8 +128,14 @@ func decodeMetadata(tags []string) map[string]string {
 	return md
 }
 
-func encodeVersion(v string) string {
-	return "v-" + encode([]byte(v))
+func encodeVersion(v string) []string {
+	return []string{
+		// old encoding,
+		// TODO: remove in 09/2016
+		"v=" + v,
+		// new encoding,
+		"v-" + encode([]byte(v)),
+	}
 }
 
 func decodeVersion(tags []string) (string, bool) {

--- a/registry/encoding.go
+++ b/registry/encoding.go
@@ -57,8 +57,17 @@ func encodeEndpoints(en []*Endpoint) []string {
 
 func decodeEndpoints(tags []string) []*Endpoint {
 	var en []*Endpoint
+
+	// use the first format you find
+	var ver byte
+
 	for _, tag := range tags {
 		if len(tag) == 0 || tag[0] != 'e' {
+			continue
+		}
+
+		// check version
+		if ver > 0 && tag[1] != ver {
 			continue
 		}
 
@@ -78,6 +87,9 @@ func decodeEndpoints(tags []string) []*Endpoint {
 		if err := json.Unmarshal(buf, &e); err == nil {
 			en = append(en, e)
 		}
+
+		// set version
+		ver = tag[1]
 	}
 	return en
 }
@@ -100,8 +112,16 @@ func encodeMetadata(md map[string]string) []string {
 
 func decodeMetadata(tags []string) map[string]string {
 	md := make(map[string]string)
+
+	var ver byte
+
 	for _, tag := range tags {
 		if len(tag) == 0 || tag[0] != 't' {
+			continue
+		}
+
+		// check version
+		if ver > 0 && tag[1] != ver {
 			continue
 		}
 
@@ -124,6 +144,9 @@ func decodeMetadata(tags []string) map[string]string {
 				md[k] = v
 			}
 		}
+
+		// set version
+		ver = tag[1]
 	}
 	return md
 }

--- a/registry/encoding.go
+++ b/registry/encoding.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+)
+
+func encode(buf []byte) string {
+	var b bytes.Buffer
+	defer b.Reset()
+
+	w := zlib.NewWriter(&b)
+	if _, err := w.Write(buf); err != nil {
+		return ""
+	}
+	w.Close()
+
+	return hex.EncodeToString(b.Bytes())
+}
+
+func decode(d string) []byte {
+	hr, err := hex.DecodeString(d)
+	if err != nil {
+		return nil
+	}
+
+	br := bytes.NewReader(hr)
+	zr, err := zlib.NewReader(br)
+	if err != nil {
+		return nil
+	}
+
+	rbuf, err := ioutil.ReadAll(zr)
+	if err != nil {
+		return nil
+	}
+
+	return rbuf
+}
+
+func encodeEndpoints(en []*Endpoint) []string {
+	var tags []string
+	for _, e := range en {
+		if b, err := json.Marshal(e); err == nil {
+			tags = append(tags, "e-"+encode(b))
+		}
+	}
+	return tags
+}
+
+func decodeEndpoints(tags []string) []*Endpoint {
+	var en []*Endpoint
+	for _, tag := range tags {
+		if len(tag) == 0 || tag[0] != 'e' {
+			continue
+		}
+
+		var e *Endpoint
+		var buf []byte
+
+		// Old encoding was plain
+		if tag[1] == '=' {
+			buf = []byte(tag[2:])
+		}
+
+		// New encoding is hex
+		if tag[1] == '-' {
+			buf = decode(tag[2:])
+		}
+
+		if err := json.Unmarshal(buf, &e); err == nil {
+			en = append(en, e)
+		}
+	}
+	return en
+}
+
+func encodeMetadata(md map[string]string) []string {
+	var tags []string
+	for k, v := range md {
+		if b, err := json.Marshal(map[string]string{
+			k: v,
+		}); err == nil {
+			tags = append(tags, "t-"+encode(b))
+		}
+	}
+	return tags
+}
+
+func decodeMetadata(tags []string) map[string]string {
+	md := make(map[string]string)
+	for _, tag := range tags {
+		if len(tag) == 0 || tag[0] != 't' {
+			continue
+		}
+
+		var kv map[string]string
+		var buf []byte
+
+		// Old encoding was plain
+		if tag[1] == '=' {
+			buf = []byte(tag[2:])
+		}
+
+		// New encoding is hex
+		if tag[1] == '-' {
+			buf = decode(tag[2:])
+		}
+
+		// Now unmarshal
+		if err := json.Unmarshal(buf, &kv); err == nil {
+			for k, v := range kv {
+				md[k] = v
+			}
+		}
+	}
+	return md
+}
+
+func encodeVersion(v string) string {
+	return "v-" + encode([]byte(v))
+}
+
+func decodeVersion(tags []string) (string, bool) {
+	for _, tag := range tags {
+		if len(tag) < 2 || tag[0] != 'v' {
+			continue
+		}
+
+		// Old encoding was plain
+		if tag[1] == '=' {
+			return tag[2:], true
+		}
+
+		// New encoding is hex
+		if tag[1] == '-' {
+			return string(decode(tag[2:])), true
+		}
+	}
+	return "", false
+}

--- a/registry/encoding_test.go
+++ b/registry/encoding_test.go
@@ -33,7 +33,7 @@ func TestEncodingEndpoints(t *testing.T) {
 	for _, data := range testData {
 		e := encodeEndpoints([]*Endpoint{data.decoded})
 
-		if len(e) != 1 || e[0] != data.encoded {
+		if len(e) != 2 || e[1] != data.encoded {
 			t.Fatalf("Expected %s got %s", data.encoded, e)
 		}
 
@@ -82,11 +82,11 @@ func TestEncodingVersion(t *testing.T) {
 	for _, data := range testData {
 		e := encodeVersion(data.decoded)
 
-		if e != data.encoded {
+		if e[1] != data.encoded {
 			t.Fatalf("Expected %s got %s", data.encoded, e)
 		}
 
-		d, ok := decodeVersion([]string{e})
+		d, ok := decodeVersion(e)
 		if !ok {
 			t.Fatal("Unexpected %t for %s", ok, data.encoded)
 		}

--- a/registry/encoding_test.go
+++ b/registry/encoding_test.go
@@ -1,0 +1,116 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestEncodingEndpoints(t *testing.T) {
+	testData := []struct {
+		decoded    *Endpoint
+		encoded    string
+		oldEncoded string
+	}{
+		{
+			&Endpoint{
+				Name: "Endpoint",
+				Request: &Value{
+					Name: "request",
+					Type: "Request",
+				},
+				Response: &Value{
+					Name: "response",
+					Type: "Response",
+				},
+				Metadata: map[string]string{
+					"foo": "bar",
+				},
+			},
+			"e-789caa56ca4bcc4d55b25272cd4b29c8cfcc2b51d2512a4a2d2c4d2d2e51b2824bc24474944a2a0b4002417081b2c41c204bc92aaf3427a716a4b7b8203faf38154533540849375c044d7b6e6a49624a624922487b5a7e3e506d526291526d2d200000ffffb9fb3937",
+			`e={"name":"Endpoint","request":{"name":"request","type":"Request","values":null},"response":{"name":"response","type":"Response","values":null},"metadata":{"foo":"bar"}}`,
+		},
+	}
+
+	for _, data := range testData {
+		e := encodeEndpoints([]*Endpoint{data.decoded})
+
+		if len(e) != 1 || e[0] != data.encoded {
+			t.Fatalf("Expected %s got %s", data.encoded, e)
+		}
+
+		d := decodeEndpoints(e)
+		if len(d) == 0 {
+			t.Fatalf("Expected %v got %v", data.decoded, d)
+		}
+
+		if d[0].Name != data.decoded.Name {
+			t.Fatalf("Expected ep %s got %s", data.decoded.Name, d[0].Name)
+		}
+
+		for k, v := range data.decoded.Metadata {
+			if gv := d[0].Metadata[k]; gv != v {
+				t.Fatalf("Expected key %s val %s got val %s", k, v, gv)
+			}
+		}
+
+		d = decodeEndpoints([]string{data.oldEncoded})
+		if len(d) == 0 {
+			t.Fatalf("Expected %v got %v", data.decoded, d)
+		}
+
+		if d[0].Name != data.decoded.Name {
+			t.Fatalf("Expected ep %s got %s", data.decoded.Name, d[0].Name)
+		}
+
+		for k, v := range data.decoded.Metadata {
+			if gv := d[0].Metadata[k]; gv != v {
+				t.Fatalf("Expected key %s val %s got val %s", k, v, gv)
+			}
+		}
+	}
+}
+
+func TestEncodingVersion(t *testing.T) {
+	testData := []struct {
+		decoded    string
+		encoded    string
+		oldEncoded string
+	}{
+		{"1.0.0", "v-789c32d433d03300040000ffff02ce00ee", "v=1.0.0"},
+		{"latest", "v-789cca492c492d2e01040000ffff08cc028e", "v=latest"},
+	}
+
+	for _, data := range testData {
+		e := encodeVersion(data.decoded)
+
+		if e != data.encoded {
+			t.Fatalf("Expected %s got %s", data.encoded, e)
+		}
+
+		d, ok := decodeVersion([]string{e})
+		if !ok {
+			t.Fatal("Unexpected %t for %s", ok, data.encoded)
+		}
+
+		if d != data.decoded {
+			t.Fatal("Expected %s got %s", data.decoded, d)
+		}
+
+		d, ok = decodeVersion([]string{data.encoded})
+		if !ok {
+			t.Fatal("Unexpected %t for %s", ok, data.encoded)
+		}
+
+		if d != data.decoded {
+			t.Fatal("Expected %s got %s", data.decoded, d)
+		}
+
+		d, ok = decodeVersion([]string{data.oldEncoded})
+		if !ok {
+			t.Fatal("Unexpected %t for %s", ok, data.oldEncoded)
+		}
+
+		if d != data.decoded {
+			t.Fatal("Expected %s got %s", data.decoded, d)
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue https://github.com/micro/go-micro/issues/62 BUT old clients cannot decode data for new apps which means version is hex encoded and endpoints/metadata is not returned.
