### PR TITLE
Transport Deadline Support

### DIFF
--- a/transport/options.go
+++ b/transport/options.go
@@ -11,7 +11,8 @@ type Options struct {
 	Addrs     []string
 	Secure    bool
 	TLSConfig *tls.Config
-
+	// Deadline sets the time to wait to Send/Recv
+	Deadline time.Duration
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
@@ -42,6 +43,13 @@ type ListenOptions struct {
 func Addrs(addrs ...string) Option {
 	return func(o *Options) {
 		o.Addrs = addrs
+	}
+}
+
+// Deadline sets the time to wait for Send/Recv execution
+func Deadline(t time.Duration) Option {
+	return func(o *Options) {
+		o.Deadline = t
 	}
 }
 


### PR DESCRIPTION
This adds support for setting Deadline on the transport. By default Send/Recv block indefinitely. In a connectionless protocol closing of the connection does not signal the remote side. Supporting deadline allows the connection to be dropped if no response is received. 
