### PR TITLE
fix wrong path of nats.go

### DIFF
--- a/broker/nats/nats.go
+++ b/broker/nats/nats.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/micro/go-micro/broker"
 	"github.com/micro/go-micro/codec/json"
-	nats "github.com/nats-io/nats.go"
+	nats "github.com/nats-io/go-nats"
 )
 
 type natsBroker struct {

--- a/broker/nats/options.go
+++ b/broker/nats/options.go
@@ -2,7 +2,7 @@ package nats
 
 import (
 	"github.com/micro/go-micro/broker"
-	nats "github.com/nats-io/nats.go"
+	nats "github.com/nats-io/go-nats"
 )
 
 type optionsKey struct{}


### PR DESCRIPTION
seems nats-io already mved it ago
err:

```
stat github.com/nats-io/nats.go: no such file or directory
```
