### PR TITLE
solve consul.NewRegistry httpclient 'nil pointer dereference' bug

### DIFF
--- a/registry/consul/consul.go
+++ b/registry/consul/consul.go
@@ -105,12 +105,13 @@ func configure(c *consulRegistry, opts ...registry.Option) {
 		}
 	}
 
+	if config.HttpClient == nil {
+		config.HttpClient = new(http.Client)
+	}
+
 	// requires secure connection?
 	if c.opts.Secure || c.opts.TLSConfig != nil {
-		if config.HttpClient == nil {
-			config.HttpClient = new(http.Client)
-		}
-
+		
 		config.Scheme = "https"
 		// We're going to support InsecureSkipVerify
 		config.HttpClient.Transport = newTransport(c.opts.TLSConfig)


### PR DESCRIPTION
when use **consul.NewRegistry** like this:

```golang
micReg := consul.NewRegistry(registryOptions)
	micS := micro.NewService(
		micro.Name(config.GetAppName()),
		micro.Registry(micReg),
		micro.RegisterTTL(time.Second*30),
		micro.RegisterInterval(time.Second*10),
	)
	micS.Init()
```

There would be nil exception:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x14ff4c8]

goroutine 1 [running]:
github.com/micro/go-micro/registry/consul.configure(0xc00035a500, 0xc000187f18, 0x1, 0x1)
        ../src/github.com/micro/go-micro/registry/consul/consul.go:121 +0x128
github.com/micro/go-micro/registry/consul.NewRegistry(0xc000187f18, 0x1, 0x1, 0x1af9ec0, 0xc00019a000)
        ../src/github.com/micro/go-micro/registry/consul/consul.go:385 +0xc8
```

when set timeout of **config.HttpClient** and the **HttpClient** is null


