### PR TITLE
[WIP] router and mucp proxy integration

### DIFF
--- a/network/router/options.go
+++ b/network/router/options.go
@@ -19,9 +19,9 @@ type Options struct {
 	Id string
 	// Address is router address
 	Address string
-	// Gateway is micro network gateway
+	// Gateway is network gateway
 	Gateway string
-	// Network is micro network
+	// Network is network address
 	Network string
 	// Registry is the local registry
 	Registry registry.Registry
@@ -57,17 +57,17 @@ func Network(n string) Option {
 	}
 }
 
-// Table sets the routing table
-func Table(t table.Table) Option {
-	return func(o *Options) {
-		o.Table = t
-	}
-}
-
 // Registry sets the local registry
 func Registry(r registry.Registry) Option {
 	return func(o *Options) {
 		o.Registry = r
+	}
+}
+
+// Table sets the routing table
+func Table(t table.Table) Option {
+	return func(o *Options) {
+		o.Table = t
 	}
 }
 

--- a/network/router/router.go
+++ b/network/router/router.go
@@ -7,20 +7,9 @@ import (
 	"github.com/micro/go-micro/network/router/table"
 )
 
-const (
-	// Status codes
-	// Running means the router is up and running
-	Running StatusCode = iota
-	// Stopped means the router has been stopped
-	Stopped
-	// Error means the router has encountered error
-	Error
-
-	// Advert types
-	// Announce is advertised when the router announces itself
-	Announce AdvertType = iota
-	// Update advertises route updates
-	Update
+var (
+	// DefaultRouter is default network router
+	DefaultRouter = NewRouter()
 )
 
 // Router is an interface for a routing control plane
@@ -31,6 +20,8 @@ type Router interface {
 	Init(...Option) error
 	// Options returns the router options
 	Options() Options
+	// Run starts the router
+	Run() error
 	// Advertise advertises routes to the network
 	Advertise() (<-chan *Advert, error)
 	// Process processes incoming adverts
@@ -46,8 +37,37 @@ type Router interface {
 // Option used by the router
 type Option func(*Options)
 
+// StatusCode defines router status
+type StatusCode int
+
+const (
+	// Running means the router is up and running
+	Running StatusCode = iota
+	// Advertising means the router is advertising
+	Advertising
+	// Stopped means the router has been stopped
+	Stopped
+	// Error means the router has encountered error
+	Error
+)
+
+// Status is router status
+type Status struct {
+	// Error is router error
+	Error error
+	// Code defines router status
+	Code StatusCode
+}
+
 // AdvertType is route advertisement type
 type AdvertType int
+
+const (
+	// Announce is advertised when the router announces itself
+	Announce AdvertType = iota
+	// Update advertises route updates
+	Update
+)
 
 // Advert contains a list of events advertised by the router to the network
 type Advert struct {
@@ -62,22 +82,6 @@ type Advert struct {
 	// Events is a list of routing table events to advertise
 	Events []*table.Event
 }
-
-// StatusCode defines router status
-type StatusCode int
-
-// Status is router status
-type Status struct {
-	// Error is router error
-	Error error
-	// Code defines router status
-	Code StatusCode
-}
-
-var (
-	// DefaultRouter is default network router
-	DefaultRouter = NewRouter()
-)
 
 // NewRouter creates new Router and returns it
 func NewRouter(opts ...Option) Router {

--- a/network/router/router.go
+++ b/network/router/router.go
@@ -20,8 +20,6 @@ type Router interface {
 	Init(...Option) error
 	// Options returns the router options
 	Options() Options
-	// Run starts the router
-	Run() error
 	// Advertise advertises routes to the network
 	Advertise() (<-chan *Advert, error)
 	// Process processes incoming adverts


### PR DESCRIPTION
**DO NOT MERGE YET: THIS IS WIP aka POC**

This PR shows a prototype implementation of `router` and `mucp.Proxy` integration.

It adds the following changes to `router` package:
* it refactors `Advertise()` function which now does **only** what it claims to do: **advertising**
* various `router` packages functions/methods have been renamed to make their functionality more obvious and more in line with what they actually do
* function documentation changes related to the above bullet points

It adds the following changes to `mucp.Proxy` package:
* it initializes the internal state of the proxy when creating it
* it does the absolute minimum necessary when looking up the routes in `getRoute()`
* it adds un-exported `watchRoutes()` method which watches routes in remote router
* it reimplements the proxy cache using a similar approach the in-memory implementation of the default routing table uses