### PR TITLE
Add registry.OAuth2ClientCredentials option

### DIFF
--- a/registry/options.go
+++ b/registry/options.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Options struct {
-	Addrs     []string
-	Timeout   time.Duration
-	Secure    bool
-	TLSConfig *tls.Config
+	Addrs                   []string
+	Timeout                 time.Duration
+	Secure                  bool
+	TLSConfig               *tls.Config
+	OAuth2ClientCredentials *oauth2ClientCredentials
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -23,6 +24,13 @@ type RegisterOptions struct {
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
+}
+
+// Options for OAuth 2.0 Client Credentials Grant Flow
+type oauth2ClientCredentials struct {
+	ClientID     string
+	ClientSecret string
+	TokenURL     string
 }
 
 // Addrs is the registry addresses to use
@@ -49,6 +57,17 @@ func Secure(b bool) Option {
 func TLSConfig(t *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = t
+	}
+}
+
+// Enable OAuth 2.0 Client Credentials Grant Flow
+func OAuth2ClientCredentials(clientID, clientSecret, tokenURL string) Option {
+	return func(o *Options) {
+		o.OAuth2ClientCredentials = &oauth2ClientCredentials{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			TokenURL:     tokenURL,
+		}
 	}
 }
 

--- a/registry/options_test.go
+++ b/registry/options_test.go
@@ -1,0 +1,33 @@
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/micro/go-micro/registry"
+)
+
+func TestOAuth2ClientCredentials(t *testing.T) {
+	clientID := "client-id"
+	clientSecret := "client-secret"
+	tokenURL := "token-url"
+
+	options := &registry.Options{}
+	registry.OAuth2ClientCredentials(clientID, clientSecret, tokenURL)(options)
+
+	creds := options.OAuth2ClientCredentials
+	if creds == nil {
+		t.Errorf("options.OAuth2ClientCredentials not set")
+	}
+
+	if clientID != creds.ClientID {
+		t.Errorf("ClientID: want %q, got %q", clientID, creds.ClientID)
+	}
+
+	if clientSecret != creds.ClientSecret {
+		t.Errorf("ClientSecret: want %q, got %q", clientSecret, creds.ClientSecret)
+	}
+
+	if tokenURL != creds.TokenURL {
+		t.Errorf("TokenURL: want %q, got %q", tokenURL, creds.TokenURL)
+	}
+}


### PR DESCRIPTION
@asim: Not sure what you had in mind with regards to naming but what do you think about this? Happy to wait with this until https://github.com/hudl/fargo/pull/38 has been merged.

I've got a corresponding change in https://github.com/micro/go-plugins/tree/master/registry/eureka but wanted to get some feedback on the registry option first.
