### PR TITLE
Syntactic sugar for pubsub

### DIFF
--- a/go-micro.go
+++ b/go-micro.go
@@ -22,6 +22,11 @@ type Service interface {
 	String() string
 }
 
+// Publisher is syntactic sugar for publishing
+type Publisher interface {
+	Publish(ctx context.Context, msg interface{}, opts ...client.PublishOption) error
+}
+
 type Option func(*Options)
 
 var (
@@ -42,4 +47,22 @@ func FromContext(ctx context.Context) (Service, bool) {
 // NewContext returns a new Context with the Service embedded within it.
 func NewContext(ctx context.Context, s Service) context.Context {
 	return context.WithValue(ctx, serviceKey{}, s)
+}
+
+// NewPublisher returns a new Publisher
+func NewPublisher(topic string, c client.Client) Publisher {
+	if c == nil {
+		c = client.NewClient()
+	}
+	return &publisher{c, topic}
+}
+
+// RegisterHandler is syntactic sugar for registering a handler
+func RegisterHandler(s server.Server, h interface{}, opts ...server.HandlerOption) error {
+	return s.Handle(s.NewHandler(h, opts...))
+}
+
+// RegisterSubscriber is syntactic sugar for registering a subscriber
+func RegisterSubscriber(topic string, s server.Server, h interface{}, opts ...server.SubscriberOption) error {
+	return s.Subscribe(s.NewSubscriber(topic, h))
 }

--- a/publisher.go
+++ b/publisher.go
@@ -1,0 +1,15 @@
+package micro
+
+import (
+	"github.com/micro/go-micro/client"
+	"golang.org/x/net/context"
+)
+
+type publisher struct {
+	c     client.Client
+	topic string
+}
+
+func (p *publisher) Publish(ctx context.Context, msg interface{}, opts ...client.PublishOption) error {
+	return p.c.Publish(ctx, p.c.NewPublication(p.topic, msg))
+}


### PR DESCRIPTION
This has been stripped from proto generation but syntactic sugar would be convenient for registering a subscriber and creating a publisher.