### PR TITLE
Properly delete service nodes

### DIFF
--- a/registry/gossip/util.go
+++ b/registry/gossip/util.go
@@ -115,27 +115,20 @@ func delNodes(old, del []*registry.Node) []*registry.Node {
 
 func delServices(old, del []*registry.Service) []*registry.Service {
 	var services []*registry.Service
-
 	for _, o := range old {
-		srv := new(registry.Service)
-		*srv = *o
-
 		var rem bool
-
 		for _, s := range del {
-			if srv.Version == s.Version {
-				srv.Nodes = delNodes(srv.Nodes, s.Nodes)
-
-				if len(srv.Nodes) == 0 {
+			if o.Version == s.Version {
+				s.Nodes = delNodes(s.Nodes, o.Nodes)
+				if len(s.Nodes) == 0 {
 					rem = true
+					break
 				}
 			}
 		}
-
 		if !rem {
-			services = append(services, srv)
+			services = append(services, o)
 		}
 	}
-
 	return services
 }


### PR DESCRIPTION
When deleting the service we fail to properly delete its nodes when publishing the [delete event](https://github.com/micro/go-micro/blob/7266c62d098d0f927685c45768f97734d6d50db6/registry/gossip/gossip.go#L657).

It might not seem obvious why we failed to do so; let's break it down; in order to delete the service we call `delServices(service, []*registry.Service{u.Service})` which passes pointer to `u.Service` to `delService` function.

However, in the `delService` code we do some clone object kung-fu for some reason and then fail to actually override the nodes of `u.Service` which is passed in as a pointer as we override the *clone object*'s nodes [instead](https://github.com/micro/go-micro/blob/7266c62d098d0f927685c45768f97734d6d50db6/registry/gossip/util.go#L127).

We then happily send the unmodified `u.Service` in the publish event; unmodified in a sense of its `registry.Nodes` remain untouched. This PR addresses that.

This is a rather obscure case of bug where unit test pass fine in the original code for obvious reasons once you know those reasons.