### PR TITLE
fix version option in cmd

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -413,6 +413,7 @@ func (c *cmd) Init(opts ...Option) error {
 	}
 	c.app.Name = c.opts.Name
 	c.app.Version = c.opts.Version
+	c.app.HideVersion = len(c.opts.Version) == 0
 	c.app.Usage = c.opts.Description
 	c.app.RunAndExitOnError()
 	return nil


### PR DESCRIPTION
After cmd.Init with the cmd.Version option, the cmd.app.HideVersion should be updated. Otherwise the help message will ignore version infomation.