### PR TITLE
Use existing consul client for watcher

### DIFF
--- a/registry/consul/watcher.go
+++ b/registry/consul/watcher.go
@@ -2,6 +2,8 @@ package consul
 
 import (
 	"errors"
+	"log"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/consul/api"
@@ -43,7 +45,7 @@ func newConsulWatcher(cr *consulRegistry, opts ...registry.WatchOption) (registr
 	}
 
 	wp.Handler = cw.handle
-	go wp.Run(cr.Address)
+	go wp.RunWithClientAndLogger(cr.Client, log.New(os.Stderr, "", log.LstdFlags))
 	cw.wp = wp
 
 	return cw, nil
@@ -208,7 +210,7 @@ func (cw *consulWatcher) handle(idx uint64, data interface{}) {
 		})
 		if err == nil {
 			wp.Handler = cw.serviceHandler
-			go wp.Run(cw.r.Address)
+			go wp.RunWithClientAndLogger(cw.r.Client, log.New(os.Stderr, "", log.LstdFlags))
 			cw.watchers[service] = wp
 			cw.next <- &registry.Result{Action: "create", Service: &registry.Service{Name: service}}
 		}


### PR DESCRIPTION
# Description

This change utilises the existing Consul Client for connecting the Watcher to Consul rather than creating a new Client during the `wp.Run()` call. The definition of the log entry is taken from the `.Run()`→ `.RunWithConfig()` → `.RunWithClientAndLogger()` flow that exists.

## Why does this matter

In our setup, we run Consul with multiple Datacenters to support multiple environments. We configure the micro Registry to connect to Consul specifying the Datacenter to use which correctly facilitates service discovery. Some of our services need to be able to access services in other environments which we do by maintaining a separate Client connection with the Datacenter specified to use within the service discovery. This all works well until a service deregisters, we never get the watch event firing (by design within Consul due to Datacenters).

## Solution

By making use of the `consul.Client` available on the `consulRegistry` we can piggyback on any configuration already applied to the Client, including Datacenter specifications.