### PR TITLE
switch to stdlib context

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ It does the following:
 package main
 
 import (
+	"context"
 	"fmt"
 
 	micro "github.com/micro/go-micro"
 	proto "github.com/micro/examples/service/proto"
-	"golang.org/x/net/context"
 )
 
 type Greeter struct{}
@@ -180,11 +180,11 @@ The generated proto includes a greeter client to reduce boilerplate code.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	micro "github.com/micro/go-micro"
 	proto "github.com/micro/examples/service/proto"
-	"golang.org/x/net/context"
 )
 
 
@@ -230,9 +230,10 @@ A Function is a one time executing Service which exits after completing a reques
 package main
 
 import (
+	"context"
+
 	proto "github.com/micro/examples/function/proto"
 	"github.com/micro/go-micro"
-	"golang.org/x/net/context"
 )
 
 type Greeter struct{}

--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -26,8 +27,6 @@ import (
 	mnet "github.com/micro/misc/lib/net"
 	mls "github.com/micro/misc/lib/tls"
 	"github.com/pborman/uuid"
-
-	"golang.org/x/net/context"
 )
 
 // HTTP Broker is a point to point async broker

--- a/broker/options.go
+++ b/broker/options.go
@@ -1,11 +1,11 @@
 package broker
 
 import (
+	"context"
 	"crypto/tls"
 
 	"github.com/micro/go-micro/broker/codec"
 	"github.com/micro/go-micro/registry"
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/client/backoff.go
+++ b/client/backoff.go
@@ -1,10 +1,9 @@
 package client
 
 import (
+	"context"
 	"math"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type BackoffFunc func(ctx context.Context, req Request, attempts int) (time.Duration, error)

--- a/client/backoff_test.go
+++ b/client/backoff_test.go
@@ -1,11 +1,10 @@
 package client
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestBackoff(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -2,9 +2,8 @@
 package client
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Client is the interface used to make requests to services.

--- a/client/client_wrapper.go
+++ b/client/client_wrapper.go
@@ -1,41 +1,7 @@
 package client
 
-/*
-Wrapper is a type of middleware for the go-micro client. It allows
-the client to be "wrapped" so that requests and responses can be intercepted
-to perform extra requirements such as auth, tracing, monitoring, logging, etc.
-
-Example usage:
-
-	import (
-		"log"
-		"github.com/micro/go-micro/client"
-
-	)
-
-	type LogWrapper struct {
-		client.Client
-	}
-
-	func (l *LogWrapper) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
-		log.Println("Making request to service " + req.Service() + " method " + req.Method())
-		return w.Client.Call(ctx, req, rsp)
-	}
-
-	func Wrapper(c client.Client) client.Client {
-		return &LogWrapper{c}
-	}
-
-	func main() {
-		c := client.NewClient(client.Wrap(Wrapper))
-
-	}
-
-
-*/
-
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // CallFunc represents the individual call func

--- a/client/context.go
+++ b/client/context.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type clientKey struct{}

--- a/client/mock/context.go
+++ b/client/mock/context.go
@@ -1,7 +1,7 @@
 package mock
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type responseKey struct{}

--- a/client/mock/mock.go
+++ b/client/mock/mock.go
@@ -1,14 +1,13 @@
 package mock
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
 
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/errors"
-
-	"golang.org/x/net/context"
 )
 
 var (

--- a/client/mock/mock_test.go
+++ b/client/mock/mock_test.go
@@ -1,11 +1,10 @@
 package mock
 
 import (
+	"context"
 	"testing"
 
 	"github.com/micro/go-micro/errors"
-
-	"golang.org/x/net/context"
 )
 
 func TestClient(t *testing.T) {

--- a/client/options.go
+++ b/client/options.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/go-micro/broker"
@@ -8,8 +9,6 @@ import (
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-micro/transport"
-
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/client/retry.go
+++ b/client/retry.go
@@ -1,6 +1,8 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"context"
+)
 
 // note that returning either false or a non-nil error will result in the call not being retried
 type RetryFunc func(ctx context.Context, req Request, retryCount int, err error) (bool, error)

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -12,8 +13,6 @@ import (
 	"github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-micro/transport"
-
-	"golang.org/x/net/context"
 )
 
 type rpcClient struct {

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -1,14 +1,13 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/registry/mock"
 	"github.com/micro/go-micro/selector"
-
-	"golang.org/x/net/context"
 )
 
 func TestCallWrapper(t *testing.T) {

--- a/client/rpc_stream.go
+++ b/client/rpc_stream.go
@@ -1,10 +1,9 @@
 package client
 
 import (
+	"context"
 	"io"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 // Implements the streamer interface

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
-
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/function.go
+++ b/function.go
@@ -1,10 +1,10 @@
 package micro
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/go-micro/server"
-	"golang.org/x/net/context"
 )
 
 type function struct {

--- a/function_test.go
+++ b/function_test.go
@@ -1,13 +1,12 @@
 package micro
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/micro/go-micro/registry/mock"
 	proto "github.com/micro/go-micro/server/debug/proto"
-
-	"golang.org/x/net/context"
 )
 
 func TestFunction(t *testing.T) {

--- a/go-micro.go
+++ b/go-micro.go
@@ -2,10 +2,10 @@
 package micro
 
 import (
+	"context"
+
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/server"
-
-	"golang.org/x/net/context"
 )
 
 type serviceKey struct{}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -2,7 +2,7 @@
 package metadata
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type metaKey struct{}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,9 +1,8 @@
 package metadata
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestMetadataContext(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package micro
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/cli"
@@ -11,8 +12,6 @@ import (
 	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-micro/server"
 	"github.com/micro/go-micro/transport"
-
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/publisher.go
+++ b/publisher.go
@@ -1,8 +1,9 @@
 package micro
 
 import (
+	"context"
+
 	"github.com/micro/go-micro/client"
-	"golang.org/x/net/context"
 )
 
 type publisher struct {

--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -1,9 +1,10 @@
 package consul
 
 import (
+	"context"
+
 	consul "github.com/hashicorp/consul/api"
 	"github.com/micro/go-micro/registry"
-	"golang.org/x/net/context"
 )
 
 func Config(c *consul.Config) registry.Option {

--- a/registry/options.go
+++ b/registry/options.go
@@ -1,10 +1,9 @@
 package registry
 
 import (
+	"context"
 	"crypto/tls"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/selector/cache/options.go
+++ b/selector/cache/options.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/go-micro/selector"
-	"golang.org/x/net/context"
 )
 
 type ttlKey struct{}

--- a/selector/options.go
+++ b/selector/options.go
@@ -1,9 +1,9 @@
 package selector
 
 import (
-	"github.com/micro/go-micro/registry"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/micro/go-micro/registry"
 )
 
 type Options struct {

--- a/server/context.go
+++ b/server/context.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type serverKey struct{}

--- a/server/debug/debug.go
+++ b/server/debug/debug.go
@@ -1,12 +1,11 @@
 package debug
 
 import (
+	"context"
 	"runtime"
 	"time"
 
 	proto "github.com/micro/go-micro/server/debug/proto"
-
-	"golang.org/x/net/context"
 )
 
 // The debug handler represents an internal server handler

--- a/server/extractor_test.go
+++ b/server/extractor_test.go
@@ -1,11 +1,11 @@
 package server
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/micro/go-micro/registry"
-	"golang.org/x/net/context"
 )
 
 type testHandler struct{}

--- a/server/options.go
+++ b/server/options.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"time"
 
 	"github.com/micro/go-micro/broker"
@@ -8,8 +9,6 @@ import (
 	"github.com/micro/go-micro/registry"
 	"github.com/micro/go-micro/server/debug"
 	"github.com/micro/go-micro/transport"
-
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"sort"
@@ -17,8 +18,6 @@ import (
 	"github.com/micro/go-micro/transport"
 
 	"github.com/micro/misc/lib/addr"
-
-	"golang.org/x/net/context"
 )
 
 type rpcServer struct {

--- a/server/rpc_service.go
+++ b/server/rpc_service.go
@@ -7,6 +7,7 @@ package server
 // Meh, we need to get rid of this shit
 
 import (
+	"context"
 	"errors"
 	"io"
 	"reflect"
@@ -16,7 +17,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/micro/go-log"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/server/rpc_stream.go
+++ b/server/rpc_stream.go
@@ -1,9 +1,8 @@
 package server
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 // Implements the Streamer interface

--- a/server/server.go
+++ b/server/server.go
@@ -2,13 +2,13 @@
 package server
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/micro/go-log"
 	"github.com/pborman/uuid"
-	"golang.org/x/net/context"
 )
 
 type Server interface {

--- a/server/server_wrapper.go
+++ b/server/server_wrapper.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // HandlerFunc represents a single method of a handler. It's used primarily

--- a/server/subscriber.go
+++ b/server/subscriber.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/micro/go-micro/codec"
 	"github.com/micro/go-micro/metadata"
 	"github.com/micro/go-micro/registry"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/service_test.go
+++ b/service_test.go
@@ -1,13 +1,12 @@
 package micro
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/micro/go-micro/registry/mock"
 	proto "github.com/micro/go-micro/server/debug/proto"
-
-	"golang.org/x/net/context"
 )
 
 func TestService(t *testing.T) {

--- a/transport/options.go
+++ b/transport/options.go
@@ -1,11 +1,11 @@
 package transport
 
 import (
+	"context"
 	"crypto/tls"
 	"time"
 
 	"github.com/micro/go-micro/transport/codec"
-	"golang.org/x/net/context"
 )
 
 type Options struct {

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,10 +1,10 @@
 package micro
 
 import (
+	"context"
+
 	"github.com/micro/go-micro/client"
 	"github.com/micro/go-micro/metadata"
-
-	"golang.org/x/net/context"
 )
 
 type clientWrapper struct {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,11 +1,10 @@
 package micro
 
 import (
+	"context"
 	"testing"
 
 	"github.com/micro/go-micro/metadata"
-
-	"golang.org/x/net/context"
 )
 
 func TestWrapper(t *testing.T) {


### PR DESCRIPTION
This switches to the stdlib context. As of Go 1.9 this is a non-breaking change. We'll always try support the two latest releases. Ideally we don't want to make breaking changes but users should be updating Golang versions.