### PR TITLE
consul registry configuration

### DIFF
--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -1,6 +1,9 @@
 package consul
 
 import (
+	"net/http"
+	"time"
+
 	consul "github.com/hashicorp/consul/api"
 	"github.com/micro/go-micro/registry"
 	"golang.org/x/net/context"
@@ -12,6 +15,60 @@ func Config(c *consul.Config) registry.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, "consul_config", c)
+	}
+}
+
+func Address(a string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_address", a)
+	}
+}
+
+func Scheme(s string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_scheme", s)
+	}
+}
+
+func Datacenter(d string) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_datacenter", d)
+	}
+}
+
+func HttpClient(c *http.Client) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_http-client", c)
+	}
+}
+
+func HttpAuth(a *consul.HttpBasicAuth) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_http-auth", a)
+	}
+}
+
+func WaitTime(t time.Duration) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_wait-time", t)
 	}
 }
 

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -59,6 +59,30 @@ func newConsulRegistry(opts ...Option) Registry {
 			config = c
 		}
 
+		if addr, ok := options.Context.Value("consul_address").(string); ok {
+			config.Address = addr
+		}
+
+		if s, ok := options.Context.Value("consul_scheme").(string); ok {
+			config.Scheme = s
+		}
+
+		if dc, ok := options.Context.Value("consul_datacenter").(string); ok {
+			config.Datacenter = dc
+		}
+
+		if h, ok := options.Context.Value("consul_http-client").(*http.Client); ok {
+			config.HttpClient = h
+		}
+
+		if a, ok := options.Context.Value("consul_http-auth").(*consul.HttpBasicAuth); ok {
+			config.HttpAuth = a
+		}
+
+		if wt, ok := options.Context.Value("consul_wait-time").(time.Duration); ok {
+			config.WaitTime = wt
+		}
+
 		if t, ok := options.Context.Value("consul_token").(string); ok {
 			config.Token = t
 		}


### PR DESCRIPTION
Along the lines of: https://github.com/micro/go-micro/commit/8a25723fe07c02d47308a32e629b2fe11184c91a, which added a `Token` helper method to configure a consul registry. 

For completeness, this PR adds the remaining methods for configuring the [consul configuration struct](https://github.com/hashicorp/consul/blob/c744792fc4d665363dba0ecfc7d05fdedc9cab32/api/api.go#L126..L150), should they differ from the default settings. (`Address`, `Scheme` `Datacenter` etc). 

https://github.com/micro/go-micro/pull/139 *did* add the `Config` method enabling you to pass the complete config object, but for consistency these individual methods can be used in the same manner as the `Token` helper.

Something along the lines of:

```go

    import(
        "github.com/micro/go-micro"
        "github.com/micro/go-micro/registry/consul"
    )

   // .....

    service := micro.NewService(
        micro.Name("example"),
        micro.Version("latest"),
        micro.Registry(
            consul.NewRegistry(
                consul.Address("127.0.0.1:9000"), // consul running on a non-standard port
                consul.Token("TOKEN_HERE"),       // consul ACL token
            ),
        ),
    )
```
