### PR TITLE
remove mock data from memory registry

### DIFF
--- a/broker/common_test.go
+++ b/broker/common_test.go
@@ -1,0 +1,51 @@
+package broker
+
+import (
+	"github.com/micro/go-micro/registry"
+)
+
+var (
+	// mock data
+	testData = map[string][]*registry.Service{
+		"foo": []*registry.Service{
+			{
+				Name:    "foo",
+				Version: "1.0.0",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.0-123",
+						Address: "localhost",
+						Port:    9999,
+					},
+					{
+						Id:      "foo-1.0.0-321",
+						Address: "localhost",
+						Port:    9999,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.1",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.1-321",
+						Address: "localhost",
+						Port:    6666,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.3",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.3-345",
+						Address: "localhost",
+						Port:    8888,
+					},
+				},
+			},
+		},
+	}
+)

--- a/broker/http_broker_test.go
+++ b/broker/http_broker_test.go
@@ -14,7 +14,7 @@ import (
 func newTestRegistry() *memory.Registry {
 	r := memory.NewRegistry()
 	m := r.(*memory.Registry)
-	m.Setup()
+	m.Services = testData
 	return m
 }
 

--- a/client/common_test.go
+++ b/client/common_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"github.com/micro/go-micro/registry"
+)
+
+var (
+	// mock data
+	testData = map[string][]*registry.Service{
+		"foo": []*registry.Service{
+			{
+				Name:    "foo",
+				Version: "1.0.0",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.0-123",
+						Address: "localhost",
+						Port:    9999,
+					},
+					{
+						Id:      "foo-1.0.0-321",
+						Address: "localhost",
+						Port:    9999,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.1",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.1-321",
+						Address: "localhost",
+						Port:    6666,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.3",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.3-345",
+						Address: "localhost",
+						Port:    8888,
+					},
+				},
+			},
+		},
+	}
+)

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -13,8 +13,9 @@ import (
 
 func newTestRegistry() registry.Registry {
 	r := memory.NewRegistry()
-	r.(*memory.Registry).Setup()
-	return r
+	reg := r.(*memory.Registry)
+	reg.Services = testData
+	return reg
 }
 
 func TestCallAddress(t *testing.T) {

--- a/common_test.go
+++ b/common_test.go
@@ -1,4 +1,4 @@
-package memory
+package micro
 
 import (
 	"github.com/micro/go-micro/registry"
@@ -6,7 +6,7 @@ import (
 
 var (
 	// mock data
-	Data = map[string][]*registry.Service{
+	testData = map[string][]*registry.Service{
 		"foo": []*registry.Service{
 			{
 				Name:    "foo",

--- a/function_test.go
+++ b/function_test.go
@@ -14,7 +14,7 @@ func TestFunction(t *testing.T) {
 	wg.Add(1)
 
 	r := memory.NewRegistry()
-	r.(*memory.Registry).Setup()
+	r.(*memory.Registry).Services = testData
 
 	// create service
 	fn := NewFunction(

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -22,6 +22,7 @@ var (
 	timeout = time.Millisecond * 10
 )
 
+/*
 // Setup sets mock data
 func (m *Registry) Setup() {
 	m.Lock()
@@ -30,6 +31,7 @@ func (m *Registry) Setup() {
 	// add some memory data
 	m.Services = Data
 }
+*/
 
 func (m *Registry) watch(r *registry.Result) {
 	var watchers []*Watcher

--- a/selector/common_test.go
+++ b/selector/common_test.go
@@ -1,0 +1,51 @@
+package selector
+
+import (
+	"github.com/micro/go-micro/registry"
+)
+
+var (
+	// mock data
+	testData = map[string][]*registry.Service{
+		"foo": []*registry.Service{
+			{
+				Name:    "foo",
+				Version: "1.0.0",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.0-123",
+						Address: "localhost",
+						Port:    9999,
+					},
+					{
+						Id:      "foo-1.0.0-321",
+						Address: "localhost",
+						Port:    9999,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.1",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.1-321",
+						Address: "localhost",
+						Port:    6666,
+					},
+				},
+			},
+			{
+				Name:    "foo",
+				Version: "1.0.3",
+				Nodes: []*registry.Node{
+					{
+						Id:      "foo-1.0.3-345",
+						Address: "localhost",
+						Port:    8888,
+					},
+				},
+			},
+		},
+	}
+)

--- a/selector/default_test.go
+++ b/selector/default_test.go
@@ -10,7 +10,8 @@ func TestRegistrySelector(t *testing.T) {
 	counts := map[string]int{}
 
 	r := memory.NewRegistry()
-	r.(*memory.Registry).Setup()
+	rg := r.(*memory.Registry)
+	rg.Services = testData
 	cache := NewSelector(Registry(r))
 
 	next, err := cache.Select("foo")

--- a/service_test.go
+++ b/service_test.go
@@ -30,7 +30,7 @@ func testService(ctx context.Context, wg *sync.WaitGroup, name string) Service {
 	wg.Add(1)
 
 	r := memory.NewRegistry()
-	r.(*memory.Registry).Setup()
+	r.(*memory.Registry).Services = testData
 
 	// create service
 	return NewService(


### PR DESCRIPTION
memory registry can be used as fast inprocess registry,
so mock data needs to be in tests only

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>