### PR TITLE
client: add call option to set maximum received message size

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,9 @@ var (
 	DefaultPoolSize = 1
 	// DefaultPoolTTL sets the connection pool ttl
 	DefaultPoolTTL = time.Minute
+	// DefaultMaxRecvMsgSize maximum message that client can receive
+	// (4 MB).
+	DefaultMaxRecvMsgSize = 1024 * 1024 * 4
 )
 
 // Makes a synchronous call to a service using the default client

--- a/client/options.go
+++ b/client/options.go
@@ -52,6 +52,8 @@ type CallOptions struct {
 	Retries int
 	// Request/Response timeout
 	RequestTimeout time.Duration
+	// MaxRecvMsgSize the maximum message size the client can receive.
+	MaxRecvMsgSize int
 
 	// Middleware for low level call func
 	CallWrappers []CallWrapper
@@ -85,6 +87,7 @@ func newOptions(options ...Option) Options {
 		Codecs: make(map[string]codec.NewCodec),
 		CallOptions: CallOptions{
 			Backoff:        DefaultBackoff,
+			MaxRecvMsgSize: DefaultMaxRecvMsgSize,
 			Retry:          DefaultRetry,
 			Retries:        DefaultRetries,
 			RequestTimeout: DefaultRequestTimeout,
@@ -228,6 +231,14 @@ func RequestTimeout(d time.Duration) Option {
 func DialTimeout(d time.Duration) Option {
 	return func(o *Options) {
 		o.CallOptions.DialTimeout = d
+	}
+}
+
+// WithMaxRecvMsgSize is a CallOptions which overrides that which set in
+// Options.CallOptions.
+func WithMaxRecvMsgSize(s int) Option {
+	return func(o *Options) {
+		o.CallOptions.MaxRecvMsgSize = s
 	}
 }
 


### PR DESCRIPTION
The MaxRecvMsgSize is an option for gRPC call which allow client to
customize maximum message that their can receive.

The default maximum received is 4 MB.

This resolve #219.