### PR TITLE
all: replace "pborman/uuid" with "google/uuid"

### DIFF
--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-log"
 	"github.com/micro/go-micro/broker/codec/json"
 	merr "github.com/micro/go-micro/errors"
@@ -26,7 +27,6 @@ import (
 	maddr "github.com/micro/util/go/lib/addr"
 	mnet "github.com/micro/util/go/lib/net"
 	mls "github.com/micro/util/go/lib/tls"
-	"github.com/pborman/uuid"
 )
 
 // HTTP Broker is a point to point async broker
@@ -116,7 +116,7 @@ func newHttpBroker(opts ...Option) Broker {
 	}
 
 	h := &httpBroker{
-		id:          "broker-" + uuid.NewUUID().String(),
+		id:          "broker-" + uuid.New().String(),
 		address:     addr,
 		opts:        options,
 		r:           reg,
@@ -413,7 +413,7 @@ func (h *httpBroker) Init(opts ...Option) error {
 	}
 
 	if len(h.id) == 0 {
-		h.id = "broker-" + uuid.NewUUID().String()
+		h.id = "broker-" + uuid.New().String()
 	}
 
 	// get registry
@@ -520,7 +520,7 @@ func (h *httpBroker) Subscribe(topic string, handler Handler, opts ...SubscribeO
 	}
 
 	// create unique id
-	id := h.id + "." + uuid.NewUUID().String()
+	id := h.id + "." + uuid.New().String()
 
 	var secure bool
 

--- a/broker/http_broker_test.go
+++ b/broker/http_broker_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-micro/registry/mock"
-	"github.com/pborman/uuid"
 )
 
 func sub(be *testing.B, c int) {
 	be.StopTimer()
 	m := mock.NewRegistry()
 	b := NewBroker(Registry(m))
-	topic := uuid.NewUUID().String()
+	topic := uuid.New().String()
 
 	if err := b.Init(); err != nil {
 		be.Fatalf("Unexpected init error: %v", err)
@@ -72,7 +72,7 @@ func pub(be *testing.B, c int) {
 	be.StopTimer()
 	m := mock.NewRegistry()
 	b := NewBroker(Registry(m))
-	topic := uuid.NewUUID().String()
+	topic := uuid.New().String()
 
 	if err := b.Init(); err != nil {
 		be.Fatalf("Unexpected init error: %v", err)

--- a/broker/mock/mock.go
+++ b/broker/mock/mock.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-micro/broker"
-	"github.com/pborman/uuid"
 )
 
 type mockBroker struct {
@@ -112,7 +112,7 @@ func (m *mockBroker) Subscribe(topic string, handler broker.Handler, opts ...bro
 
 	sub := &mockSubscriber{
 		exit:    make(chan bool, 1),
-		id:      uuid.NewUUID().String(),
+		id:      uuid.New().String(),
 		topic:   topic,
 		handler: handler,
 		opts:    options,

--- a/server/mock/mock.go
+++ b/server/mock/mock.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-micro/server"
-	"github.com/pborman/uuid"
 )
 
 type MockServer struct {
@@ -69,7 +69,7 @@ func (m *MockServer) NewHandler(h interface{}, opts ...server.HandlerOption) ser
 	}
 
 	return &MockHandler{
-		Id:   uuid.NewUUID().String(),
+		Id:   uuid.New().String(),
 		Hdlr: h,
 		Opts: options,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-log"
-	"github.com/pborman/uuid"
 )
 
 type Server interface {
@@ -63,7 +63,7 @@ var (
 	DefaultAddress        = ":0"
 	DefaultName           = "go-server"
 	DefaultVersion        = "1.0.0"
-	DefaultId             = uuid.NewUUID().String()
+	DefaultId             = uuid.New().String()
 	DefaultServer  Server = newRpcServer()
 )
 


### PR DESCRIPTION
Internally, "pborman/uuid.NewUUID()" is calling "google/uuid.New()"
that return nil when there is an error [1].

Both package use the same license.

[1] https://github.com/pborman/uuid/blob/master/version1.go#L17