### PR TITLE
grpc: using jsonpb.Marshaler to do Marshal, map to jsonpb.Unmarsh

### DIFF
--- a/client/grpc/codec.go
+++ b/client/grpc/codec.go
@@ -22,6 +22,8 @@ type protoCodec struct{}
 type bytesCodec struct{}
 type wrapCodec struct{ encoding.Codec }
 
+var jsonpbMarshaler = &jsonpb.Marshaler{}
+
 var (
 	defaultGRPCCodecs = map[string]encoding.Codec{
 		"application/json":         jsonCodec{},
@@ -113,6 +115,12 @@ func (bytesCodec) Name() string {
 }
 
 func (jsonCodec) Marshal(v interface{}) ([]byte, error) {
+	if pb, ok := v.(proto.Message); ok {
+		s, err := jsonpbMarshaler.MarshalToString(pb)
+
+		return []byte(s), err
+	}
+
 	return json.Marshal(v)
 }
 

--- a/server/grpc/codec.go
+++ b/server/grpc/codec.go
@@ -23,6 +23,8 @@ type bytesCodec struct{}
 type protoCodec struct{}
 type wrapCodec struct{ encoding.Codec }
 
+var jsonpbMarshaler = &jsonpb.Marshaler{}
+
 var (
 	defaultGRPCCodecs = map[string]encoding.Codec{
 		"application/json":         jsonCodec{},
@@ -78,6 +80,12 @@ func (protoCodec) Name() string {
 }
 
 func (jsonCodec) Marshal(v interface{}) ([]byte, error) {
+	if pb, ok := v.(proto.Message); ok {
+		s, err := jsonpbMarshaler.MarshalToString(pb)
+
+		return []byte(s), err
+	}
+
 	return json.Marshal(v)
 }
 


### PR DESCRIPTION
Correspond to grpc jsonCodec.Unmarshal, using jsonpb.Marshaler to do Marshal.