### PR TITLE
fix possible deadlock since code can return without unlocking the Mutex

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -182,12 +182,12 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 	}
 
 	s.Lock()
+	defer s.Unlock()
 	_, ok = s.subscribers[sub]
 	if ok {
 		return fmt.Errorf("subscriber %v already exists", s)
 	}
 	s.subscribers[sub] = nil
-	s.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Hi,

If a subscriber already exists the code returns without unlocking the rpcServer's Mutex. This might cause a deadlock later on.

