### PR TITLE
registry: [gossip] fix panic

### DIFF
--- a/registry/gossip/gossip.go
+++ b/registry/gossip/gossip.go
@@ -561,9 +561,11 @@ func (g *gossipRegistry) run() {
 				case <-ticker.C:
 					var addrs []string
 					g.RLock()
-					for node, action := range g.members {
-						if action == nodeActionLeave && g.member.LocalNode().Address() != node {
-							addrs = append(addrs, node)
+					if g.member != nil {
+						for node, action := range g.members {
+							if action == nodeActionLeave && g.member.LocalNode().Address() != node {
+								addrs = append(addrs, node)
+							}
 						}
 					}
 					g.RUnlock()


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0xd1b215]

goroutine 8 [running]:
sync.(*RWMutex).RLock(...)
        /var/home/vtolstov/sdk/go1.12beta2/src/sync/rwmutex.go:48
github.com/hashicorp/memberlist.(*Memberlist).LocalNode(0x0, 0x0)
        /home/vtolstov/devel/projects/centralv2/vendor/github.com/hashicorp/memberlist/memberlist.go:417 +0x35
github.com/micro/go-micro/registry/gossip.(*gossipRegistry).run.func3(0xc000155880)
        /home/vtolstov/devel/projects/centralv2/vendor/github.com/micro/go-micro/registry/gossip/gossip.go:565 +0xf5
created by github.com/micro/go-micro/registry/gossip.(*gossipRegistry).run
        /home/vtolstov/devel/projects/centralv2/vendor/github.com/micro/go-micro/registry/gossip/gossip.go:553 +0xa25

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>