### PR TITLE
Broker Codec implementation

### DIFF
--- a/broker/buffer.go
+++ b/broker/buffer.go
@@ -1,0 +1,23 @@
+package broker
+
+import (
+	"bytes"
+	"io"
+)
+
+type closeBuffer struct {
+	*bytes.Buffer
+}
+
+type writeBuffer struct {
+	io.ReadCloser
+}
+
+func (b *closeBuffer) Close() error {
+	b.Buffer.Reset()
+	return nil
+}
+
+func (b *writeBuffer) Write([]byte) (int, error) {
+	return 0, nil
+}

--- a/broker/options.go
+++ b/broker/options.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"crypto/tls"
 
+	"github.com/micro/go-micro/codec"
 	"github.com/micro/go-micro/registry"
 	"golang.org/x/net/context"
 )
@@ -11,6 +12,9 @@ type Options struct {
 	Addrs     []string
 	Secure    bool
 	TLSConfig *tls.Config
+
+	// Encoding Codec
+	Codec codec.NewCodec
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -65,6 +69,13 @@ func newSubscribeOptions(opts ...SubscribeOption) SubscribeOptions {
 func Addrs(addrs ...string) Option {
 	return func(o *Options) {
 		o.Addrs = addrs
+	}
+}
+
+// Codec sets the codec to use for the broker
+func Codec(c codec.NewCodec) Option {
+	return func(o *Options) {
+		o.Codec = c
 	}
 }
 


### PR DESCRIPTION
This uses a codec rather than forcing json marshalling. Not entirely sure about this yet. It highlights some problems with the codec. The codec is a legacy artifact of net/rpc. It works but its not "clean".
