### PR TITLE
Add MessagePack broker codec

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -1,6 +1,9 @@
 // Package broker is an interface used for asynchronous messaging
 package broker
 
+// This is required by the MsgPack broker codel
+//go:generate msgp -io=false -tests=false
+
 // Broker is an interface used for asynchronous messaging.
 // Its an abstraction over various message brokers
 // {NATS, RabbitMQ, Kafka, ...}

--- a/broker/broker_gen.go
+++ b/broker/broker_gen.go
@@ -1,0 +1,98 @@
+package broker
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Message) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Header"
+	o = append(o, 0x82, 0xa6, 0x48, 0x65, 0x61, 0x64, 0x65, 0x72)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Header)))
+	for zxvk, zbzg := range z.Header {
+		o = msgp.AppendString(o, zxvk)
+		o = msgp.AppendString(o, zbzg)
+	}
+	// string "Body"
+	o = append(o, 0xa4, 0x42, 0x6f, 0x64, 0x79)
+	o = msgp.AppendBytes(o, z.Body)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Message) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zbai uint32
+	zbai, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zbai > 0 {
+		zbai--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Header":
+			var zcmr uint32
+			zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Header == nil && zcmr > 0 {
+				z.Header = make(map[string]string, zcmr)
+			} else if len(z.Header) > 0 {
+				for key, _ := range z.Header {
+					delete(z.Header, key)
+				}
+			}
+			for zcmr > 0 {
+				var zxvk string
+				var zbzg string
+				zcmr--
+				zxvk, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				zbzg, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Header[zxvk] = zbzg
+			}
+		case "Body":
+			z.Body, bts, err = msgp.ReadBytesBytes(bts, z.Body)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Message) Msgsize() (s int) {
+	s = 1 + 7 + msgp.MapHeaderSize
+	if z.Header != nil {
+		for zxvk, zbzg := range z.Header {
+			_ = zbzg
+			s += msgp.StringPrefixSize + len(zxvk) + msgp.StringPrefixSize + len(zbzg)
+		}
+	}
+	s += 5 + msgp.BytesPrefixSize + len(z.Body)
+	return
+}

--- a/broker/codec/msgp/msgp.go
+++ b/broker/codec/msgp/msgp.go
@@ -1,0 +1,37 @@
+package msgp
+
+import (
+	"errors"
+
+	"github.com/micro/go-micro/broker"
+	"github.com/micro/go-micro/broker/codec"
+)
+
+type msgpCodec struct{}
+
+func (n msgpCodec) Marshal(v interface{}) ([]byte, error) {
+	msg, ok := v.(*broker.Message)
+	if !ok {
+		return nil, errors.New("invalid message")
+	}
+
+	out := make([]byte, msg.Msgsize())
+	return msg.MarshalMsg(out)
+}
+
+func (n msgpCodec) Unmarshal(d []byte, v interface{}) error {
+	msg, ok := v.(*broker.Message)
+	if !ok {
+		return errors.New("invalid message")
+	}
+	_, err := msg.UnmarshalMsg(d)
+	return err
+}
+
+func (n msgpCodec) String() string {
+	return "msgp"
+}
+
+func NewCodec() codec.Codec {
+	return msgpCodec{}
+}


### PR DESCRIPTION
Hi,

This PR adds a message pack broker codec. I do understand that this probably should be in the go-plugins repo, but due to the way the msgp go implementation works (afaict, it needs to generate methods on the serialized data structure), this is not cleanly possible.

That being said, the serialization performance (as documented here https://github.com/alecthomas/go_serialization_benchmarks) are preaching for its inclusion into the project :)

Any comment is is highly appreciated :)
