### PR TITLE
Update consul/watch import

### DIFF
--- a/registry/consul/watcher.go
+++ b/registry/consul/watcher.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/watch"
+	"github.com/hashicorp/consul/api/watch"
 	"github.com/micro/go-micro/registry"
 )
 


### PR DESCRIPTION
Per: https://github.com/hashicorp/consul/commit/6c885d383a7f303cc6c625108d3e7fc1a35d715d
`The watch package was moved from github.com/hashicorp/consul/watch to github.com/hashicorp/consul/api/watch to live in the API module.`
