### PR TITLE
Evolution of Codecs and Methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,9 @@ type Message interface {
 type Request interface {
 	// The service to call
 	Service() string
-	// The endpoint to call
+	// The action to take
+	Method() string
+	// The endpoint to invoke
 	Endpoint() string
 	// The content type
 	ContentType() string

--- a/client/rpc_codec.go
+++ b/client/rpc_codec.go
@@ -104,6 +104,7 @@ func (c *rpcCodec) Write(m *codec.Message, body interface{}) error {
 	// set the mucp headers
 	m.Header["X-Micro-Id"] = m.Id
 	m.Header["X-Micro-Service"] = m.Target
+	m.Header["X-Micro-Method"] = m.Method
 	m.Header["X-Micro-Endpoint"] = m.Endpoint
 
 	// if body is bytes Frame don't encode
@@ -154,6 +155,7 @@ func (c *rpcCodec) ReadHeader(wm *codec.Message, r codec.MessageType) error {
 	// read header
 	err := c.codec.ReadHeader(&me, r)
 	wm.Endpoint = me.Endpoint
+	wm.Method = me.Method
 	wm.Id = me.Id
 	wm.Error = me.Error
 
@@ -162,9 +164,14 @@ func (c *rpcCodec) ReadHeader(wm *codec.Message, r codec.MessageType) error {
 		wm.Error = me.Header["X-Micro-Error"]
 	}
 
-	// check method in header
+	// check endpoint in header
 	if len(me.Endpoint) == 0 {
 		wm.Endpoint = me.Header["X-Micro-Endpoint"]
+	}
+
+	// check method in header
+	if len(me.Method) == 0 {
+		wm.Method = me.Header["X-Micro-Method"]
 	}
 
 	if len(me.Id) == 0 {

--- a/client/rpc_request.go
+++ b/client/rpc_request.go
@@ -6,7 +6,7 @@ import (
 
 type rpcRequest struct {
 	service     string
-	method	string
+	method      string
 	endpoint    string
 	contentType string
 	codec       codec.Codec
@@ -28,7 +28,7 @@ func newRequest(service, endpoint string, request interface{}, contentType strin
 
 	return &rpcRequest{
 		service:     service,
-		method: endpoint,
+		method:      endpoint,
 		endpoint:    endpoint,
 		body:        request,
 		contentType: contentType,

--- a/client/rpc_request.go
+++ b/client/rpc_request.go
@@ -6,6 +6,7 @@ import (
 
 type rpcRequest struct {
 	service     string
+	method	string
 	endpoint    string
 	contentType string
 	codec       codec.Codec
@@ -27,6 +28,7 @@ func newRequest(service, endpoint string, request interface{}, contentType strin
 
 	return &rpcRequest{
 		service:     service,
+		method: endpoint,
 		endpoint:    endpoint,
 		body:        request,
 		contentType: contentType,
@@ -40,6 +42,10 @@ func (r *rpcRequest) ContentType() string {
 
 func (r *rpcRequest) Service() string {
 	return r.service
+}
+
+func (r *rpcRequest) Method() string {
+	return r.method
 }
 
 func (r *rpcRequest) Endpoint() string {

--- a/client/rpc_stream.go
+++ b/client/rpc_stream.go
@@ -53,6 +53,7 @@ func (r *rpcStream) Send(msg interface{}) error {
 	req := codec.Message{
 		Id:       r.id,
 		Target:   r.request.Service(),
+		Method: r.request.Method(),
 		Endpoint: r.request.Endpoint(),
 		Type:     codec.Request,
 	}

--- a/client/rpc_stream.go
+++ b/client/rpc_stream.go
@@ -53,7 +53,7 @@ func (r *rpcStream) Send(msg interface{}) error {
 	req := codec.Message{
 		Id:       r.id,
 		Target:   r.request.Service(),
-		Method: r.request.Method(),
+		Method:   r.request.Method(),
 		Endpoint: r.request.Endpoint(),
 		Type:     codec.Request,
 	}

--- a/client/wrapper.go
+++ b/client/wrapper.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"context"
+
+	"github.com/micro/go-micro/registry"
 )
 
 // CallFunc represents the individual call func
-type CallFunc func(ctx context.Context, address string, req Request, rsp interface{}, opts CallOptions) error
+type CallFunc func(ctx context.Context, node *registry.Node, req Request, rsp interface{}, opts CallOptions) error
 
 // CallWrapper is a low level wrapper for the CallFunc
 type CallWrapper func(CallFunc) CallFunc

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -53,6 +53,7 @@ type Message struct {
 	Id       string
 	Type     MessageType
 	Target   string
+	Method   string
 	Endpoint string
 	Error    string
 

--- a/codec/jsonrpc/client.go
+++ b/codec/jsonrpc/client.go
@@ -45,9 +45,9 @@ func newClientCodec(conn io.ReadWriteCloser) *clientCodec {
 
 func (c *clientCodec) Write(m *codec.Message, b interface{}) error {
 	c.Lock()
-	c.pending[m.Id] = m.Endpoint
+	c.pending[m.Id] = m.Method
 	c.Unlock()
-	c.req.Method = m.Endpoint
+	c.req.Method = m.Method
 	c.req.Params[0] = b
 	c.req.ID = m.Id
 	return c.enc.Encode(&c.req)
@@ -66,7 +66,7 @@ func (c *clientCodec) ReadHeader(m *codec.Message) error {
 	}
 
 	c.Lock()
-	m.Endpoint = c.pending[c.resp.ID]
+	m.Method = c.pending[c.resp.ID]
 	delete(c.pending, c.resp.ID)
 	c.Unlock()
 

--- a/codec/jsonrpc/server.go
+++ b/codec/jsonrpc/server.go
@@ -53,7 +53,7 @@ func (c *serverCodec) ReadHeader(m *codec.Message) error {
 	if err := c.dec.Decode(&c.req); err != nil {
 		return err
 	}
-	m.Endpoint = c.req.Method
+	m.Method = c.req.Method
 	m.Id = fmt.Sprintf("%v", c.req.ID)
 	c.req.ID = nil
 	return nil

--- a/codec/protorpc/protorpc.go
+++ b/codec/protorpc/protorpc.go
@@ -47,7 +47,7 @@ func (c *protoCodec) Write(m *codec.Message, b interface{}) error {
 		c.Lock()
 		defer c.Unlock()
 		// This is protobuf, of course we copy it.
-		pbr := &Request{ServiceMethod: &m.Endpoint, Seq: id(m.Id)}
+		pbr := &Request{ServiceMethod: &m.Method, Seq: id(m.Id)}
 		data, err := proto.Marshal(pbr)
 		if err != nil {
 			return err
@@ -73,7 +73,7 @@ func (c *protoCodec) Write(m *codec.Message, b interface{}) error {
 	case codec.Response, codec.Error:
 		c.Lock()
 		defer c.Unlock()
-		rtmp := &Response{ServiceMethod: &m.Endpoint, Seq: id(m.Id), Error: &m.Error}
+		rtmp := &Response{ServiceMethod: &m.Method, Seq: id(m.Id), Error: &m.Error}
 		data, err := proto.Marshal(rtmp)
 		if err != nil {
 			return err
@@ -126,7 +126,7 @@ func (c *protoCodec) ReadHeader(m *codec.Message, mt codec.MessageType) error {
 		if err != nil {
 			return err
 		}
-		m.Endpoint = rtmp.GetServiceMethod()
+		m.Method = rtmp.GetServiceMethod()
 		m.Id = fmt.Sprintf("%d", rtmp.GetSeq())
 	case codec.Response:
 		data, err := ReadNetString(c.rwc)
@@ -138,7 +138,7 @@ func (c *protoCodec) ReadHeader(m *codec.Message, mt codec.MessageType) error {
 		if err != nil {
 			return err
 		}
-		m.Endpoint = rtmp.GetServiceMethod()
+		m.Method = rtmp.GetServiceMethod()
 		m.Id = fmt.Sprintf("%d", rtmp.GetSeq())
 		m.Error = rtmp.GetError()
 	case codec.Publication:

--- a/server/rpc_codec.go
+++ b/server/rpc_codec.go
@@ -153,8 +153,14 @@ func (c *rpcCodec) ReadHeader(r *codec.Message, t codec.MessageType) error {
 	err := c.codec.ReadHeader(&m, codec.Request)
 
 	// set the method/id
+	r.Method = m.Method
 	r.Endpoint = m.Endpoint
 	r.Id = m.Id
+
+	// TODO: remove the old legacy cruft
+	if len(r.Endpoint) == 0 {
+		r.Endpoint = r.Method
+	}
 
 	return err
 }

--- a/server/rpc_request.go
+++ b/server/rpc_request.go
@@ -7,6 +7,7 @@ import (
 
 type rpcRequest struct {
 	service     string
+	method      string
 	endpoint    string
 	contentType string
 	socket      transport.Socket
@@ -32,6 +33,10 @@ func (r *rpcRequest) ContentType() string {
 
 func (r *rpcRequest) Service() string {
 	return r.service
+}
+
+func (r *rpcRequest) Method() string {
+	return r.method
 }
 
 func (r *rpcRequest) Endpoint() string {

--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -189,6 +189,7 @@ func (s *service) call(ctx context.Context, router *router, sending *sync.Mutex,
 	r := &rpcRequest{
 		service:     req.msg.Target,
 		contentType: req.msg.Header["Content-Type"],
+		method:      req.msg.Method,
 		endpoint:    req.msg.Endpoint,
 		body:        req.msg.Body,
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -283,6 +283,7 @@ func (s *rpcServer) Register() error {
 	node.Metadata["broker"] = config.Broker.String()
 	node.Metadata["server"] = s.String()
 	node.Metadata["registry"] = config.Registry.String()
+	node.Metadata["protocol"] = "mucp"
 
 	s.RLock()
 	// Maps are ordered randomly, sort the keys for consistency

--- a/server/rpc_stream.go
+++ b/server/rpc_stream.go
@@ -31,6 +31,8 @@ func (r *rpcStream) Send(msg interface{}) error {
 	defer r.Unlock()
 
 	resp := codec.Message{
+		Target:   r.request.Service(),
+		Method:   r.request.Method(),
 		Endpoint: r.request.Endpoint(),
 		Id:       r.id,
 		Type:     codec.Response,

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,8 @@ type Message interface {
 type Request interface {
 	// Service name requested
 	Service() string
+	// The action requested
+	Method() string
 	// Endpoint name requested
 	Endpoint() string
 	// Content type provided


### PR DESCRIPTION
We're moving to new encoding formats and some different internal abstractions. Due to high amounts of issues posed by the breaking changes, we're going to take an evolutionary approach. New micro apps will be able to gracefully handle the old protocol. 

The new protocol looks for message headers to determine the protocol. In the event these headers do not exist it assumes its using the old protocol. This works well on the server side. On the client side we have to inspect registry information to determine the protocol to use.