### PR TITLE
Add ability to specify Consul options

### DIFF
--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -27,6 +27,40 @@ func Config(c *consul.Config) registry.Option {
 	}
 }
 
+// AllowStale sets whether any Consul server (non-leader) can service
+// a read. This allows for lower latency and higher throughput
+// at the cost of potentially stale data.
+// Works similar to Consul DNS Config option [1].
+// Defaults to true.
+//
+// [1] https://www.consul.io/docs/agent/options.html#allow_stale
+//
+func AllowStale(v bool) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_allow_stale", v)
+	}
+}
+
+// QueryOptions specifies the QueryOptions to be used when calling
+// Consul. See `Consul API` for more information [1].
+//
+// [1] https://godoc.org/github.com/hashicorp/consul/api#QueryOptions
+//
+func QueryOptions(q *consul.QueryOptions) registry.Option {
+	return func(o *registry.Options) {
+		if q == nil {
+			return
+		}
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_query_options", q)
+	}
+}
+
 //
 // TCPCheck will tell the service provider to check the service address
 // and port every `t` interval. It will enabled only if `t` is greater than 0.

--- a/registry/consul_registry_test.go
+++ b/registry/consul_registry_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	consul "github.com/hashicorp/consul/api"
 )
@@ -53,9 +54,14 @@ func newConsulTestRegistry(r *mockRegistry) (*consulRegistry, func()) {
 	go newMockServer(r, l)
 
 	return &consulRegistry{
-			Address:  cfg.Address,
-			Client:   cl,
-			register: make(map[string]uint64),
+			Address:     cfg.Address,
+			Client:      cl,
+			opts:        Options{},
+			register:    make(map[string]uint64),
+			lastChecked: make(map[string]time.Time),
+			queryOptions: &consul.QueryOptions{
+				AllowStale: true,
+			},
 		}, func() {
 			l.Close()
 		}


### PR DESCRIPTION
Add two new Options to allow turning off `AllowStale` (defaults to on) and allows specifying the entire `QueryOptions` struct too for granular control.

```golang
reg := registry.NewRegistry(consulOptions.AllowStale(false))
```

```golang
reg := registry.NewRegistry(consulOptions.QueryOptions(&consul.QueryOptions{
    RequireConsistent: true,
}))
```

I've put together a [second branch](https://github.com/sneat/go-micro/blob/consul-options-test/registry/consul_registry_test.go#L208-L298) that I don't recommend merging to show a couple of tests. Unfortunately import cycles make standard tests difficult without a large refactor which I wasn't willing to do without your go-ahead.

Finally, would you consider a refactor to support non-string `context.WithValue` keys as per [https://godoc.org/context#WithValue](https://godoc.org/context#WithValue). As it stands currently with `consul_registry.go` being part of the `registry` package, converting them away from strings would create an import cycle unless the keys were part of a third package. What are your thoughts here?