### PR TITLE
add option to set http handlers

### DIFF
--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -1,9 +1,11 @@
+// Package http returns a http2 transport using net/http
 package http
 
 import (
 	"github.com/micro/go-micro/transport"
 )
 
+// NewTransport returns a new http transport using net/http and supporting http2
 func NewTransport(opts ...transport.Option) transport.Transport {
 	return transport.NewTransport(opts...)
 }

--- a/transport/http/options.go
+++ b/transport/http/options.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/micro/go-micro/transport"
+)
+
+// Handle registers the handler for the given pattern.
+func Handle(pattern string, handler http.Handler) transport.Option {
+	return func(o *transport.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		handlers, ok := o.Context.Value("http_handlers").(map[string]http.Handler)
+		if !ok {
+			handlers = make(map[string]http.Handler)
+		}
+		handlers[pattern] = handler
+		o.Context = context.WithValue(o.Context, "http_handlers", handlers)
+	}
+}


### PR DESCRIPTION
For https://github.com/micro/go-micro/issues/326

Example usage

```go
import (
    "github.com/micro/go-micro"
    "github.com/micro/go-micro/transport/http"
    "github.com/prometheus/client_golang/prometheus/promhttp"
)

func main() {
    t := http.NewTransport(
        http.Handle("/metrics", promhttp.Handler()),
    )

    service := micro.NewService(
        micro.Name("greeter"),
        micro.Transport(t),
    )
}
```