### PR TITLE
Improve the UX for users of the errors package.

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,14 +1,14 @@
-// Package errors is an interface for defining detailed errors
+// Package errors provides a way to return detailed information
+// for an RPC request error. The error is normally JSON encoded.
 package errors
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
-// Errors provide a way to return detailed information
-// for an RPC request error. The error is normally
-// JSON encoded.
+// Error implements the error interface.
 type Error struct {
 	Id     string `json:"id"`
 	Code   int32  `json:"code"`
@@ -21,6 +21,7 @@ func (e *Error) Error() string {
 	return string(b)
 }
 
+// New generates a custom error.
 func New(id, detail string, code int32) error {
 	return &Error{
 		Id:     id,
@@ -30,6 +31,8 @@ func New(id, detail string, code int32) error {
 	}
 }
 
+// Parse tries to parse a JSON string into an error. If that
+// fails, it will set the given string as the error detail.
 func Parse(err string) *Error {
 	e := new(Error)
 	errr := json.Unmarshal([]byte(err), e)
@@ -39,47 +42,52 @@ func Parse(err string) *Error {
 	return e
 }
 
-func BadRequest(id, detail string) error {
+// BadRequest generates a 400 error.
+func BadRequest(id, format string, a ...interface{}) error {
 	return &Error{
 		Id:     id,
 		Code:   400,
-		Detail: detail,
+		Detail: fmt.Sprintf(format, a...),
 		Status: http.StatusText(400),
 	}
 }
 
-func Unauthorized(id, detail string) error {
+// Unauthorized generates a 401 error.
+func Unauthorized(id, format string, a ...interface{}) error {
 	return &Error{
 		Id:     id,
 		Code:   401,
-		Detail: detail,
+		Detail: fmt.Sprintf(format, a...),
 		Status: http.StatusText(401),
 	}
 }
 
-func Forbidden(id, detail string) error {
+// Forbidden generates a 403 error.
+func Forbidden(id, format string, a ...interface{}) error {
 	return &Error{
 		Id:     id,
 		Code:   403,
-		Detail: detail,
+		Detail: fmt.Sprintf(format, a...),
 		Status: http.StatusText(403),
 	}
 }
 
-func NotFound(id, detail string) error {
+// NotFound generates a 404 error.
+func NotFound(id, format string, a ...interface{}) error {
 	return &Error{
 		Id:     id,
 		Code:   404,
-		Detail: detail,
+		Detail: fmt.Sprintf(format, a...),
 		Status: http.StatusText(404),
 	}
 }
 
-func InternalServerError(id, detail string) error {
+// InternalServerError generates a 500 error.
+func InternalServerError(id, format string, a ...interface{}) error {
 	return &Error{
 		Id:     id,
 		Code:   500,
-		Detail: detail,
+		Detail: fmt.Sprintf(format, a...),
 		Status: http.StatusText(500),
 	}
 }


### PR DESCRIPTION
By making the error helper functions variadic functions, you can pass either a string (like the existing behaviour) or a format and verbs that will then be formatted for you.

This doesn’t break any existing API’s, but it prevents people using this package to have to call `fmt.Sprintf` whenever they would like to format the error detail.

Also fixed as much linter warning as possible without making backwards incompatible changes...