### PR TITLE
Call Wrapper

### DIFF
--- a/client/client_wrapper.go
+++ b/client/client_wrapper.go
@@ -34,8 +34,24 @@ Example usage:
 
 */
 
+import (
+	"golang.org/x/net/context"
+)
+
+// CallFunc represents the individual call func
+type CallFunc func(ctx context.Context, address string, req Request, rsp interface{}, opts CallOptions) error
+
+// StreamFunc represents the individual stream func
+type StreamFunc func(ctx context.Context, address string, req Request, opts CallOptions) (Streamer, error)
+
 // Wrapper wraps a client and returns a client
 type Wrapper func(Client) Client
 
 // StreamWrapper wraps a Stream and returns the equivalent
 type StreamWrapper func(Streamer) Streamer
+
+// CallFuncWrapper is a low level wrapper for the CallFunc
+type CallFuncWrapper func(CallFunc) CallFunc
+
+// StreamFuncWrapper is a low level wrapper for the StreamFunc
+type StreamFuncWrapper func(StreamFunc) StreamFunc

--- a/client/client_wrapper.go
+++ b/client/client_wrapper.go
@@ -41,17 +41,11 @@ import (
 // CallFunc represents the individual call func
 type CallFunc func(ctx context.Context, address string, req Request, rsp interface{}, opts CallOptions) error
 
-// StreamFunc represents the individual stream func
-type StreamFunc func(ctx context.Context, address string, req Request, opts CallOptions) (Streamer, error)
+// CallWrapper is a low level wrapper for the CallFunc
+type CallWrapper func(CallFunc) CallFunc
 
 // Wrapper wraps a client and returns a client
 type Wrapper func(Client) Client
 
 // StreamWrapper wraps a Stream and returns the equivalent
 type StreamWrapper func(Streamer) Streamer
-
-// CallFuncWrapper is a low level wrapper for the CallFunc
-type CallFuncWrapper func(CallFunc) CallFunc
-
-// StreamFuncWrapper is a low level wrapper for the StreamFunc
-type StreamFuncWrapper func(StreamFunc) StreamFunc

--- a/client/options.go
+++ b/client/options.go
@@ -53,7 +53,7 @@ type CallOptions struct {
 	RequestTimeout time.Duration
 
 	// Middleware for low level call func
-	CallWrappers []CallFuncWrapper
+	CallFuncWrappers []CallFuncWrapper
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -183,7 +183,7 @@ func Wrap(w Wrapper) Option {
 // Adds a Wrapper to the list of CallFunc wrappers
 func WrapCallFunc(cw ...CallFuncWrapper) Option {
 	return func(o *Options) {
-		o.CallOptions.CallWrappers = append(o.CallOptions.CallWrappers, cw...)
+		o.CallOptions.CallFuncWrappers = append(o.CallOptions.CallFuncWrappers, cw...)
 	}
 }
 
@@ -229,7 +229,7 @@ func WithSelectOption(so ...selector.SelectOption) CallOption {
 // WithCallFuncWrapper is a CallOption which adds to the existing CallFunc wrappers
 func WithCallFuncWrapper(cw ...CallFuncWrapper) CallOption {
 	return func(o *CallOptions) {
-		o.CallWrappers = append(o.CallWrappers, cw...)
+		o.CallFuncWrappers = append(o.CallFuncWrappers, cw...)
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -181,7 +181,7 @@ func Wrap(w Wrapper) Option {
 }
 
 // Adds a Wrapper to the list of CallFunc wrappers
-func WrapCallFunc(cw ...CallWrapper) Option {
+func WrapCall(cw ...CallWrapper) Option {
 	return func(o *Options) {
 		o.CallOptions.CallWrappers = append(o.CallOptions.CallWrappers, cw...)
 	}

--- a/client/options.go
+++ b/client/options.go
@@ -53,7 +53,7 @@ type CallOptions struct {
 	RequestTimeout time.Duration
 
 	// Middleware for low level call func
-	CallFuncWrappers []CallFuncWrapper
+	CallWrappers []CallWrapper
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -181,9 +181,9 @@ func Wrap(w Wrapper) Option {
 }
 
 // Adds a Wrapper to the list of CallFunc wrappers
-func WrapCallFunc(cw ...CallFuncWrapper) Option {
+func WrapCallFunc(cw ...CallWrapper) Option {
 	return func(o *Options) {
-		o.CallOptions.CallFuncWrappers = append(o.CallOptions.CallFuncWrappers, cw...)
+		o.CallOptions.CallWrappers = append(o.CallOptions.CallWrappers, cw...)
 	}
 }
 
@@ -226,10 +226,10 @@ func WithSelectOption(so ...selector.SelectOption) CallOption {
 	}
 }
 
-// WithCallFuncWrapper is a CallOption which adds to the existing CallFunc wrappers
-func WithCallFuncWrapper(cw ...CallFuncWrapper) CallOption {
+// WithCallWrapper is a CallOption which adds to the existing CallFunc wrappers
+func WithCallWrapper(cw ...CallWrapper) CallOption {
 	return func(o *CallOptions) {
-		o.CallFuncWrappers = append(o.CallFuncWrappers, cw...)
+		o.CallWrappers = append(o.CallWrappers, cw...)
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -52,6 +52,9 @@ type CallOptions struct {
 	// Request/Response timeout
 	RequestTimeout time.Duration
 
+	// Middleware for low level call func
+	CallWrappers []CallFuncWrapper
+
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
@@ -177,6 +180,13 @@ func Wrap(w Wrapper) Option {
 	}
 }
 
+// Adds a Wrapper to the list of CallFunc wrappers
+func WrapCallFunc(cw ...CallFuncWrapper) Option {
+	return func(o *Options) {
+		o.CallOptions.CallWrappers = append(o.CallOptions.CallWrappers, cw...)
+	}
+}
+
 // Backoff is used to set the backoff function used
 // when retrying Calls
 func Backoff(fn BackoffFunc) Option {
@@ -213,6 +223,13 @@ func DialTimeout(d time.Duration) Option {
 func WithSelectOption(so ...selector.SelectOption) CallOption {
 	return func(o *CallOptions) {
 		o.SelectOptions = append(o.SelectOptions, so...)
+	}
+}
+
+// WithCallFuncWrapper is a CallOption which adds to the existing CallFunc wrappers
+func WithCallFuncWrapper(cw ...CallFuncWrapper) CallOption {
+	return func(o *CallOptions) {
+		o.CallWrappers = append(o.CallWrappers, cw...)
 	}
 }
 

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -279,8 +279,8 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 
 		// wrap the call in reverse
 		rcall := r.call
-		for i := len(callOpts.CallWrappers); i > 0; i-- {
-			rcall = callOpts.CallWrappers[i-1](rcall)
+		for i := len(callOpts.CallFuncWrappers); i > 0; i-- {
+			rcall = callOpts.CallFuncWrappers[i-1](rcall)
 		}
 
 		// make the call

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -250,6 +250,14 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 	default:
 	}
 
+	// make copy of call method
+	rcall := r.call
+
+	// wrap the call in reverse
+	for i := len(callOpts.CallWrappers); i > 0; i-- {
+		rcall = callOpts.CallWrappers[i-1](rcall)
+	}
+
 	// return errors.New("go.micro.client", "request timeout", 408)
 	call := func(i int) error {
 		// call backoff first. Someone may want an initial start delay
@@ -275,12 +283,6 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 		address := node.Address
 		if node.Port > 0 {
 			address = fmt.Sprintf("%s:%d", address, node.Port)
-		}
-
-		// wrap the call in reverse
-		rcall := r.call
-		for i := len(callOpts.CallWrappers); i > 0; i-- {
-			rcall = callOpts.CallWrappers[i-1](rcall)
 		}
 
 		// make the call

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -279,8 +279,8 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 
 		// wrap the call in reverse
 		rcall := r.call
-		for i := len(callOpts.CallFuncWrappers); i > 0; i-- {
-			rcall = callOpts.CallFuncWrappers[i-1](rcall)
+		for i := len(callOpts.CallWrappers); i > 0; i-- {
+			rcall = callOpts.CallWrappers[i-1](rcall)
 		}
 
 		// make the call

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -277,8 +277,14 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 			address = fmt.Sprintf("%s:%d", address, node.Port)
 		}
 
+		// wrap the call in reverse
+		rcall := r.call
+		for i := len(callOpts.CallWrappers); i > 0; i-- {
+			rcall = callOpts.CallWrappers[i-1](rcall)
+		}
+
 		// make the call
-		err = r.call(ctx, address, request, response, callOpts)
+		err = rcall(ctx, address, request, response, callOpts)
 		r.opts.Selector.Mark(request.Service(), node, err)
 		return err
 	}

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -21,7 +21,7 @@ func TestCallWrapper(t *testing.T) {
 	address := "10.1.10.1:8080"
 
 	wrap := func(cf CallFunc) CallFunc {
-		return func(ctx context.Context, addr string, req Request, rsp interface{}, opts ...CallOptions) error {
+		return func(ctx context.Context, addr string, req Request, rsp interface{}, opts CallOptions) error {
 			called = true
 
 			if req.Service() != service {

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-micro/registry/mock"
+	"github.com/micro/go-micro/selector"
+
+	"golang.org/x/net/context"
+)
+
+func TestCallWrapper(t *testing.T) {
+	var called bool
+	id := "test.1"
+	service := "test.service"
+	method := "Test.Method"
+	host := "10.1.10.1"
+	port := 8080
+	address := "10.1.10.1:8080"
+
+	wrap := func(cf CallFunc) CallFunc {
+		return func(ctx context.Context, addr string, req Request, rsp interface{}, opts ...CallOptions) error {
+			called = true
+
+			if req.Service() != service {
+				return fmt.Errorf("expected service: %s got %s", service, req.Service())
+			}
+
+			if req.Method() != method {
+				return fmt.Errorf("expected service: %s got %s", method, req.Method())
+			}
+
+			if addr != address {
+				return fmt.Errorf("expected address: %s got %s", address, addr)
+			}
+
+			// don't do the call
+			return nil
+		}
+	}
+
+	r := mock.NewRegistry()
+	c := NewClient(
+		Registry(r),
+		WrapCall(wrap),
+	)
+	c.Options().Selector.Init(selector.Registry(r))
+
+	r.Register(&registry.Service{
+		Name:    service,
+		Version: "latest",
+		Nodes: []*registry.Node{
+			&registry.Node{
+				Id:      id,
+				Address: host,
+				Port:    port,
+			},
+		},
+	})
+
+	req := c.NewRequest(service, method, nil)
+	if err := c.Call(context.Background(), req, nil); err != nil {
+		t.Fatal("call wrapper error", err)
+	}
+
+	if !called {
+		t.Fatal("wrapper not called")
+	}
+}


### PR DESCRIPTION
This wrapper introduces a low level call wrapper for the individual calls made by the client. The existing `client.Call` method only lets you know which service a request is being made to but not the individual service instance. This PR provides a way of wrapping the inner call. This is useful where you may want to track individual calls.