### PR TITLE
Add ack() after executing the subscriber handler

### DIFF
--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -205,6 +205,7 @@ func (s *rpcServer) createSubHandler(sb *subscriber, opts Options) broker.Handle
 			}
 
 			fn := func(ctx context.Context, msg Publication) error {
+				defer p.Ack()
 				var vals []reflect.Value
 				if sb.typ.Kind() != reflect.Func {
 					vals = append(vals, sb.rcvr)


### PR DESCRIPTION
Right now we cannot catch the event when a subscriber handler finishes the execution. Something would be nice to solve this. Here I used the broker.Publication(), but maybe something else that allow us to inject our code to handle this event would be even better.