### PR TITLE
make use of micro/go-log

### DIFF
--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/micro/go-log"
 	"github.com/micro/go-micro/broker/codec/json"
 	"github.com/micro/go-micro/errors"
 	"github.com/micro/go-micro/registry"
@@ -249,7 +249,7 @@ func (h *httpBroker) start() error {
 		return err
 	}
 
-	log.Printf("Broker Listening on %s", l.Addr().String())
+	log.Logf("Broker Listening on %s", l.Addr().String())
 	h.address = l.Addr().String()
 
 	go http.Serve(l, h.mux)

--- a/selector/cache/cache.go
+++ b/selector/cache/cache.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
-	"log"
 	"sync"
 	"time"
 
+	"github.com/micro/go-log"
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/selector"
 )
@@ -241,14 +241,14 @@ func (c *cacheSelector) run() {
 		// create new watcher
 		w, err := c.so.Registry.Watch()
 		if err != nil {
-			log.Println(err)
+			log.Log(err)
 			time.Sleep(time.Second)
 			continue
 		}
 
 		// watch for events
 		if err := c.watch(w); err != nil {
-			log.Println(err)
+			log.Log(err)
 			continue
 		}
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -2,13 +2,13 @@ package server
 
 import (
 	"fmt"
-	"log"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/micro/go-log"
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/codec"
 	"github.com/micro/go-micro/metadata"
@@ -53,7 +53,7 @@ func (s *rpcServer) accept(sock transport.Socket) {
 		sock.Close()
 
 		if r := recover(); r != nil {
-			log.Print(r, string(debug.Stack()))
+			log.Log(r, string(debug.Stack()))
 		}
 	}()
 
@@ -101,7 +101,7 @@ func (s *rpcServer) accept(sock transport.Socket) {
 
 		// TODO: needs better error handling
 		if err := s.rpc.serveRequest(ctx, codec, ct); err != nil {
-			log.Printf("Unexpected error serving request, closing socket: %v", err)
+			log.Logf("Unexpected error serving request, closing socket: %v", err)
 			return
 		}
 	}
@@ -252,7 +252,7 @@ func (s *rpcServer) Register() error {
 	s.Unlock()
 
 	if !registered {
-		log.Printf("Registering node: %s", node.Id)
+		log.Logf("Registering node: %s", node.Id)
 	}
 
 	// create registry options
@@ -327,7 +327,7 @@ func (s *rpcServer) Deregister() error {
 		Nodes:   []*registry.Node{node},
 	}
 
-	log.Printf("Deregistering node: %s", node.Id)
+	log.Logf("Deregistering node: %s", node.Id)
 	if err := config.Registry.Deregister(service); err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func (s *rpcServer) Deregister() error {
 
 	for sb, subs := range s.subscribers {
 		for _, sub := range subs {
-			log.Printf("Unsubscribing from topic: %s", sub.Topic())
+			log.Logf("Unsubscribing from topic: %s", sub.Topic())
 			sub.Unsubscribe()
 		}
 		s.subscribers[sb] = nil
@@ -362,7 +362,7 @@ func (s *rpcServer) Start() error {
 		return err
 	}
 
-	log.Printf("Listening on %s", ts.Addr())
+	log.Logf("Listening on %s", ts.Addr())
 	s.Lock()
 	s.opts.Address = ts.Addr()
 	s.Unlock()

--- a/server/rpc_service.go
+++ b/server/rpc_service.go
@@ -9,13 +9,13 @@ package server
 import (
 	"errors"
 	"io"
-	"log"
 	"reflect"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/micro/go-log"
 	"golang.org/x/net/context"
 )
 
@@ -113,7 +113,7 @@ func prepareMethod(method reflect.Method) *methodType {
 		replyType = mtype.In(3)
 		contextType = mtype.In(1)
 	default:
-		log.Println("method", mname, "of", mtype, "has wrong number of ins:", mtype.NumIn())
+		log.Log("method", mname, "of", mtype, "has wrong number of ins:", mtype.NumIn())
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func prepareMethod(method reflect.Method) *methodType {
 		// check stream type
 		streamType := reflect.TypeOf((*Streamer)(nil)).Elem()
 		if !argType.Implements(streamType) {
-			log.Println(mname, "argument does not implement Streamer interface:", argType)
+			log.Log(mname, "argument does not implement Streamer interface:", argType)
 			return nil
 		}
 	} else {
@@ -129,30 +129,30 @@ func prepareMethod(method reflect.Method) *methodType {
 
 		// First arg need not be a pointer.
 		if !isExportedOrBuiltinType(argType) {
-			log.Println(mname, "argument type not exported:", argType)
+			log.Log(mname, "argument type not exported:", argType)
 			return nil
 		}
 
 		if replyType.Kind() != reflect.Ptr {
-			log.Println("method", mname, "reply type not a pointer:", replyType)
+			log.Log("method", mname, "reply type not a pointer:", replyType)
 			return nil
 		}
 
 		// Reply type must be exported.
 		if !isExportedOrBuiltinType(replyType) {
-			log.Println("method", mname, "reply type not exported:", replyType)
+			log.Log("method", mname, "reply type not exported:", replyType)
 			return nil
 		}
 	}
 
 	// Method needs one out.
 	if mtype.NumOut() != 1 {
-		log.Println("method", mname, "has wrong number of outs:", mtype.NumOut())
+		log.Log("method", mname, "has wrong number of outs:", mtype.NumOut())
 		return nil
 	}
 	// The return type of the method must be error.
 	if returnType := mtype.Out(0); returnType != typeOfError {
-		log.Println("method", mname, "returns", returnType.String(), "not error")
+		log.Log("method", mname, "returns", returnType.String(), "not error")
 		return nil
 	}
 	return &methodType{method: method, ArgType: argType, ReplyType: replyType, ContextType: contextType, stream: stream}
@@ -169,11 +169,12 @@ func (server *server) register(rcvr interface{}) error {
 	s.rcvr = reflect.ValueOf(rcvr)
 	sname := reflect.Indirect(s.rcvr).Type().Name()
 	if sname == "" {
-		log.Fatal("rpc: no service name for type", s.typ.String())
+		log.Log("rpc: no service name for type", s.typ.String())
+		return errors.New("rpc: no service name for type" + s.typ.String())
 	}
 	if !isExported(sname) {
 		s := "rpc Register: type " + sname + " is not exported"
-		log.Print(s)
+		log.Log(s)
 		return errors.New(s)
 	}
 	if _, present := server.serviceMap[sname]; present {
@@ -192,7 +193,7 @@ func (server *server) register(rcvr interface{}) error {
 
 	if len(s.method) == 0 {
 		s := "rpc Register: type " + sname + " has no exported methods of suitable type"
-		log.Print(s)
+		log.Log(s)
 		return errors.New(s)
 	}
 	server.serviceMap[s.name] = s

--- a/server/rpc_service.go
+++ b/server/rpc_service.go
@@ -169,8 +169,7 @@ func (server *server) register(rcvr interface{}) error {
 	s.rcvr = reflect.ValueOf(rcvr)
 	sname := reflect.Indirect(s.rcvr).Type().Name()
 	if sname == "" {
-		log.Log("rpc: no service name for type", s.typ.String())
-		return errors.New("rpc: no service name for type" + s.typ.String())
+		log.Fatal("rpc: no service name for type", s.typ.String())
 	}
 	if !isExported(sname) {
 		s := "rpc Register: type " + sname + " is not exported"

--- a/server/server.go
+++ b/server/server.go
@@ -2,11 +2,11 @@
 package server
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/micro/go-log"
 	"github.com/pborman/uuid"
 	"golang.org/x/net/context"
 )
@@ -140,7 +140,7 @@ func Run() error {
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
-	log.Printf("Received signal %s", <-ch)
+	log.Logf("Received signal %s", <-ch)
 
 	if err := DefaultServer.Deregister(); err != nil {
 		return err
@@ -152,13 +152,13 @@ func Run() error {
 // Start starts the default server
 func Start() error {
 	config := DefaultServer.Options()
-	log.Printf("Starting server %s id %s", config.Name, config.Id)
+	log.Logf("Starting server %s id %s", config.Name, config.Id)
 	return DefaultServer.Start()
 }
 
 // Stop stops the default server
 func Stop() error {
-	log.Printf("Stopping server")
+	log.Logf("Stopping server")
 	return DefaultServer.Stop()
 }
 

--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
+	"github.com/micro/go-log"
 	maddr "github.com/micro/misc/lib/addr"
 	mnet "github.com/micro/misc/lib/net"
 	mls "github.com/micro/misc/lib/tls"
@@ -301,7 +301,7 @@ func (h *httpTransportListener) Accept(fn func(Socket)) error {
 				if max := 1 * time.Second; tempDelay > max {
 					tempDelay = max
 				}
-				log.Printf("http: Accept error: %v; retrying in %v\n", err, tempDelay)
+				log.Logf("http: Accept error: %v; retrying in %v\n", err, tempDelay)
 				time.Sleep(tempDelay)
 				continue
 			}
@@ -319,6 +319,7 @@ func (h *httpTransportListener) Accept(fn func(Socket)) error {
 			// TODO: think of a better error response strategy
 			defer func() {
 				if r := recover(); r != nil {
+					log.Logf("http: recovered %v", r)
 					sock.Close()
 				}
 			}()


### PR DESCRIPTION
In favour of "libraries not logging" I've defined a universal log interface https://github.com/go-log/log to help solve this problem and a micro scoped logger https://github.com/micro/go-log for all micro libraries. This is the first PR to shift to using that logger. This change actually changes nothing since the underlying implementation still uses the stdlib log package. In the grand scheme of things people can freely set the logger using `micro/go-log.SetLogger`.