### PR TITLE
Transport callbacks no longer silently recovering from error

### DIFF
--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -316,9 +316,13 @@ func (h *httpTransportListener) Accept(fn func(Socket)) error {
 		}
 
 		go func() {
-			// TODO: think of a better error response strategy
 			defer func() {
 				if r := recover(); r != nil {
+					// in case a callback handler was specified, call it
+					if h.ht.opts.OnPanicCallBack != nil {
+						h.ht.opts.OnPanicCallBack(r)
+					}
+					// we close the socket anyway, because the handling already failed
 					sock.Close()
 				}
 			}()

--- a/transport/options.go
+++ b/transport/options.go
@@ -17,7 +17,8 @@ type Options struct {
 	Timeout time.Duration
 	// Other options for implementations of the interface
 	// can be stored in a context
-	Context context.Context
+	Context         context.Context
+	OnPanicCallBack func(obj interface{})
 }
 
 type DialOptions struct {
@@ -89,5 +90,12 @@ func WithStream() DialOption {
 func WithTimeout(d time.Duration) DialOption {
 	return func(o *DialOptions) {
 		o.Timeout = d
+	}
+}
+
+// OnPanic lets you specify what should happen when a panic occured
+func OnPanic(cbfn func(obj interface{})) Option {
+	return func(o *Options) {
+		o.OnPanicCallBack = cbfn
 	}
 }


### PR DESCRIPTION
These days we had problems with some of our services that got an "unexpected EOF" error from endpoints on services using the micro framework. We couldn't find any log messages to what causes these unexpected EOFs. After some digging in the framework I found this spot with a TODO on it. Now we can give an option of a callback so we can control if we want to log the error or if we even want to restart the service etc. 