### PR TITLE
Add Label and Version based Filters

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -187,9 +187,9 @@ func DialTimeout(d time.Duration) Option {
 
 // Call Options
 
-func WithSelectOption(so selector.SelectOption) CallOption {
+func WithSelectOption(so ...selector.SelectOption) CallOption {
 	return func(o *CallOptions) {
-		o.SelectOptions = append(o.SelectOptions, so)
+		o.SelectOptions = append(o.SelectOptions, so...)
 	}
 }
 

--- a/examples/client/dc_filter/dc_filter.go
+++ b/examples/client/dc_filter/dc_filter.go
@@ -41,7 +41,7 @@ func (dc *dcWrapper) Call(ctx context.Context, req client.Request, rsp interface
 	}
 
 	callOptions := append(opts, client.WithSelectOption(
-		selector.Filter(filter),
+		selector.WithFilter(filter),
 	))
 
 	fmt.Printf("[DC Wrapper] filtering for datacenter %s\n", md["datacenter"])

--- a/selector/filter.go
+++ b/selector/filter.go
@@ -4,6 +4,25 @@ import (
 	"github.com/micro/go-micro/registry"
 )
 
+// FilterEndpoint is an endpoint based Select Filter which will
+// only return services with the endpoint specified.
+func FilterEndpoint(name string) Filter {
+	return func(old []*registry.Service) []*registry.Service {
+		var services []*registry.Service
+
+		for _, service := range old {
+			for _, ep := range service.Endpoints {
+				if ep.Name == name {
+					services = append(services, service)
+					break
+				}
+			}
+		}
+
+		return services
+	}
+}
+
 // FilterLabel is a label based Select Filter which will
 // only return services with the label specified.
 func FilterLabel(key, val string) Filter {

--- a/selector/filter.go
+++ b/selector/filter.go
@@ -4,9 +4,9 @@ import (
 	"github.com/micro/go-micro/registry"
 )
 
-// LabelFilter is a label based Select Filter which will
+// FilterLabel is a label based Select Filter which will
 // only return services with the label specified.
-func LabelFilter(key, val string) Filter {
+func FilterLabel(key, val string) Filter {
 	return func(old []*registry.Service) []*registry.Service {
 		var services []*registry.Service
 
@@ -37,9 +37,9 @@ func LabelFilter(key, val string) Filter {
 	}
 }
 
-// VersionFilter is a version based Select Filter which will
+// FilterVersion is a version based Select Filter which will
 // only return services with the version specified.
-func VersionFilter(version string) Filter {
+func FilterVersion(version string) Filter {
 	return func(old []*registry.Service) []*registry.Service {
 		var services []*registry.Service
 

--- a/selector/filter.go
+++ b/selector/filter.go
@@ -1,0 +1,54 @@
+package selector
+
+import (
+	"github.com/micro/go-micro/registry"
+)
+
+// LabelFilter is a label based Select Filter which will
+// only return services with the label specified.
+func LabelFilter(key, val string) Filter {
+	return func(old []*registry.Service) []*registry.Service {
+		var services []*registry.Service
+
+		for _, service := range old {
+			serv := new(registry.Service)
+			var nodes []*registry.Node
+
+			for _, node := range service.Nodes {
+				if node.Metadata == nil {
+					continue
+				}
+
+				if node.Metadata[key] == val {
+					nodes = append(nodes, node)
+				}
+			}
+
+			// only add service if there's some nodes
+			if len(nodes) > 0 {
+				// copy
+				*serv = *service
+				serv.Nodes = nodes
+				services = append(services, serv)
+			}
+		}
+
+		return services
+	}
+}
+
+// VersionFilter is a version based Select Filter which will
+// only return services with the version specified.
+func VersionFilter(version string) Filter {
+	return func(old []*registry.Service) []*registry.Service {
+		var services []*registry.Service
+
+		for _, service := range old {
+			if service.Version == version {
+				services = append(services, service)
+			}
+		}
+
+		return services
+	}
+}

--- a/selector/filter_test.go
+++ b/selector/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/micro/go-micro/registry"
 )
 
-func TestLabelFilter(t *testing.T) {
+func TestFilterLabel(t *testing.T) {
 	testData := []struct {
 		services []*registry.Service
 		label    [2]string
@@ -73,7 +73,7 @@ func TestLabelFilter(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		filter := LabelFilter(data.label[0], data.label[1])
+		filter := FilterLabel(data.label[0], data.label[1])
 		services := filter(data.services)
 
 		if len(services) != data.count {
@@ -98,7 +98,7 @@ func TestLabelFilter(t *testing.T) {
 	}
 }
 
-func TestVersionFilter(t *testing.T) {
+func TestFilterVersion(t *testing.T) {
 	testData := []struct {
 		services []*registry.Service
 		version  string
@@ -135,7 +135,7 @@ func TestVersionFilter(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		filter := VersionFilter(data.version)
+		filter := FilterVersion(data.version)
 		services := filter(data.services)
 
 		if len(services) != data.count {

--- a/selector/filter_test.go
+++ b/selector/filter_test.go
@@ -1,0 +1,158 @@
+package selector
+
+import (
+	"testing"
+
+	"github.com/micro/go-micro/registry"
+)
+
+func TestLabelFilter(t *testing.T) {
+	testData := []struct {
+		services []*registry.Service
+		label    [2]string
+		count    int
+	}{
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+					Nodes: []*registry.Node{
+						&registry.Node{
+							Id:      "test-1",
+							Address: "localhost",
+							Metadata: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+					Nodes: []*registry.Node{
+						&registry.Node{
+							Id:      "test-2",
+							Address: "localhost",
+							Metadata: map[string]string{
+								"foo": "baz",
+							},
+						},
+					},
+				},
+			},
+			label: [2]string{"foo", "bar"},
+			count: 1,
+		},
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+					Nodes: []*registry.Node{
+						&registry.Node{
+							Id:      "test-1",
+							Address: "localhost",
+						},
+					},
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+					Nodes: []*registry.Node{
+						&registry.Node{
+							Id:      "test-2",
+							Address: "localhost",
+						},
+					},
+				},
+			},
+			label: [2]string{"foo", "bar"},
+			count: 0,
+		},
+	}
+
+	for _, data := range testData {
+		filter := LabelFilter(data.label[0], data.label[1])
+		services := filter(data.services)
+
+		if len(services) != data.count {
+			t.Fatalf("Expected %d services, got %d", data.count, len(services))
+		}
+
+		for _, service := range services {
+			var seen bool
+
+			for _, node := range service.Nodes {
+				if node.Metadata[data.label[0]] != data.label[1] {
+					t.Fatal("Expected %s=%s but got %s=%s for service %+v node %+v",
+						data.label[0], data.label[1], data.label[0], node.Metadata[data.label[0]], service, node)
+				}
+				seen = true
+			}
+
+			if !seen {
+				t.Fatalf("Expected node for %s=%s but saw none; results %+v", data.label[0], data.label[1], service)
+			}
+		}
+	}
+}
+
+func TestVersionFilter(t *testing.T) {
+	testData := []struct {
+		services []*registry.Service
+		version  string
+		count    int
+	}{
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+				},
+			},
+			version: "1.0.0",
+			count:   1,
+		},
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+				},
+			},
+			version: "2.0.0",
+			count:   0,
+		},
+	}
+
+	for _, data := range testData {
+		filter := VersionFilter(data.version)
+		services := filter(data.services)
+
+		if len(services) != data.count {
+			t.Fatalf("Expected %d services, got %d", data.count, len(services))
+		}
+
+		var seen bool
+
+		for _, service := range services {
+			if service.Version != data.version {
+				t.Fatalf("Expected version %s, got %s", data.version, service.Version)
+			}
+			seen = true
+		}
+
+		if seen == false && data.count > 0 {
+			t.Fatalf("Expected %d services but seen is %t; result %+v", data.count, seen, services)
+		}
+	}
+}

--- a/selector/filter_test.go
+++ b/selector/filter_test.go
@@ -6,6 +6,87 @@ import (
 	"github.com/micro/go-micro/registry"
 )
 
+func TestFilterEndpoint(t *testing.T) {
+	testData := []struct {
+		services []*registry.Service
+		endpoint string
+		count    int
+	}{
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+					Endpoints: []*registry.Endpoint{
+						&registry.Endpoint{
+							Name: "Foo.Bar",
+						},
+					},
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+					Endpoints: []*registry.Endpoint{
+						&registry.Endpoint{
+							Name: "Baz.Bar",
+						},
+					},
+				},
+			},
+			endpoint: "Foo.Bar",
+			count:    1,
+		},
+		{
+			services: []*registry.Service{
+				&registry.Service{
+					Name:    "test",
+					Version: "1.0.0",
+					Endpoints: []*registry.Endpoint{
+						&registry.Endpoint{
+							Name: "Foo.Bar",
+						},
+					},
+				},
+				&registry.Service{
+					Name:    "test",
+					Version: "1.1.0",
+					Endpoints: []*registry.Endpoint{
+						&registry.Endpoint{
+							Name: "Foo.Bar",
+						},
+					},
+				},
+			},
+			endpoint: "Bar.Baz",
+			count:    0,
+		},
+	}
+
+	for _, data := range testData {
+		filter := FilterEndpoint(data.endpoint)
+		services := filter(data.services)
+
+		if len(services) != data.count {
+			t.Fatalf("Expected %d services, got %d", data.count, len(services))
+		}
+
+		for _, service := range services {
+			var seen bool
+
+			for _, ep := range service.Endpoints {
+				if ep.Name == data.endpoint {
+					seen = true
+					break
+				}
+			}
+
+			if seen == false && data.count > 0 {
+				t.Fatalf("Expected %d services but seen is %t; result %+v", data.count, seen, services)
+			}
+		}
+	}
+}
+
 func TestFilterLabel(t *testing.T) {
 	testData := []struct {
 		services []*registry.Service

--- a/selector/options.go
+++ b/selector/options.go
@@ -15,7 +15,7 @@ type Options struct {
 }
 
 type SelectOptions struct {
-	Filters []SelectFilter
+	Filters []Filter
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -35,9 +35,9 @@ func Registry(r registry.Registry) Option {
 	}
 }
 
-// Filter adds a filter function to the list of filters
+// WithFilter adds a filter function to the list of filters
 // used during the Select call.
-func Filter(fn SelectFilter) SelectOption {
+func WithFilter(fn Filter) SelectOption {
 	return func(o *SelectOptions) {
 		o.Filters = append(o.Filters, fn)
 	}

--- a/selector/options.go
+++ b/selector/options.go
@@ -37,8 +37,8 @@ func Registry(r registry.Registry) Option {
 
 // WithFilter adds a filter function to the list of filters
 // used during the Select call.
-func WithFilter(fn Filter) SelectOption {
+func WithFilter(fn ...Filter) SelectOption {
 	return func(o *SelectOptions) {
-		o.Filters = append(o.Filters, fn)
+		o.Filters = append(o.Filters, fn...)
 	}
 }

--- a/selector/selector.go
+++ b/selector/selector.go
@@ -82,8 +82,8 @@ type Selector interface {
 // based on the selector's algorithm
 type Next func() (*registry.Node, error)
 
-// SelectFilter is used to filter a service during the selection process
-type SelectFilter func([]*registry.Service) []*registry.Service
+// Filter is used to filter a service during the selection process
+type Filter func([]*registry.Service) []*registry.Service
 
 var (
 	DefaultSelector = newRandomSelector()


### PR DESCRIPTION
We need to make it clear that Service and Node filtering can be done when calling a service by using the Filter option. This is a method to do version based routing or label based routing. We provide some primitive filters here that can be used out of the box.

Here's an example of version based filtering where we only want to talk to version 1.0.0 of the service.

```
req := client.NewRequest("service.name", "Service.Method", &Request{})
rsp := &Response{}

client.Call(ctx, req, rsp, client.WithSelectOption(
    selector.WithFilter(
        selector.FilterVersion("1.0.0"),
    ),
))
```

And here's an example where we want nodes with a specific metadata label. This is great where you want to pin down requests to a local AZ, datacenter, machine, etc. Or you're doing canarying of a new feature.

```
req := client.NewRequest("service.name", "Service.Method", &Request{})
rsp := &Response{}

client.Call(ctx, req, rsp, client.WithSelectOption(
    selector.WithFilter(
        selector.FilterLabel("datacenter", "eu-west-1a"),
    ),
))
```

We may have multiple versions of a service and endpoints may only exist in varying versions. We can filter based solely on the endpoint name. 

```
req := client.NewRequest("service.name", "Service.Method", &Request{})
rsp := &Response{}

client.Call(ctx, req, rsp, client.WithSelectOption(
    selector.WithFilter(
        selector.FilterEndpoint("Service.Method"),
    ),
))
```

We can also combine filters

```
req := client.NewRequest("service.name", "Service.Method", &Request{})
rsp := &Response{}

client.Call(ctx, req, rsp, client.WithSelectOption(
    selector.WithFilter(
        selector.FilterEndpoint("Service.Method"),
        selector.FilterLabel("datacenter", "eu-west-1a"),
        selector.FilterVersion("1.0.0"),
    ),
))
```
