### PR TITLE
Use once instead of chan on service init and optimize

### DIFF
--- a/service.go
+++ b/service.go
@@ -63,13 +63,9 @@ func (s *service) Init(opts ...Option) {
 		inited = true
 
 		// We might get more command flags or the action here
-		// This is pretty ugly, find a better way
-		options := newOptions()
-		options.Cmd = s.opts.Cmd
 		for _, o := range opts {
-			o(&options)
+			o(&s.opts)
 		}
-		s.opts.Cmd = options.Cmd
 
 		// Initialise the command flags, overriding new service
 		s.opts.Cmd.Init(


### PR DESCRIPTION
1.Use `sync.Once` instead of `chan` for service init once, just better.
2.I don't understand why create a temp options to keep cmd instance, it still will be override in the loop