### PR TITLE
`prefix` in consul api starts with no leading slash

### DIFF
--- a/config/source/consul/README.md
+++ b/config/source/consul/README.md
@@ -4,7 +4,7 @@ The consul source reads config from consul key/values
 
 ## Consul Format
 
-The consul source expects keys under the default prefix `/micro/config`
+The consul source expects keys under the default prefix `micro/config`
 
 Values are expected to be json
 
@@ -29,8 +29,8 @@ Specify source with data
 consulSource := consul.NewSource(
 	// optionally specify consul address; default to localhost:8500
 	consul.WithAddress("10.0.0.10:8500"),
-	// optionally specify prefix; defaults to /micro/config
-	consul.WithPrefix("/my/prefix"),
+	// optionally specify prefix; defaults to micro/config
+	consul.WithPrefix("my/prefix"),
   // optionally strip the provided prefix from the keys, defaults to false
   consul.StripPrefix(true),
 )

--- a/config/source/consul/consul.go
+++ b/config/source/consul/consul.go
@@ -21,7 +21,7 @@ type consul struct {
 var (
 	// DefaultPrefix is the prefix that consul keys will be assumed to have if you
 	// haven't specified one
-	DefaultPrefix = "/micro/config/"
+	DefaultPrefix = "micro/config/"
 )
 
 func (c *consul) Read() (*source.ChangeSet, error) {


### PR DESCRIPTION
When `consul.StripPrefix(true)` is set, current impl. will pass the
specified prefix (or default prefix) when calling consul api.

However, `prefix` in consul api starts with no leading slash, so
the default prefix (`/micro/config`) doesn't actually work.

I avoid code changes (esp. the one in `util.go`) to eliminate
impact on users who already notice it.