### PR TITLE
Remove consul token helper method.

### DIFF
--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -14,12 +14,3 @@ func Config(c *consul.Config) registry.Option {
 		o.Context = context.WithValue(o.Context, "consul_config", c)
 	}
 }
-
-func Token(t string) registry.Option {
-	return func(o *registry.Options) {
-		if o.Context == nil {
-			o.Context = context.Background()
-		}
-		o.Context = context.WithValue(o.Context, "consul_token", t)
-	}
-}

--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -58,10 +58,6 @@ func newConsulRegistry(opts ...Option) Registry {
 		if c, ok := options.Context.Value("consul_config").(*consul.Config); ok {
 			config = c
 		}
-
-		if t, ok := options.Context.Value("consul_token").(string); ok {
-			config.Token = t
-		}
 	}
 
 	// set timeout


### PR DESCRIPTION
This removes the redundant `Token` helper method introduced in #139.

To use consul with non-default settings (such as configuring the use of a consul ACL token) you can pass a [`github.com/hashicorp/consul/api.Config`](https://github.com/hashicorp/consul/blob/c744792fc4d665363dba0ecfc7d05fdedc9cab32/api/api.go#L126..L150) struct when creating your registry:

```go
import(
    "github.com/micro/go-micro"
    "github.com/micro/go-micro/registry/consul"
    consulapi "github.com/hashicorp/consul/api"
)

// ...

consulconf := consulapi.DefaultConfig()
consulconf.Address = "127.0.0.1:9000"  // Consul running on a non-default port
consulconf.Token = "TOKEN_HERE"        // Consul ACL Token to use

service := micro.NewService(
    micro.Name("example"),
    micro.Version("latest"),
    micro.Registry(
        consul.NewRegistry(
            consul.Config(consulconf),
        ),
    ),
)

```
Change discussed in #140.