### PR TITLE
registry: export consul registry

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -14,7 +14,7 @@ import (
 	hash "github.com/mitchellh/hashstructure"
 )
 
-type consulRegistry struct {
+type ConsulRegistry struct {
 	Address string
 	Client  *consul.Client
 	Options Options
@@ -91,7 +91,7 @@ func newConsulRegistry(opts ...Option) Registry {
 		config.HttpClient.Timeout = options.Timeout
 	}
 
-	cr := &consulRegistry{
+	cr := &ConsulRegistry{
 		Address:  config.Address,
 		Client:   client,
 		Options:  options,
@@ -101,7 +101,7 @@ func newConsulRegistry(opts ...Option) Registry {
 	return cr
 }
 
-func (c *consulRegistry) Deregister(s *Service) error {
+func (c *ConsulRegistry) Deregister(s *Service) error {
 	if len(s.Nodes) == 0 {
 		return errors.New("Require at least one node")
 	}
@@ -115,7 +115,7 @@ func (c *consulRegistry) Deregister(s *Service) error {
 	return c.Client.Agent().ServiceDeregister(node.Id)
 }
 
-func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
+func (c *ConsulRegistry) Register(s *Service, opts ...RegisterOption) error {
 	if len(s.Nodes) == 0 {
 		return errors.New("Require at least one node")
 	}
@@ -197,7 +197,7 @@ func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
 	return c.Client.Agent().PassTTL("service:"+node.Id, "")
 }
 
-func (c *consulRegistry) GetService(name string) ([]*Service, error) {
+func (c *ConsulRegistry) GetService(name string) ([]*Service, error) {
 	rsp, _, err := c.Client.Health().Service(name, "", false, nil)
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func (c *consulRegistry) GetService(name string) ([]*Service, error) {
 	return services, nil
 }
 
-func (c *consulRegistry) ListServices() ([]*Service, error) {
+func (c *ConsulRegistry) ListServices() ([]*Service, error) {
 	rsp, _, err := c.Client.Catalog().Services(nil)
 	if err != nil {
 		return nil, err
@@ -279,10 +279,10 @@ func (c *consulRegistry) ListServices() ([]*Service, error) {
 	return services, nil
 }
 
-func (c *consulRegistry) Watch() (Watcher, error) {
+func (c *ConsulRegistry) Watch() (Watcher, error) {
 	return newConsulWatcher(c)
 }
 
-func (c *consulRegistry) String() string {
+func (c *ConsulRegistry) String() string {
 	return "consul"
 }

--- a/registry/consul_registry_test.go
+++ b/registry/consul_registry_test.go
@@ -40,7 +40,7 @@ func newMockServer(rg *mockRegistry, l net.Listener) error {
 	return http.Serve(l, mux)
 }
 
-func newConsulTestRegistry(r *mockRegistry) (*consulRegistry, func()) {
+func newConsulTestRegistry(r *mockRegistry) (*ConsulRegistry, func()) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		// blurgh?!!
@@ -52,7 +52,7 @@ func newConsulTestRegistry(r *mockRegistry) (*consulRegistry, func()) {
 
 	go newMockServer(r, l)
 
-	return &consulRegistry{
+	return &ConsulRegistry{
 			Address:  cfg.Address,
 			Client:   cl,
 			register: make(map[string]uint64),

--- a/registry/consul_watcher.go
+++ b/registry/consul_watcher.go
@@ -9,7 +9,7 @@ import (
 )
 
 type consulWatcher struct {
-	r        *consulRegistry
+	r        *ConsulRegistry
 	wp       *watch.Plan
 	watchers map[string]*watch.Plan
 
@@ -20,7 +20,7 @@ type consulWatcher struct {
 	services map[string][]*Service
 }
 
-func newConsulWatcher(cr *consulRegistry) (Watcher, error) {
+func newConsulWatcher(cr *ConsulRegistry) (Watcher, error) {
 	cw := &consulWatcher{
 		r:        cr,
 		exit:     make(chan bool),


### PR DESCRIPTION
Export the consul registry to allow direct manipulation of the consul client used by it for more complex use cases. This way, services can declare consul tags or use the K/V storage.