### PR TITLE
`memoryStore.Read()` returns honor `Record.Expiry`

### DIFF
--- a/data/store/memory/memory.go
+++ b/data/store/memory/memory.go
@@ -36,6 +36,11 @@ func (m *memoryStore) Dump() ([]*store.Record, error) {
 		if d > time.Duration(0) && t > d {
 			continue
 		}
+
+		// update expiry
+		v.r.Expiry -= t
+		v.c = time.Now()
+
 		values = append(values, v.r)
 	}
 
@@ -59,6 +64,10 @@ func (m *memoryStore) Read(key string) (*store.Record, error) {
 	if d > time.Duration(0) && t > d {
 		return nil, store.ErrNotFound
 	}
+
+	// update expiry
+	v.r.Expiry -= t
+	v.c = time.Now()
 
 	return v.r, nil
 }

--- a/data/store/memory/memory.go
+++ b/data/store/memory/memory.go
@@ -38,8 +38,10 @@ func (m *memoryStore) Dump() ([]*store.Record, error) {
 		}
 
 		// update expiry
-		v.r.Expiry -= t
-		v.c = time.Now()
+		if d > time.Duration(0) {
+			v.r.Expiry -= t
+			v.c = time.Now()
+		}
 
 		values = append(values, v.r)
 	}
@@ -66,8 +68,10 @@ func (m *memoryStore) Read(key string) (*store.Record, error) {
 	}
 
 	// update expiry
-	v.r.Expiry -= t
-	v.c = time.Now()
+	if d > time.Duration(0) {
+		v.r.Expiry -= t
+		v.c = time.Now()
+	}
 
 	return v.r, nil
 }

--- a/data/store/memory/memory.go
+++ b/data/store/memory/memory.go
@@ -32,13 +32,12 @@ func (m *memoryStore) Dump() ([]*store.Record, error) {
 		d := v.r.Expiry
 		t := time.Since(v.c)
 
-		// expired
-		if d > time.Duration(0) && t > d {
-			continue
-		}
-
-		// update expiry
 		if d > time.Duration(0) {
+			// expired
+			if t > d {
+				continue
+			}
+			// update expiry
 			v.r.Expiry -= t
 			v.c = time.Now()
 		}
@@ -63,12 +62,11 @@ func (m *memoryStore) Read(key string) (*store.Record, error) {
 	t := time.Since(v.c)
 
 	// expired
-	if d > time.Duration(0) && t > d {
-		return nil, store.ErrNotFound
-	}
-
-	// update expiry
 	if d > time.Duration(0) {
+		if t > d {
+			return nil, store.ErrNotFound
+		}
+		// update expiry
 		v.r.Expiry -= t
 		v.c = time.Now()
 	}

--- a/data/store/memory/memory_test.go
+++ b/data/store/memory/memory_test.go
@@ -1,0 +1,37 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/micro/go-micro/data/store"
+)
+
+func TestReadRecordExpire(t *testing.T) {
+	s := NewStore()
+
+	var (
+		key    = "foo"
+		expire = 100 * time.Millisecond
+	)
+	rec := &store.Record{
+		Key:    key,
+		Value:  nil,
+		Expiry: expire,
+	}
+	s.Write(rec)
+
+	rrec, err := s.Read(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rrec.Expiry >= expire {
+		t.Fatal("expiry of read record is not changed")
+	}
+
+	time.Sleep(expire)
+
+	if _, err := s.Read(key); err != store.ErrNotFound {
+		t.Fatal("expire elapsed, but key still accessable")
+	}
+}


### PR DESCRIPTION
Current implementation of `memoryStore.Read()` will return an non-sense expiry. From user's perspective, one want's to know from the duration when the read key will expire since one calls `Read()` (something like call redis TTL) 