### PR TITLE
add https support for consul

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -59,14 +59,6 @@ func newConsulRegistry(opts ...Option) Registry {
 			config = c
 		}
 	}
-	if config.HttpClient == nil {
-		config.HttpClient = new(http.Client)
-	}
-
-	// set timeout
-	if options.Timeout > 0 {
-		config.HttpClient.Timeout = options.Timeout
-	}
 
 	// check if there are any addrs
 	if len(options.Addrs) > 0 {
@@ -82,6 +74,10 @@ func newConsulRegistry(opts ...Option) Registry {
 
 	// requires secure connection?
 	if options.Secure || options.TLSConfig != nil {
+		if config.HttpClient == nil {
+			config.HttpClient = new(http.Client)
+		}
+
 		config.Scheme = "https"
 		// We're going to support InsecureSkipVerify
 		config.HttpClient.Transport = newTransport(options.TLSConfig)
@@ -89,6 +85,11 @@ func newConsulRegistry(opts ...Option) Registry {
 
 	// create the client
 	client, _ := consul.NewClient(config)
+
+	// set timeout
+	if options.Timeout > 0 {
+		config.HttpClient.Timeout = options.Timeout
+	}
 
 	cr := &consulRegistry{
 		Address:  config.Address,


### PR DESCRIPTION
fix issue that will never get a chance to setup tls even the environment variables set.
using enviroment variables

for example:
export CONSUL_HTTP_SSL=1
export CONSUL_HTTP_ADDR="https://example.com"
export CONSUL_CLIENT_CERT="/Users/foo/.ssh/consul/consul.cert"
export CONSUL_CLIENT_KEY="/Users/foo/.ssh/consul/consul.key"
export CONSUL_CACERT="/Users/foo/.ssh/consul/ca.cert"