### PR TITLE
Check last for the address binded in lo interface (LVS , DR mode)

### DIFF
--- a/util/addr/addr.go
+++ b/util/addr/addr.go
@@ -40,6 +40,7 @@ func Extract(addr string) (string, error) {
 	}
 
 	var addrs []net.Addr
+	var loAddrs []net.Addr
 	for _, iface := range ifaces {
 		ifaceAddrs, err := iface.Addrs()
 		if err != nil {
@@ -47,10 +48,12 @@ func Extract(addr string) (string, error) {
 			continue
 		}
 		if iface.Flags&net.FlagLoopback != 0 {
+			loAddrs = append(loAddrs, ifaceAddrs...)
 			continue
 		}
 		addrs = append(addrs, ifaceAddrs...)
 	}
+	addrs = append(addrs, loAddrs...)
 
 	var ipAddr []byte
 	var publicIP []byte

--- a/util/addr/addr.go
+++ b/util/addr/addr.go
@@ -46,6 +46,9 @@ func Extract(addr string) (string, error) {
 			// ignore error, interface can dissapear from system
 			continue
 		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
 		addrs = append(addrs, ifaceAddrs...)
 	}
 


### PR DESCRIPTION
ignore Loopback Address
In LVS,DR mode, we need to bind the vip in iface "lo";
but i should not be registed.

consul:
https://github.com/hashicorp/consul/blob/master/ipaddr/detect.go
