### PR TITLE
ConsulWatcher: deregister if service checks fail.

### DIFF
--- a/registry/consul_watcher.go
+++ b/registry/consul_watcher.go
@@ -79,15 +79,7 @@ func (cw *consulWatcher) serviceHandler(idx uint64, data interface{}) {
 		var del bool
 
 		for _, check := range e.Checks {
-			if check.ServiceName != serviceName {
-				continue
-			}
-
-			if check.ServiceID != id {
-				continue
-			}
-
-			// delete the node
+			// delete the node if the status is critical
 			if check.Status == "critical" {
 				del = true
 				break

--- a/registry/consul_watcher_test.go
+++ b/registry/consul_watcher_test.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func TestHealthyServiceHandler(t *testing.T) {
+	watcher := newWatcher()
+	serviceEntry := newServiceEntry(
+		"node-name", "node-address", "service-name", "v1.0.0",
+		[]*api.HealthCheck{
+			newHealthCheck("node-name", "service-name", "passing"),
+		},
+	)
+
+	watcher.serviceHandler(1234, []*api.ServiceEntry{serviceEntry})
+
+	if len(watcher.services["service-name"][0].Nodes) != 1 {
+		t.Errorf("Expected length of the service nodes to be 1")
+	}
+}
+
+func TestUnhealthyServiceHandler(t *testing.T) {
+	watcher := newWatcher()
+	serviceEntry := newServiceEntry(
+		"node-name", "node-address", "service-name", "v1.0.0",
+		[]*api.HealthCheck{
+			newHealthCheck("node-name", "service-name", "critical"),
+		},
+	)
+
+	watcher.serviceHandler(1234, []*api.ServiceEntry{serviceEntry})
+
+	if len(watcher.services["service-name"][0].Nodes) != 0 {
+		t.Errorf("Expected length of the service nodes to be 0")
+	}
+}
+
+func TestUnhealthyNodeServiceHandler(t *testing.T) {
+	watcher := newWatcher()
+	serviceEntry := newServiceEntry(
+		"node-name", "node-address", "service-name", "v1.0.0",
+		[]*api.HealthCheck{
+			newHealthCheck("node-name", "service-name", "passing"),
+			newHealthCheck("node-name", "serfHealth", "critical"),
+		},
+	)
+
+	watcher.serviceHandler(1234, []*api.ServiceEntry{serviceEntry})
+
+	if len(watcher.services["service-name"][0].Nodes) != 0 {
+		t.Errorf("Expected length of the service nodes to be 0")
+	}
+}
+
+func newWatcher() *consulWatcher {
+	return &consulWatcher{
+		exit:     make(chan bool),
+		next:     make(chan *Result, 10),
+		services: make(map[string][]*Service),
+	}
+}
+
+func newHealthCheck(node, name, status string) *api.HealthCheck {
+	return &api.HealthCheck{
+		Node:        node,
+		Name:        name,
+		Status:      status,
+		ServiceName: name,
+	}
+}
+
+func newServiceEntry(node, address, name, version string, checks []*api.HealthCheck) *api.ServiceEntry {
+	return &api.ServiceEntry{
+		Node: &api.Node{Node: node, Address: name},
+		Service: &api.AgentService{
+			Service: name,
+			Address: address,
+			Tags:    encodeVersion(version),
+		},
+		Checks: checks,
+	}
+}


### PR DESCRIPTION
We've seen an issue where if a node crashes/fails, the cache doesn't get updated. This means that other services would still try to talk to the service. The reason for this is because Consul's serf can't broadcast the service health anymore, and thus the cluster thinks it's still healthy. It does however mark the node as unhealthy.

Example:
- service a and b both have 2 instances and run in different nodes.
- service a's cache gets populated with 2 nodes for service b
- service b, node 1 crashes. In the consul cluster, the service get's marked healthy, but serf unhealthy ([example](http://screenshots.siphoc.com/2016-08-11-16-04-15.png))
- service a still tries to talk to both nodes for service b but returns failures for 50% of them (since 1/2 nodes are down)

This patch removes the check on ServiceName and ServiceID to determine if a node is healthy or not which results in updating the cache properly. The service will still get hit for a few seconds, until the Consul cluster updates it's serf health across all nodes.
