### PR TITLE
Allow new subscriptions after initial registration.

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -185,16 +185,14 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 	config := s.Options()
 
 	s.Lock()
+	defer s.Unlock()
 	_, ok = s.subscribers[sub]
 	if ok {
-		s.Unlock()
 		return fmt.Errorf("subscriber %v already exists", s)
 	}
 	s.subscribers[sub] = nil
-	defer s.Unlock()
 
-	registered := s.registered
-	if registered {
+	if s.registered {
 		handler := s.createSubHandler(sub, s.opts)
 		var opts []broker.SubscribeOption
 		if queue := sub.Options().Queue; len(queue) > 0 {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -182,13 +182,31 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 		return err
 	}
 
+	config := s.Options()
+
 	s.Lock()
-	defer s.Unlock()
 	_, ok = s.subscribers[sub]
 	if ok {
+		s.Unlock()
 		return fmt.Errorf("subscriber %v already exists", s)
 	}
 	s.subscribers[sub] = nil
+	defer s.Unlock()
+
+	registered := s.registered
+	if registered {
+		handler := s.createSubHandler(sub, s.opts)
+		var opts []broker.SubscribeOption
+		if queue := sub.Options().Queue; len(queue) > 0 {
+			opts = append(opts, broker.Queue(queue))
+		}
+		subs, err := config.Broker.Subscribe(sub.Topic(), handler, opts...)
+		if err != nil {
+			return err
+		}
+		s.subscribers[sub] = []broker.Subscriber{subs}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

Currently while subscriptions can be attempted after initial registration of the service without issue, the subscription never actually happens because of a check of the `registered` property.

The next call to `Register()` then publishes the subscription in the endpoints list to the registry, even though the subscription is not actually subscribed.

When the server exits, the endpoint is subsequently deregistered, so all this works as expected, apart from the fact that the application isn't actually receiving anything on the subscription because it's never created.

The following is a minimal test case that shows the issue:
https://gist.github.com/norganna/763ffe795602f37fdc6d16cf78378301

# Proposal

It seems that it would be simple to allow subscriptions after first registration by checking if registered and then simply adding the subscription.

At the next `RegisterInterval` the registration will be updated with the correct endpoints.

The MR as attached will create the subscription and add it to the `subscriptions` map.