### PR TITLE
Add Backoff func option

### DIFF
--- a/client/backoff.go
+++ b/client/backoff.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"math"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+type BackoffFunc func(ctx context.Context, req Request, attempts int) (time.Duration, error)
+
+// exponential backoff
+func exponentialBackoff(ctx context.Context, req Request, attempts int) (time.Duration, error) {
+	if attempts == 0 {
+		return time.Duration(0), nil
+	}
+	return time.Duration(math.Pow(10, float64(attempts))) * time.Millisecond, nil
+}

--- a/client/backoff_test.go
+++ b/client/backoff_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestBackoff(t *testing.T) {
+	delta := time.Duration(0)
+
+	for i := 0; i < 5; i++ {
+		d, err := exponentialBackoff(context.TODO(), NewJsonRequest("test", "test", nil), i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if d < delta {
+			t.Fatalf("Expected greater than %v, got %v", delta, d)
+		}
+
+		delta = time.Millisecond * time.Duration(math.Pow(10, float64(i+1)))
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,7 @@ type RequestOption func(*RequestOptions)
 var (
 	DefaultClient Client = newRpcClient()
 
+	DefaultBackoff        = exponentialBackoff
 	DefaultRetries        = 1
 	DefaultRequestTimeout = time.Second * 5
 )

--- a/client/options.go
+++ b/client/options.go
@@ -37,6 +37,8 @@ type Options struct {
 type CallOptions struct {
 	SelectOptions []selector.SelectOption
 
+	// Backoff func
+	Backoff BackoffFunc
 	// Transport Dial Timeout
 	DialTimeout time.Duration
 	// Number of Call attempts
@@ -67,6 +69,7 @@ func newOptions(options ...Option) Options {
 	opts := Options{
 		Codecs: make(map[string]codec.NewCodec),
 		CallOptions: CallOptions{
+			Backoff:        DefaultBackoff,
 			Retries:        DefaultRetries,
 			RequestTimeout: DefaultRequestTimeout,
 			DialTimeout:    transport.DefaultDialTimeout,
@@ -151,6 +154,14 @@ func Wrap(w Wrapper) Option {
 	}
 }
 
+// Backoff is used to set the backoff function used
+// when retrying Calls
+func Backoff(fn BackoffFunc) Option {
+	return func(o *Options) {
+		o.CallOptions.Backoff = fn
+	}
+}
+
 // Number of retries when making the request.
 // Should this be a Call Option?
 func Retries(i int) Option {
@@ -179,6 +190,14 @@ func DialTimeout(d time.Duration) Option {
 func WithSelectOption(so selector.SelectOption) CallOption {
 	return func(o *CallOptions) {
 		o.SelectOptions = append(o.SelectOptions, so)
+	}
+}
+
+// WithBackoff is a CallOption which overrides that which
+// set in Options.CallOptions
+func WithBackoff(fn BackoffFunc) CallOption {
+	return func(o *CallOptions) {
+		o.Backoff = fn
 	}
 }
 


### PR DESCRIPTION
This enables backoff to be specified as a function to the client. The function is executed in the retry cycle. We execute before the first request for completely sake. This allows initial delays to be added or basically kicking out of the cycle before even beginning. There is however notable overlap in functionality between this and the Selector. 
