### PR TITLE
Small router refactoring

### DIFF
--- a/network/router/default.go
+++ b/network/router/default.go
@@ -113,7 +113,7 @@ func (r *router) manageRoute(route table.Route, action string) error {
 	return nil
 }
 
-// manageServiceRoutes applies action on all routes of given service.
+// manageServiceRoutes applies action to all routes of the service.
 // It returns error of the action fails with error.
 func (r *router) manageServiceRoutes(service *registry.Service, action string) error {
 	// action is the routing table action
@@ -138,7 +138,7 @@ func (r *router) manageServiceRoutes(service *registry.Service, action string) e
 	return nil
 }
 
-// manageRegistryRoutes applies action on all routes of each service found in the registry.
+// manageRegistryRoutes applies action to all routes of each service found in the registry.
 // It returns error if either the services failed to be listed or the routing table action fails.
 func (r *router) manageRegistryRoutes(reg registry.Registry, action string) error {
 	services, err := reg.ListServices()

--- a/network/router/options.go
+++ b/network/router/options.go
@@ -19,9 +19,9 @@ type Options struct {
 	Id string
 	// Address is router address
 	Address string
-	// Gateway is micro network gateway
+	// Gateway is network gateway
 	Gateway string
-	// Network is micro network
+	// Network is network address
 	Network string
 	// Registry is the local registry
 	Registry registry.Registry
@@ -57,17 +57,17 @@ func Network(n string) Option {
 	}
 }
 
-// Table sets the routing table
-func Table(t table.Table) Option {
-	return func(o *Options) {
-		o.Table = t
-	}
-}
-
 // Registry sets the local registry
 func Registry(r registry.Registry) Option {
 	return func(o *Options) {
 		o.Registry = r
+	}
+}
+
+// Table sets the routing table
+func Table(t table.Table) Option {
+	return func(o *Options) {
+		o.Table = t
 	}
 }
 

--- a/network/router/router.go
+++ b/network/router/router.go
@@ -7,20 +7,9 @@ import (
 	"github.com/micro/go-micro/network/router/table"
 )
 
-const (
-	// Status codes
-	// Running means the router is up and running
-	Running StatusCode = iota
-	// Stopped means the router has been stopped
-	Stopped
-	// Error means the router has encountered error
-	Error
-
-	// Advert types
-	// Announce is advertised when the router announces itself
-	Announce AdvertType = iota
-	// Update advertises route updates
-	Update
+var (
+	// DefaultRouter is default network router
+	DefaultRouter = NewRouter()
 )
 
 // Router is an interface for a routing control plane
@@ -46,8 +35,37 @@ type Router interface {
 // Option used by the router
 type Option func(*Options)
 
+// StatusCode defines router status
+type StatusCode int
+
+const (
+	// Running means the router is up and running
+	Running StatusCode = iota
+	// Advertising means the router is advertising
+	Advertising
+	// Stopped means the router has been stopped
+	Stopped
+	// Error means the router has encountered error
+	Error
+)
+
+// Status is router status
+type Status struct {
+	// Error is router error
+	Error error
+	// Code defines router status
+	Code StatusCode
+}
+
 // AdvertType is route advertisement type
 type AdvertType int
+
+const (
+	// Announce is advertised when the router announces itself
+	Announce AdvertType = iota
+	// Update advertises route updates
+	Update
+)
 
 // Advert contains a list of events advertised by the router to the network
 type Advert struct {
@@ -62,22 +80,6 @@ type Advert struct {
 	// Events is a list of routing table events to advertise
 	Events []*table.Event
 }
-
-// StatusCode defines router status
-type StatusCode int
-
-// Status is router status
-type Status struct {
-	// Error is router error
-	Error error
-	// Code defines router status
-	Code StatusCode
-}
-
-var (
-	// DefaultRouter is default network router
-	DefaultRouter = NewRouter()
-)
 
 // NewRouter creates new Router and returns it
 func NewRouter(opts ...Option) Router {


### PR DESCRIPTION
This commit adds the following changes to router package:
* it refactors `Advertise()` method which now does only what it claims to do: advertising
* various router packages functions/methods have been renamed to communicate their functionality more obvious
* various function documentation changes related to the above bullet points