### PR TITLE
Add Init to all things, use init in cmd package to initialise

### DIFF
--- a/registry/mdns/mdns.go
+++ b/registry/mdns/mdns.go
@@ -49,6 +49,17 @@ func newRegistry(opts ...registry.Option) registry.Registry {
 	}
 }
 
+func (m *mdnsRegistry) Init(opts ...registry.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+
+func (m *mdnsRegistry) Options() registry.Options {
+	return m.opts
+}
+
 func (m *mdnsRegistry) Register(service *registry.Service, opts ...registry.RegisterOption) error {
 	m.Lock()
 	defer m.Unlock()
@@ -320,10 +331,6 @@ func (m *mdnsRegistry) Watch(opts ...registry.WatchOption) (registry.Watcher, er
 
 func (m *mdnsRegistry) String() string {
 	return "mdns"
-}
-
-func (m *mdnsRegistry) Options() registry.Options {
-	return m.opts
 }
 
 func NewRegistry(opts ...registry.Option) registry.Registry {

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -99,11 +99,15 @@ func (m *mockRegistry) String() string {
 	return "mock"
 }
 
+func (m *mockRegistry) Init(opts ...registry.Option) error {
+	return nil
+}
+
 func (m *mockRegistry) Options() registry.Options {
 	return registry.Options{}
 }
 
-func NewRegistry() registry.Registry {
+func NewRegistry(opts ...registry.Options) registry.Registry {
 	m := &mockRegistry{Services: make(map[string][]*registry.Service)}
 	m.init()
 	return m

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -9,13 +9,14 @@ import (
 // and an abstraction over varying implementations
 // {consul, etcd, zookeeper, ...}
 type Registry interface {
+	Init(...Option) error
+	Options() Options
 	Register(*Service, ...RegisterOption) error
 	Deregister(*Service) error
 	GetService(string) ([]*Service, error)
 	ListServices() ([]*Service, error)
 	Watch(...WatchOption) (Watcher, error)
 	String() string
-	Options() Options
 }
 
 type Option func(*Options)

--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -423,6 +423,17 @@ func (h *httpTransport) Listen(addr string, opts ...ListenOption) (Listener, err
 	}, nil
 }
 
+func (h *httpTransport) Init(opts ...Option) error {
+	for _, o := range opts {
+		o(&h.opts)
+	}
+	return nil
+}
+
+func (h *httpTransport) Options() Options {
+	return h.opts
+}
+
 func (h *httpTransport) String() string {
 	return "http"
 }

--- a/transport/mock/mock.go
+++ b/transport/mock/mock.go
@@ -171,6 +171,17 @@ func (m *mockTransport) Listen(addr string, opts ...transport.ListenOption) (tra
 	return listener, nil
 }
 
+func (m *mockTransport) Init(opts ...transport.Option) error {
+	for _, o := range opts {
+		o(&m.opts)
+	}
+	return nil
+}
+
+func (m *mockTransport) Options() transport.Options {
+	return m.opts
+}
+
 func (m *mockTransport) String() string {
 	return "mock"
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -30,6 +30,8 @@ type Listener interface {
 // services. It uses socket send/recv semantics and had various
 // implementations {HTTP, RabbitMQ, NATS, ...}
 type Transport interface {
+	Init(...Option) error
+	Options() Options
 	Dial(addr string, opts ...DialOption) (Client, error)
 	Listen(addr string, opts ...ListenOption) (Listener, error)
 	String() string


### PR DESCRIPTION
This change adds Init where it's missing in interfaces. We want the cmd package to call Init to set addresses and other values rather than creating a new instance of the type we care about. In this case it's possible to setup functionality once a registry or transport is already loaded. These will only be replaced where its named on the command line and differs from what exists.