### PR TITLE
Retries can be 0

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -384,9 +384,7 @@ func (c *cmd) Before(ctx *cli.Context) error {
 	}
 
 	// client opts
-	if r := ctx.Int("client_retries"); r > 0 {
-		clientOpts = append(clientOpts, client.Retries(r))
-	}
+	clientOpts = append(clientOpts, client.Retries(r))
 
 	if t := ctx.String("client_request_timeout"); len(t) > 0 {
 		d, err := time.ParseDuration(t)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -384,8 +384,10 @@ func (c *cmd) Before(ctx *cli.Context) error {
 	}
 
 	// client opts
-	clientOpts = append(clientOpts, client.Retries(r))
-
+	if r := ctx.Int("client_retries"); r >= 0 {
+		clientOpts = append(clientOpts, client.Retries(r))
+	}
+	
 	if t := ctx.String("client_request_timeout"); len(t) > 0 {
 		d, err := time.ParseDuration(t)
 		if err != nil {


### PR DESCRIPTION
Giving a chance to set retries to 0. The errors from micro service may not be just some network error, but also created by application. For example, we notify user the password is wrong by returning error. In this situation, I don't want the gateway to request twice.