### PR TITLE
Added update action to handle update registry events. Table.Update inserts when no route found.

### DIFF
--- a/network/router/table/default.go
+++ b/network/router/table/default.go
@@ -106,17 +106,16 @@ func (t *table) Update(r Route) error {
 
 	// check if the route destination has any routes in the table
 	if _, ok := t.m[service]; !ok {
-		return ErrRouteNotFound
-	}
-
-	// if the route has been found update it
-	if _, ok := t.m[service][sum]; ok {
+		t.m[service] = make(map[uint64]Route)
 		t.m[service][sum] = r
-		go t.sendEvent(&Event{Type: Update, Timestamp: time.Now(), Route: r})
+		go t.sendEvent(&Event{Type: Create, Timestamp: time.Now(), Route: r})
 		return nil
 	}
 
-	return ErrRouteNotFound
+	t.m[service][sum] = r
+	go t.sendEvent(&Event{Type: Update, Timestamp: time.Now(), Route: r})
+
+	return nil
 }
 
 // List returns a list of all routes in the table

--- a/network/router/table/default_test.go
+++ b/network/router/table/default_test.go
@@ -94,12 +94,13 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("invalid number of routes. Expected: %d, found: %d", testTableSize, table.Size())
 	}
 
-	// this should error as the destination does not exist
+	// this should add a new route
 	route.Service = "rand.dest"
 
-	if err := table.Update(route); err != ErrRouteNotFound {
-		t.Errorf("error updating route. Expected error: %s, found: %s", ErrRouteNotFound, err)
+	if err := table.Update(route); err != nil {
+		t.Errorf("error updating route: %s", err)
 	}
+	testTableSize += 1
 
 	if table.Size() != testTableSize {
 		t.Errorf("invalid number of routes. Expected: %d, found: %d", testTableSize, table.Size())


### PR DESCRIPTION
This PR addresses the following:
* adds `update` action to `manageServiceRoutes` to handle `update` registry events
* `Table.Update` now adds a route if the the one being Updated does not exist
* cleanup code