### PR TITLE
Add Qos to broker

### DIFF
--- a/broker/options.go
+++ b/broker/options.go
@@ -32,6 +32,8 @@ type SubscribeOptions struct {
 	// will create a shared subscription where each
 	// receives a subset of messages.
 	Queue string
+	PrefetchCount int
+	PrefetchSize int
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -89,6 +91,13 @@ func DisableAutoAck() SubscribeOption {
 func Queue(name string) SubscribeOption {
 	return func(o *SubscribeOptions) {
 		o.Queue = name
+	}
+}
+
+func Qos(prefetchCount, prefetchSize int) SubscribeOption {
+	return func(o *SubscribeOptions) {
+		o.PrefetchSize = prefetchSize
+		o.PrefetchCount = prefetchCount
 	}
 }
 

--- a/broker/options.go
+++ b/broker/options.go
@@ -31,9 +31,9 @@ type SubscribeOptions struct {
 	// Subscribers with the same queue name
 	// will create a shared subscription where each
 	// receives a subset of messages.
-	Queue string
+	Queue         string
 	PrefetchCount int
-	PrefetchSize int
+	PrefetchSize  int
 
 	// Other options for implementations of the interface
 	// can be stored in a context

--- a/server/handler.go
+++ b/server/handler.go
@@ -40,6 +40,9 @@ type HandlerOptions struct {
 type SubscriberOptions struct {
 	Queue    string
 	Internal bool
+	AutoAck	 bool
+	PrefetchCount int
+	PrefetchSize int
 }
 
 // EndpointMetadata is a Handler option that allows metadata to be added to
@@ -71,5 +74,18 @@ func InternalSubscriber(b bool) SubscriberOption {
 func SubscriberQueue(n string) SubscriberOption {
 	return func(o *SubscriberOptions) {
 		o.Queue = n
+	}
+}
+
+func DisableAutoAck() SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.AutoAck = false
+	}
+}
+
+func Qos(prefetchCount, prefetchSize int) SubscriberOption {
+	return func(o *SubscriberOptions) {
+		o.PrefetchCount = prefetchCount
+		o.PrefetchSize = prefetchSize
 	}
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -38,11 +38,11 @@ type HandlerOptions struct {
 }
 
 type SubscriberOptions struct {
-	Queue    string
-	Internal bool
-	AutoAck	 bool
+	Queue         string
+	Internal      bool
+	AutoAck       bool
 	PrefetchCount int
-	PrefetchSize int
+	PrefetchSize  int
 }
 
 // EndpointMetadata is a Handler option that allows metadata to be added to

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -278,6 +278,10 @@ func (s *rpcServer) Register() error {
 		if queue := sb.Options().Queue; len(queue) > 0 {
 			opts = append(opts, broker.Queue(queue))
 		}
+		if autoAck := sb.Options().AutoAck; !autoAck {
+			opts = append(opts, broker.DisableAutoAck())
+		}
+		opts = append(opts, broker.Qos(sb.Options().PrefetchCount, sb.Options().PrefetchSize))
 		sub, err := config.Broker.Subscribe(sb.Topic(), handler, opts...)
 		if err != nil {
 			return err

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -34,9 +34,9 @@ type subscriber struct {
 
 func newSubscriber(topic string, sub interface{}, opts ...SubscriberOption) Subscriber {
 	options := SubscriberOptions{
-		AutoAck: true,
+		AutoAck:       true,
 		PrefetchCount: 0,
-		PrefetchSize : 0,
+		PrefetchSize:  0,
 	}
 	for _, o := range opts {
 		o(&options)
@@ -223,7 +223,7 @@ func (s *rpcServer) createSubHandler(sb *subscriber, opts Options) broker.Handle
 				if err := returnValues[0].Interface(); err != nil {
 					return err.(error)
 				}
-				if (!sb.opts.AutoAck) {
+				if !sb.opts.AutoAck {
 					p.Ack()
 				}
 				return nil


### PR DESCRIPTION
Right now it is not possible to fetch only one element from the queue and continue after the message has been acknowledged. The RabbitMQ supports this with Qos where we can define the number of messages that will be fetched without acknowledgment. And we also have set the AutoAck to FALSE.
I also had to change the createSubHandler function to send the acknowledgment after the handler has been executed if the AutoAck is false. I had no better idea where to do this. Actually like this it is still auto-acknowledged but done by go-micro and only after the handler.
If you need a queue without Qos you can do it like this:
```
service.Server().Subscribe(
		service.Server().NewSubscriber(
			"topic.go.micro.srv",
			subscriber.RequestHandler,
			server.DisableAutoAck(),
			server.Qos(2, 0),
		),
)
```