### PR TITLE
fix file watcher event bug on Linux

### DIFF
--- a/config/default_test.go
+++ b/config/default_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,8 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/micro/go-micro/config/source/env"
 	"github.com/micro/go-micro/config/source/file"
+)
+
+var (
+	sep = string(os.PathSeparator)
 )
 
 func createFileForIssue18(t *testing.T, content string) *os.File {
@@ -114,5 +120,59 @@ func TestConfigMerge(t *testing.T) {
 		t.Fatalf("Expected %v but got %v",
 			"rabbit.testing.com",
 			actualHost)
+	}
+}
+
+func TestFileChange(t *testing.T) {
+	// create a temp file
+	fileName := uuid.New().String() + "testWatcher.json"
+	f, err := os.OpenFile("."+sep+fileName, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Error(err)
+	}
+	defer f.Close()
+	defer os.Remove("." + sep + fileName)
+
+	// load the file
+	if err := Load(file.NewSource(
+		file.WithPath("." + sep + fileName),
+	)); err != nil {
+		t.Error(err)
+	}
+
+	// watch changes
+	watcher, err := Watch()
+	if err != nil {
+		t.Error(err)
+	}
+	changeTimes := 0
+	go func() {
+		for {
+			v, err := watcher.Next()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			changeTimes++
+			t.Logf("file change，%s", string(v.Bytes()))
+		}
+	}()
+
+	content := map[int]string{}
+	// change the file
+	for i := 0; i < 5; i++ {
+		content[i] = time.Now().String()
+		bytes, _ := json.Marshal(content)
+		f.Truncate(0)
+		f.Seek(0, 0)
+		if _, err := f.Write(bytes); err != nil {
+			t.Error(err)
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	if changeTimes != 4 {
+		t.Error(fmt.Errorf("watcher error: change times %d is not enough", changeTimes))
 	}
 }

--- a/config/source/file/watcher_linux.go
+++ b/config/source/file/watcher_linux.go
@@ -1,4 +1,4 @@
-//+build !linux
+//+build linux
 
 package file
 
@@ -55,6 +55,10 @@ func (w *watcher) Next() (*source.ChangeSet, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// add path again for the event bug of fsnotify
+		w.fw.Add(w.f.path)
+
 		return c, nil
 	case err := <-w.fw.Errors:
 		return nil, err


### PR DESCRIPTION
On Linux(ubuntu, centos), the file watcher can only get the file change event twice.

can be tested with this [example](https://github.com/micro/examples/tree/master/config/grpc)