### PR TITLE
fix registry addr error for mq-rpc

### DIFF
--- a/registry/consul/consul.go
+++ b/registry/consul/consul.go
@@ -13,6 +13,7 @@ import (
 
 	consul "github.com/hashicorp/consul/api"
 	"github.com/micro/go-micro/registry"
+	mnet "github.com/micro/go-micro/util/net"
 	hash "github.com/mitchellh/hashstructure"
 )
 
@@ -250,6 +251,9 @@ func (c *consulRegistry) Register(s *registry.Service, opts ...registry.Register
 	}
 
 	host, pt, _ := net.SplitHostPort(node.Address)
+	if host == "" {
+		host = node.Address
+	}
 	port, _ := strconv.Atoi(pt)
 
 	// register the service
@@ -351,7 +355,7 @@ func (c *consulRegistry) GetService(name string) ([]*registry.Service, error) {
 
 		svc.Nodes = append(svc.Nodes, &registry.Node{
 			Id:       id,
-			Address:  fmt.Sprintf("%s:%d", address, s.Service.Port),
+			Address:  mnet.HostPort(address, s.Service.Port),
 			Metadata: decodeMetadata(s.Service.Tags),
 		})
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -316,10 +316,15 @@ func (s *rpcServer) Register() error {
 		md[k] = v
 	}
 
+	// mq-rpc(eg. nats) doesn't need the port. its addr is queue name.
+	if port != "" {
+		addr = mnet.HostPort(addr, port)
+	}
+
 	// register service
 	node := &registry.Node{
 		Id:       config.Name + "-" + config.Id,
-		Address:  mnet.HostPort(addr, port),
+		Address:  addr,
 		Metadata: md,
 	}
 

--- a/util/net/net.go
+++ b/util/net/net.go
@@ -14,12 +14,13 @@ func HostPort(addr string, port interface{}) string {
 	if strings.Count(addr, ":") > 0 {
 		host = fmt.Sprintf("[%s]", addr)
 	}
-	// TODO check for NATS case
-	if v, ok := port.(string); ok {
-		if v == "" {
-			return fmt.Sprintf("%s", host)
-		}
+	// when port is blank or 0, host is a queue name
+	if v, ok := port.(string); ok && v == "" {
+		return host
+	} else if v, ok := port.(int); ok && v == 0 && net.ParseIP(host) == nil {
+		return host
 	}
+
 	return fmt.Sprintf("%s:%v", host, port)
 }
 


### PR DESCRIPTION
related [PR664](https://github.com/micro/go-micro/pull/664)

When using the RabbitMQ-Transport and Consul registry:

The address of the node will be registered as '127.0.0.1:0', which should be a queue name.
"rabbitmq case" means that "addr" is a queue name and port is an int "0", so it can't be drop in the "if" of Nats case.