### PR TITLE
Add ability to pass consul client config via registry options.

### DIFF
--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -1,0 +1,16 @@
+package consul
+
+import (
+	consul "github.com/hashicorp/consul/api"
+	"github.com/micro/go-micro/registry"
+	"golang.org/x/net/context"
+)
+
+func Config(c *consul.Config) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_config", c)
+	}
+}

--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -14,3 +14,12 @@ func Config(c *consul.Config) registry.Option {
 		o.Context = context.WithValue(o.Context, "consul_config", c)
 	}
 }
+
+func Token(t string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_token", t)
+	}
+}

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -53,6 +53,13 @@ func newConsulRegistry(opts ...Option) Registry {
 
 	// use default config
 	config := consul.DefaultConfig()
+	if options.Context != nil {
+		// Use the consul config passed in the options, if available
+		c := options.Context.Value("consul_config")
+		if c != nil {
+			config = c.(*consul.Config)
+		}
+	}
 
 	// set timeout
 	if options.Timeout > 0 {
@@ -253,7 +260,7 @@ func (c *consulRegistry) ListServices() ([]*Service, error) {
 
 	var services []*Service
 
-	for service, _ := range rsp {
+	for service := range rsp {
 		services = append(services, &Service{Name: service})
 	}
 

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -59,6 +59,10 @@ func newConsulRegistry(opts ...Option) Registry {
 		if c != nil {
 			config = c.(*consul.Config)
 		}
+		t := options.Context.Value("consul_token")
+		if t != nil {
+			config.Token = t.(string)
+		}
 	}
 
 	// set timeout


### PR DESCRIPTION
As discussed in the slack channel earlier:

This can be used when you need to setup the internal consul client to use a specific configuration (E.G to pass a Token if the consul cluster is using ACL policies)