### PR TITLE
Fix warnings from linter output

### DIFF
--- a/service.go
+++ b/service.go
@@ -153,7 +153,7 @@ func (s *service) Run() error {
 	go s.run(ex)
 
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
 
 	select {
 	// wait on kill signal

--- a/service.go
+++ b/service.go
@@ -67,7 +67,7 @@ func (s *service) Init(opts ...Option) {
 
 	s.once.Do(func() {
 		// Initialise the command flags, overriding new service
-		s.opts.Cmd.Init(
+		_ = s.opts.Cmd.Init(
 			cmd.Broker(&s.opts.Broker),
 			cmd.Registry(&s.opts.Registry),
 			cmd.Transport(&s.opts.Transport),

--- a/service.go
+++ b/service.go
@@ -165,9 +165,5 @@ func (s *service) Run() error {
 	// exit reg loop
 	close(ex)
 
-	if err := s.Stop(); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Stop()
 }

--- a/service_test.go
+++ b/service_test.go
@@ -30,10 +30,16 @@ func TestService(t *testing.T) {
 	// we can't test service.Init as it parses the command line
 	// service.Init()
 
-	// register handler
-	// do that later
+	t.Run("Run", func(t *testing.T) {
+		t.Parallel()
 
-	go func() {
+		// run service
+		service.Run()
+	})
+
+	t.Run("Debug.Health", func(t *testing.T) {
+		t.Parallel()
+
 		// wait for start
 		wg.Wait()
 
@@ -57,8 +63,5 @@ func TestService(t *testing.T) {
 
 		// shutdown the service
 		cancel()
-	}()
-
-	// run service
-	service.Run()
+	})
 }


### PR DESCRIPTION
Changes:

cbbf9f7 (Shulhan, 7 minutes ago)
   [test] service.TestService: run subtest in parallel

   Reason: the t.Fatalf and t.Fatal must be invoked by test routine, not by
   other routine, or the the test will not stopped [1].

   [1] megacheck SA2002

a54dee3 (Shulhan, 28 minutes ago)
   [lint] service.Init: ignore error by assigning it to blank identifier

1bd541b (Shulhan, 34 minutes ago)
   service.Run: replace signal SIGKILL with SIGQUIT

   According to "os/signal" documentation [1] and libc manual [2], SIGKILL may
   not be caught by a program.

   [1] https://godoc.org/os/signal
   [2]
   https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html

e769802 (Shulhan, 39 minutes ago)
   service.Run: simplify return statement