### PR TITLE
grpc message should be able to set

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -280,7 +280,7 @@ func (g *grpcClient) Options() client.Options {
 }
 
 func (g *grpcClient) NewMessage(topic string, msg interface{}, opts ...client.MessageOption) client.Message {
-	return newGRPCPublication(topic, msg, "application/octet-stream")
+	return newGRPCPublication(topic, msg, g.opts.ContentType, opts...)
 }
 
 func (g *grpcClient) NewRequest(service, method string, req interface{}, reqOpts ...client.RequestOption) client.Request {


### PR DESCRIPTION
The MessageOptions is unreachable, if I want to use micro.NewPublisher().Publish
Below is the source code of go-micro:
[publisher.go](https://github.com/micro/go-micro/blob/59eaa89bac017bee5d07192cbd5cf5a5c6940aac/publisher.go#L14)
```go
func (p *publisher) Publish(ctx context.Context, msg interface{}, opts ...client.PublishOption) error {
	return p.c.Publish(ctx, p.c.NewMessage(p.topic, msg), opts...)
}
````
[client/client.go](https://github.com/micro/go-micro/blob/59eaa89bac017bee5d07192cbd5cf5a5c6940aac/client/client.go#L127)
```go
// Creates a new message using the default client
func NewMessage(topic string, payload interface{}, opts ...MessageOption) Message {
	return DefaultClient.NewMessage(topic, payload, opts...)
}
```
This pull request can fixing the default content type can't change issue, but maybe the better way is to support MessageOptions instead of client opts.