### PR TITLE
Fixed references to context package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,9 +1,8 @@
 package client
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Client is the interface used to make requests to services.

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package micro
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/cli"
@@ -12,7 +13,6 @@ import (
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
 
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/registry/options.go
+++ b/registry/options.go
@@ -1,10 +1,10 @@
 package registry
 
 import (
+	"context"
 	"crypto/tls"
 	"time"
 
-	"golang.org/x/net/context"
 )
 
 type Options struct {


### PR DESCRIPTION
This follows specifications in Go version 1.7.