### PR TITLE
allow micro framework to query and return a thirdparty service

### DIFF
--- a/registry/encoding.go
+++ b/registry/encoding.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
+	"strconv"
 )
 
 func encode(buf []byte) string {
@@ -141,6 +142,20 @@ func decodeMetadata(tags []string) map[string]string {
 		// set version
 		ver = tag[1]
 	}
+	return md
+}
+
+func decodeMetadataThirdParty(tags []string) map[string]string {
+	md := make(map[string]string)
+
+	for i, tag := range tags {
+		if len(tag) == 0 {
+			continue
+		}
+
+		md[strconv.Itoa(i)] = tag
+	}
+
 	return md
 }
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -1,11 +1,12 @@
 package registry
 
 type Service struct {
-	Name      string            `json:"name"`
-	Version   string            `json:"version"`
-	Metadata  map[string]string `json:"metadata"`
-	Endpoints []*Endpoint       `json:"endpoints"`
-	Nodes     []*Node           `json:"nodes"`
+	Name       string            `json:"name"`
+	Version    string            `json:"version"`
+	Metadata   map[string]string `json:"metadata"`
+	Endpoints  []*Endpoint       `json:"endpoints"`
+	Nodes      []*Node           `json:"nodes"`
+	ThirdParty bool              `json:"thirdparty"`
 }
 
 type Node struct {


### PR DESCRIPTION
From discussion on slack.

The micro framework currently cannot return services which are not registered by ```micro```.
However within environments which uses the micro framework, it can be usefull or expected that I go-micro service has to use a already configured service within the consul registry.

Example:
Postgres service registered within the consul registry by its own agent; with the following consul config.
```json
{
    "datacenter": "datacore",
    "leave_on_terminate": true,
    "start_join": [ "172.30.0.2" ],
    "retry_join": [ "172.30.0.2" ],
    "node_name": "micro.db",
    "bind_addr": "0.0.0.0",
    "client_addr": "0.0.0.0",
        "service": {
                "name": "micro.db",
                "tags": [ "primary" ],
                "port": 5432,
                "checks": [{
                        "id": "pg_alive",
                        "notes": "Check connection",
                        "script": "/usr/bin/check_postgres --dbname micro --action connection",
                        "interval": "10s"
                }]
        }
}
```

A micro service could use this to create a database connection url and connect to the database.

Within the current code a service is excluded from the registry.GetService(...) when a 'version' tag is missing; however it might be because it is a third party service.

Furthermore; when switching to the go-micro framework, it wouldn't be uncommon to have the go-micro service connect to `for example serveral Java micro services` by protobuf until all business logic have been moved to new go-micro services.

The ListServices() already returns all services within a consul registry; this PR simply updates GetService(...) to include all requested services even if they are non go-micro.
