### PR TITLE
Added Options() to registry interface

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -17,7 +17,7 @@ import (
 type consulRegistry struct {
 	Address string
 	Client  *consul.Client
-	Options Options
+	opts    Options
 
 	sync.Mutex
 	register map[string]uint64
@@ -93,7 +93,7 @@ func newConsulRegistry(opts ...Option) Registry {
 	cr := &consulRegistry{
 		Address:  config.Address,
 		Client:   client,
-		Options:  options,
+		opts:     options,
 		register: make(map[string]uint64),
 	}
 
@@ -284,4 +284,8 @@ func (c *consulRegistry) Watch() (Watcher, error) {
 
 func (c *consulRegistry) String() string {
 	return "consul"
+}
+
+func (c *consulRegistry) Options() Options {
+	return c.opts
 }

--- a/registry/mdns/mdns.go
+++ b/registry/mdns/mdns.go
@@ -316,6 +316,10 @@ func (m *mdnsRegistry) String() string {
 	return "mdns"
 }
 
+func (m *mdnsRegistry) Options() registry.Options {
+	return m.opts
+}
+
 func NewRegistry(opts ...registry.Option) registry.Registry {
 	return newRegistry(opts...)
 }

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -95,6 +95,10 @@ func (m *mockRegistry) String() string {
 	return "mock"
 }
 
+func (m *mockRegistry) Options() registry.Options {
+	return registry.Options{}
+}
+
 func NewRegistry() registry.Registry {
 	m := &mockRegistry{Services: make(map[string][]*registry.Service)}
 	m.init()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,6 +15,7 @@ type Registry interface {
 	ListServices() ([]*Service, error)
 	Watch() (Watcher, error)
 	String() string
+	Options() Options
 }
 
 type Option func(*Options)


### PR DESCRIPTION
I have added the Options flag to the registry.

At the moment I cannot extract any registry option from the Registry implementation.
Yes if i set this option from command line I can get it via an action or env variable but if it is a default option I cannot.

For example if I do not set the registry address via command line the default consul implementation will use an address of 127.0.0.1:8500, so i could have a copy of this address in my service but what if I decide to switch to a different implementation that uses address x.x.x.x my code now needs to change. 

I have made the change in go-plugins see [here](https://github.com/darren-west/go-plugins). go-os would also need to be updated.
