### PR TITLE
Added client/pool.go, updated client/options.go

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -32,6 +32,9 @@ type Options struct {
 	// Default Call Options
 	CallOptions CallOptions
 
+	// Default Pool Options
+	PoolOptions PoolOptions
+
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
@@ -90,8 +93,10 @@ func newOptions(options ...Option) Options {
 			RequestTimeout: DefaultRequestTimeout,
 			DialTimeout:    transport.DefaultDialTimeout,
 		},
-		PoolSize: DefaultPoolSize,
-		PoolTTL:  DefaultPoolTTL,
+		PoolOptions: PoolOptions{
+			PoolSize: DefaultPoolSize,
+			PoolTTL:  DefaultPoolTTL,
+		},
 	}
 
 	for _, o := range options {
@@ -141,20 +146,6 @@ func Codec(contentType string, c codec.NewCodec) Option {
 func ContentType(ct string) Option {
 	return func(o *Options) {
 		o.ContentType = ct
-	}
-}
-
-// PoolSize sets the connection pool size
-func PoolSize(d int) Option {
-	return func(o *Options) {
-		o.PoolSize = d
-	}
-}
-
-// PoolSize sets the connection pool size
-func PoolTTL(d time.Duration) Option {
-	return func(o *Options) {
-		o.PoolTTL = d
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -94,8 +94,8 @@ func newOptions(options ...Option) Options {
 			DialTimeout:    transport.DefaultDialTimeout,
 		},
 		PoolOptions: PoolOptions{
-			PoolSize: DefaultPoolSize,
-			PoolTTL:  DefaultPoolTTL,
+			Size: DefaultPoolSize,
+			TTL:  DefaultPoolTTL,
 		},
 	}
 

--- a/client/options.go
+++ b/client/options.go
@@ -142,6 +142,20 @@ func Codec(contentType string, c codec.NewCodec) Option {
 	}
 }
 
+// PoolSize sets the connection pool size
+func PoolSize(d int) Option {
+	return func(o *Options) {
+		o.PoolOptions.Size = d
+	}
+}
+
+// PoolTTL sets the connection pool ttl
+func PoolTTL(d time.Duration) Option {
+	return func(o *Options) {
+		o.PoolOptions.TTL = d
+	}
+}
+
 // Default content type of the client
 func ContentType(ct string) Option {
 	return func(o *Options) {

--- a/client/options.go
+++ b/client/options.go
@@ -22,10 +22,6 @@ type Options struct {
 	Selector  selector.Selector
 	Transport transport.Transport
 
-	// Connection Pool
-	PoolSize int
-	PoolTTL  time.Duration
-
 	// Middleware for client
 	Wrappers []Wrapper
 

--- a/client/pool.go
+++ b/client/pool.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/micro/go-micro/transport"
+)
+
+// Pool is a connection pool.
+type Pool interface {
+	Conn(ctx context.Context, addr string) Conn
+	Release(ctx context.Context, addr string, conn Conn, err error)
+	Idle() int
+	Options() PoolOptions
+	Close() error
+}
+
+// Conn is a item in the client pool
+type Conn interface {
+	Created() time.Time
+	transport.Client
+}
+
+// PoolOptions are options for the client pool.
+type PoolOptions struct {
+	PoolSize int
+	PoolTTL  time.Duration
+}
+
+// PoolOption is a option for the client pool
+type PoolOption func(*PoolOptions)
+
+// WithPoolSize sets the connection pool size
+func WithPoolSize(d int) PoolOption {
+	return func(o *PoolOptions) {
+		o.PoolSize = d
+	}
+}
+
+// TTL sets the connection pool size
+func WithPoolTTL(d time.Duration) PoolOption {
+	return func(o *PoolOptions) {
+		o.PoolTTL = d
+	}
+}

--- a/client/pool.go
+++ b/client/pool.go
@@ -10,10 +10,10 @@ import (
 // Pool is a connection pool.
 type Pool interface {
 	Conn(ctx context.Context, addr string) Conn
-	Release(ctx context.Context, addr string, conn Conn, err error)
+	Close() error
 	Idle() int
 	Options() PoolOptions
-	Close() error
+	Release(ctx context.Context, addr string, conn Conn, err error)
 }
 
 // Conn is a item in the client pool

--- a/client/pool.go
+++ b/client/pool.go
@@ -24,23 +24,23 @@ type Conn interface {
 
 // PoolOptions are options for the client pool.
 type PoolOptions struct {
-	PoolSize int
-	PoolTTL  time.Duration
+	Size int
+	TTL  time.Duration
 }
 
 // PoolOption is a option for the client pool
 type PoolOption func(*PoolOptions)
 
-// WithPoolSize sets the connection pool size
-func WithPoolSize(d int) PoolOption {
+// WithSize sets the connection pool size
+func WithSize(d int) PoolOption {
 	return func(o *PoolOptions) {
-		o.PoolSize = d
+		o.Size = d
 	}
 }
 
-// TTL sets the connection pool size
-func WithPoolTTL(d time.Duration) PoolOption {
+// WithTTL sets the connection pool size
+func WithTTL(d time.Duration) PoolOption {
 	return func(o *PoolOptions) {
-		o.PoolTTL = d
+		o.TTL = d
 	}
 }

--- a/client/pool.go
+++ b/client/pool.go
@@ -9,8 +9,8 @@ import (
 
 // Pool is a connection pool.
 type Pool interface {
-	Conn(ctx context.Context, addr string) Conn
 	Close() error
+	Conn(ctx context.Context, addr string) Conn
 	Idle() int
 	Options() PoolOptions
 	Release(ctx context.Context, addr string, conn Conn, err error)

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -30,7 +30,7 @@ func newRpcClient(opt ...Option) Client {
 	rc := &rpcClient{
 		once: sync.Once{},
 		opts: opts,
-		pool: newPool(opts.PoolSize, opts.PoolTTL),
+		pool: newPool(opts.PoolOptions.Size, opts.PoolOptions.TTL),
 		seq:  0,
 	}
 
@@ -203,18 +203,18 @@ func (r *rpcClient) stream(ctx context.Context, address string, req Request, opt
 }
 
 func (r *rpcClient) Init(opts ...Option) error {
-	size := r.opts.PoolSize
-	ttl := r.opts.PoolTTL
+	size := r.opts.PoolOptions.Size
+	ttl := r.opts.PoolOptions.TTL
 
 	for _, o := range opts {
 		o(&r.opts)
 	}
 
 	// update pool configuration if the options changed
-	if size != r.opts.PoolSize || ttl != r.opts.PoolTTL {
+	if size != r.opts.PoolOptions.Size || ttl != r.opts.PoolOptions.TTL {
 		r.pool.Lock()
-		r.pool.size = r.opts.PoolSize
-		r.pool.ttl = int64(r.opts.PoolTTL.Seconds())
+		r.pool.size = r.opts.PoolOptions.Size
+		r.pool.ttl = int64(r.opts.PoolOptions.TTL.Seconds())
 		r.pool.Unlock()
 	}
 

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -138,7 +138,7 @@ func TestCallWrapper(t *testing.T) {
 		Name:    service,
 		Version: "latest",
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      id,
 				Address: host,
 				Port:    port,


### PR DESCRIPTION
Suggested interface for `PoolConnections `and `PoolConnection`

- Added `client/pool.go`
- Updated `client/options.go` to use `PoolOptions` for `PoolSize` and `PoolTTL`

Related go-plugin changes https://github.com/micro/go-plugins/pull/214