### PR TITLE
Fix concurrent access to config metadata

### DIFF
--- a/options.go
+++ b/options.go
@@ -142,7 +142,13 @@ func Version(v string) Option {
 // Metadata associated with the service
 func Metadata(md map[string]string) Option {
 	return func(o *Options) {
-		o.Server.Init(server.Metadata(md))
+		newMd := make(map[string]string)
+
+		for k, v := range md {
+			newMd[k] = v
+		}
+
+		o.Server.Init(server.Metadata(newMd))
 	}
 }
 

--- a/server/options.go
+++ b/server/options.go
@@ -153,7 +153,11 @@ func DebugHandler(d debug.DebugHandler) Option {
 // Metadata associated with the server
 func Metadata(md map[string]string) Option {
 	return func(o *Options) {
-		o.Metadata = md
+		newMd := make(map[string]string)
+		for k, v := range md {
+			newMd[k] = v
+		}
+		o.Metadata = newMd
 	}
 }
 

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -220,12 +220,18 @@ func (s *rpcServer) Register() error {
 		return err
 	}
 
+	newMd := make(map[string]string)
+
+	for k, v := range config.Metadata {
+		newMd[k] = v
+	}
+
 	// register service
 	node := &registry.Node{
 		Id:       config.Name + "-" + config.Id,
 		Address:  addr,
 		Port:     port,
-		Metadata: config.Metadata,
+		Metadata: newMd,
 	}
 
 	node.Metadata["transport"] = config.Transport.String()


### PR DESCRIPTION
This adds in a patch Pete wrote which copies over the metadata maps to allow concurrent access.