### PR TITLE
Fix read yaml config from memory

### DIFF
--- a/config/source/memory/memory.go
+++ b/config/source/memory/memory.go
@@ -18,6 +18,7 @@ type memory struct {
 func (s *memory) Read() (*source.ChangeSet, error) {
 	s.RLock()
 	cs := &source.ChangeSet{
+		Format:    s.ChangeSet.Format,
 		Timestamp: s.ChangeSet.Timestamp,
 		Data:      s.ChangeSet.Data,
 		Checksum:  s.ChangeSet.Checksum,


### PR DESCRIPTION
test case:
``` go
package main

import (
	"fmt"

	"github.com/micro/go-micro/config"
	"github.com/micro/go-micro/config/source/memory"
)

var configData = []byte(`
---
a: 1234
`)

func main() {
	memorySource := memory.NewSource(
		memory.WithYAML(configData),
	)
	// Create new config
	conf := config.NewConfig()

	// Load file source
	conf.Load(memorySource)

	fmt.Println(string(conf.Bytes()))
}
```