### PR TITLE
Only check if the service is in Consul once every deregister interval

### DIFF
--- a/registry/consul_registry.go
+++ b/registry/consul_registry.go
@@ -24,6 +24,8 @@ type consulRegistry struct {
 
 	sync.Mutex
 	register map[string]uint64
+	// lastChecked tracks when a node was last checked as existing in Consul
+	lastChecked map[string]time.Time
 }
 
 func getDeregisterTTL(t time.Duration) time.Duration {
@@ -118,8 +120,9 @@ func configure(c *consulRegistry, opts ...Option) {
 
 func newConsulRegistry(opts ...Option) Registry {
 	cr := &consulRegistry{
-		opts:     Options{},
-		register: make(map[string]uint64),
+		opts:        Options{},
+		register:    make(map[string]uint64),
+		lastChecked: make(map[string]time.Time),
 	}
 	configure(cr, opts...)
 	return cr
@@ -135,9 +138,10 @@ func (c *consulRegistry) Deregister(s *Service) error {
 		return errors.New("Require at least one node")
 	}
 
-	// delete our hash of the service
+	// delete our hash and time check of the service
 	c.Lock()
 	delete(c.register, s.Name)
+	delete(c.lastChecked, s.Name)
 	c.Unlock()
 
 	node := s.Nodes[0]
@@ -181,7 +185,13 @@ func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
 	// if it's already registered and matches then just pass the check
 	if ok && v == h {
 		if options.TTL == time.Duration(0) {
-			services, _, err := c.Client.Health().Checks(s.Name, nil)
+			// ensure that our service hasn't been deregistered by Consul
+			if time.Since(c.lastChecked[s.Name]) <= getDeregisterTTL(regInterval) {
+				return nil
+			}
+			services, _, err := c.Client.Health().Checks(s.Name, &consul.QueryOptions{
+				AllowStale: true,
+			})
 			if err == nil {
 				for _, v := range services {
 					if v.ServiceID == node.Id {
@@ -245,9 +255,10 @@ func (c *consulRegistry) Register(s *Service, opts ...RegisterOption) error {
 		return err
 	}
 
-	// save our hash of the service
+	// save our hash and time check of the service
 	c.Lock()
 	c.register[s.Name] = h
+	c.lastChecked[s.Name] = time.Now()
 	c.Unlock()
 
 	// if the TTL is 0 we don't mess with the checks


### PR DESCRIPTION
Following on from https://github.com/micro/go-micro/pull/313

Making use of the TCPCheck option currently calls `c.Client.Health().Checks` more often than is required, putting unnecessary load on Consul. This change makes it only check if it has been at least `DeregisterTTL` since it last checked.

This is a combination of your original comment (just return nil) and needing to make sure that Consul hasn't deregistered the service due to failing health checks for greater than the `DeregisterTTL` duration

 I'd additionally like to know your thoughts on allowing (presumably via an option/ENV var)

```go
&consul.QueryOptions{
    AllowStale: true,
}
```

so that requests can (optionally) be serviced by non-leader Consul servers, effectively reducing load on the Consul leader (with the tradeoff being potentially out of date data based on the synchronisation time between Consul servers).