### PR TITLE
Fixing issue which leads to concurrent map read/write errors with metadata from context

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -13,7 +13,13 @@ type Metadata map[string]string
 
 func FromContext(ctx context.Context) (Metadata, bool) {
 	md, ok := ctx.Value(metaKey{}).(Metadata)
-	return md, ok
+
+	mdCopy := make(map[string]string)
+	for k,v := range md {
+		mdCopy[k] = v
+	}
+
+	return mdCopy, ok
 }
 
 func NewContext(ctx context.Context, md Metadata) context.Context {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -38,7 +38,7 @@ func TestWrapper(t *testing.T) {
 		}
 
 		ctx := metadata.NewContext(context.Background(), d.existing)
-		c.setHeaders(ctx)
+		ctx = c.setHeaders(ctx)
 
 		md, _ := metadata.FromContext(ctx)
 


### PR DESCRIPTION
When sending many requests in a short time I get errors like this:

fatal error: concurrent map writes

```
goroutine 886 [running]:
runtime.throw(0x97439a, 0x15)
        /usr/local/go/src/runtime/panic.go:566 +0x95 fp=0xc420545a90 sp=0xc420545a70
runtime.mapassign1(0x8e1e40, 0xc4204ea720, 0xc420545be0, 0xc420545bd0)
        /usr/local/go/src/runtime/hashmap.go:553 +0x2e1 fp=0xc420545b78 sp=0xc420545a90
bitbucket.org/XXXXX/YYYY/vendor/github.com/micro/go-micro.(*clientWrapper).setHeaders(0xc4200d5560, 0x7f160667e028, 0xc42013c5c0, 0x97658e, 0x19)
        /home/sfinlay/work/src/bitbucket.org/XXXXX/YYYY/vendor/github.com/micro/go-micro/wrapper.go:22 +0x1cf fp=0xc420545c60 sp=0xc420545b78
```

I traced the error down to here: https://github.com/micro/go-micro/blob/master/wrapper.go#L21

But even introducing a mutex does nothing here since that only locks this particular attempt to access the metadata, so if some other thread modifies the the metadata in this context it creates a race condition.

Returning a copy of the data in Metadata seems to fix it.