### PR TITLE
Add watch options

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -279,8 +279,8 @@ func (c *consulRegistry) ListServices() ([]*Service, error) {
 	return services, nil
 }
 
-func (c *consulRegistry) Watch() (Watcher, error) {
-	return newConsulWatcher(c)
+func (c *consulRegistry) Watch(opts ...WatchOption) (Watcher, error) {
+	return newConsulWatcher(c, opts...)
 }
 
 func (c *consulRegistry) String() string {

--- a/registry/mdns/mdns.go
+++ b/registry/mdns/mdns.go
@@ -297,8 +297,14 @@ func (m *mdnsRegistry) ListServices() ([]*registry.Service, error) {
 	return services, nil
 }
 
-func (m *mdnsRegistry) Watch() (registry.Watcher, error) {
+func (m *mdnsRegistry) Watch(opts ...registry.WatchOption) (registry.Watcher, error) {
+	var wo registry.WatchOptions
+	for _, o := range opts {
+		o(&wo)
+	}
+
 	md := &mdnsWatcher{
+		wo:   wo,
 		ch:   make(chan *mdns.ServiceEntry, 32),
 		exit: make(chan struct{}),
 	}

--- a/registry/mdns/watcher.go
+++ b/registry/mdns/watcher.go
@@ -9,6 +9,7 @@ import (
 )
 
 type mdnsWatcher struct {
+	wo   registry.WatchOptions
 	ch   chan *mdns.ServiceEntry
 	exit chan struct{}
 }
@@ -23,6 +24,12 @@ func (m *mdnsWatcher) Next() (*registry.Result, error) {
 			}
 
 			if len(txt.Service) == 0 || len(txt.Version) == 0 {
+				continue
+			}
+
+			// Filter watch options
+			// wo.Service: Only keep services we care about
+			if len(m.wo.Service) > 0 && txt.Service != m.wo.Service {
 				continue
 			}
 

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -87,8 +87,12 @@ func (m *mockRegistry) Deregister(s *registry.Service) error {
 	return nil
 }
 
-func (m *mockRegistry) Watch() (registry.Watcher, error) {
-	return &mockWatcher{exit: make(chan bool)}, nil
+func (m *mockRegistry) Watch(opts ...registry.WatchOption) (registry.Watcher, error) {
+	var wopts registry.WatchOptions
+	for _, o := range opts {
+		o(&wopts)
+	}
+	return &mockWatcher{exit: make(chan bool), opts: wopts}, nil
 }
 
 func (m *mockRegistry) String() string {

--- a/registry/mock/mock_watcher.go
+++ b/registry/mock/mock_watcher.go
@@ -8,6 +8,7 @@ import (
 
 type mockWatcher struct {
 	exit chan bool
+	opts registry.WatchOptions
 }
 
 func (m *mockWatcher) Next() (*registry.Result, error) {

--- a/registry/options.go
+++ b/registry/options.go
@@ -25,6 +25,15 @@ type RegisterOptions struct {
 	Context context.Context
 }
 
+type WatchOptions struct {
+	// Specify a service to watch
+	// If blank, the watch is for all services
+	Service string
+	// Other options for implementations of the interface
+	// can be stored in a context
+	Context context.Context
+}
+
 // Addrs is the registry addresses to use
 func Addrs(addrs ...string) Option {
 	return func(o *Options) {
@@ -55,5 +64,12 @@ func TLSConfig(t *tls.Config) Option {
 func RegisterTTL(t time.Duration) RegisterOption {
 	return func(o *RegisterOptions) {
 		o.TTL = t
+	}
+}
+
+// Watch a service
+func WatchService(name string) WatchOption {
+	return func(o *WatchOptions) {
+		o.Service = name
 	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -13,13 +13,15 @@ type Registry interface {
 	Deregister(*Service) error
 	GetService(string) ([]*Service, error)
 	ListServices() ([]*Service, error)
-	Watch() (Watcher, error)
+	Watch(...WatchOption) (Watcher, error)
 	String() string
 }
 
 type Option func(*Options)
 
 type RegisterOption func(*RegisterOptions)
+
+type WatchOption func(*WatchOptions)
 
 var (
 	DefaultRegistry = newConsulRegistry()
@@ -52,8 +54,8 @@ func ListServices() ([]*Service, error) {
 }
 
 // Watch returns a watcher which allows you to track updates to the registry.
-func Watch() (Watcher, error) {
-	return DefaultRegistry.Watch()
+func Watch(opts ...WatchOption) (Watcher, error) {
+	return DefaultRegistry.Watch(opts...)
 }
 
 func String() string {


### PR DESCRIPTION
This PR adds watch options. We also make the selector watch services individually so that we don't cache everything. This is a workaround for the consul watcher implementation which will keep the number of go routines low since we're not watching everything.