### PR TITLE
`Wait()` option now accept *sync.WaitGroup

### DIFF
--- a/function.go
+++ b/function.go
@@ -54,7 +54,7 @@ func newFunction(opts ...Option) Function {
 
 	service.Server().Init(
 		// ensure the service waits for requests to finish
-		server.Wait(true),
+		server.Wait(nil),
 		// wrap handlers and subscribers to finish execution
 		server.WrapHandler(fnHandlerWrapper(fn)),
 		server.WrapSubscriber(fnSubWrapper(fn)),

--- a/server/context.go
+++ b/server/context.go
@@ -2,19 +2,20 @@ package server
 
 import (
 	"context"
+	"sync"
 )
 
 type serverKey struct{}
 
-func wait(ctx context.Context) bool {
+func wait(ctx context.Context) *sync.WaitGroup {
 	if ctx == nil {
-		return false
+		return nil
 	}
-	wait, ok := ctx.Value("wait").(bool)
+	wg, ok := ctx.Value("wait").(*sync.WaitGroup)
 	if !ok {
-		return false
+		return nil
 	}
-	return wait
+	return wg
 }
 
 func FromContext(ctx context.Context) (Server, bool) {

--- a/server/options.go
+++ b/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/micro/go-micro/broker"
@@ -198,12 +199,18 @@ func WithRouter(r Router) Option {
 }
 
 // Wait tells the server to wait for requests to finish before exiting
-func Wait(b bool) Option {
+// If `wg` is nil, server only wait for completion of rpc handler.
+// For user need finer grained control, pass a concrete `wg` here, server will
+// wait against it on stop.
+func Wait(wg *sync.WaitGroup) Option {
 	return func(o *Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, "wait", b)
+		if wg == nil {
+			wg = new(sync.WaitGroup)
+		}
+		o.Context = context.WithValue(o.Context, "wait", wg)
 	}
 }
 


### PR DESCRIPTION
The original signature accept a boolean, and it feel like a little
verbose, since when people pass in this option, he/she always want to
pass a `true`.

Now if input `wg` is nil, it has same effect as passing `true` in
original code. Furthermore, if user want's finer grained control during
shutdown, one can pass in a predefined `wg`, so that server will wait
against it during shutdown.

Hopefully, this pr and micro/go-plugins#339 should resolve #483 