### PR TITLE
Add consul-specific option for config (as registry)

### DIFF
--- a/config/source/consul/consul.go
+++ b/config/source/consul/consul.go
@@ -74,6 +74,11 @@ func NewSource(opts ...source.Option) source.Source {
 	// use default config
 	config := api.DefaultConfig()
 
+	// use the consul config passed in the options if any
+	if co, ok := options.Context.Value(consulConfigKey{}).(*api.Config); ok {
+		config = co
+	}
+
 	// check if there are any addrs
 	a, ok := options.Context.Value(addressKey{}).(string)
 	if ok {

--- a/config/source/consul/consul.go
+++ b/config/source/consul/consul.go
@@ -75,7 +75,7 @@ func NewSource(opts ...source.Option) source.Source {
 	config := api.DefaultConfig()
 
 	// use the consul config passed in the options if any
-	if co, ok := options.Context.Value(consulConfigKey{}).(*api.Config); ok {
+	if co, ok := options.Context.Value(configKey{}).(*api.Config); ok {
 		config = co
 	}
 

--- a/config/source/consul/options.go
+++ b/config/source/consul/options.go
@@ -12,7 +12,7 @@ type prefixKey struct{}
 type stripPrefixKey struct{}
 type dcKey struct{}
 type tokenKey struct{}
-type consulConfigKey struct{}
+type configKey struct{}
 
 // WithAddress sets the consul address
 func WithAddress(a string) source.Option {
@@ -64,12 +64,12 @@ func WithToken(p string) source.Option {
 	}
 }
 
-// WithConsulConfig set consul-specific options
-func WithConsulConfig(c *api.Config) source.Option {
+// WithConfig set consul-specific options
+func WithConfig(c *api.Config) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, consulConfigKey{}, c)
+		o.Context = context.WithValue(o.Context, configKey{}, c)
 	}
 }

--- a/config/source/consul/options.go
+++ b/config/source/consul/options.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"context"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/micro/go-micro/config/source"
 )
 
@@ -11,6 +12,7 @@ type prefixKey struct{}
 type stripPrefixKey struct{}
 type dcKey struct{}
 type tokenKey struct{}
+type consulConfigKey struct{}
 
 // WithAddress sets the consul address
 func WithAddress(a string) source.Option {
@@ -59,5 +61,15 @@ func WithToken(p string) source.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, tokenKey{}, p)
+	}
+}
+
+// WithConsulConfig set consul-specific options
+func WithConsulConfig(c *api.Config) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, consulConfigKey{}, c)
 	}
 }


### PR DESCRIPTION
Consul default `http.Client` use `Timeout` as 0, which might cause hang issue if server outage occur, as indicated by [this blog](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779).

User should have the ability to do finer grained config when using consul as config backend.