### PR TITLE
MockClient.CallRemote now returns nil on success

### DIFF
--- a/client/mock/mock.go
+++ b/client/mock/mock.go
@@ -123,6 +123,8 @@ func (m *MockClient) CallRemote(ctx context.Context, addr string, req client.Req
 		}
 
 		v.Set(reflect.ValueOf(r.Response))
+		
+		return nil
 	}
 
 	return fmt.Errorf("rpc: can't find service %s", req.Method())


### PR DESCRIPTION
MockClient.CallRemote was not returning nil on success as it should due to a missing return. This can cause tests to appear broken that are not.
