### PR TITLE
missing nil check for grpc WaitGroup

### DIFF
--- a/server/grpc/subscriber.go
+++ b/server/grpc/subscriber.go
@@ -231,9 +231,13 @@ func (g *grpcServer) createSubHandler(sb *subscriber, opts server.Options) broke
 				fn = opts.SubWrappers[i-1](fn)
 			}
 
-			g.wg.Add(1)
+			if g.wg != nil {
+				g.wg.Add(1)
+			}
 			go func() {
-				defer g.wg.Done()
+				if g.wg != nil {
+					defer g.wg.Done()
+				}
 				fn(ctx, &rpcMessage{
 					topic:       sb.topic,
 					contentType: ct,


### PR DESCRIPTION
grpc subscriber missing nil check in createSubHandler.

Nil check is added in [server/subscriber.go](https://github.com/micro/go-micro/blob/7a87ae0efa3e9bd634b19af7d165fa809e0968f2/server/subscriber.go#L247), but missing in [server/grpc/subscriber.go](https://github.com/micro/go-micro/blob/7a87ae0efa3e9bd634b19af7d165fa809e0968f2/server/grpc/subscriber.go#L234)