### PR TITLE
Adds network id. Skips processing routes when router is the origin.

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -34,8 +34,8 @@ type network struct {
 	proxy.Proxy
 	// tun is network tunnel
 	tunnel.Tunnel
-	// srv is network server
-	srv server.Server
+	// server is network server
+	server server.Server
 	// client is network client
 	client client.Client
 
@@ -59,13 +59,19 @@ func newNetwork(opts ...Option) Network {
 		tunnel.Address(options.Address),
 	)
 
+	// init router Id to the network id
+	options.Router.Init(
+		router.Id(options.Id),
+	)
+
 	// create tunnel client with tunnel transport
 	tunTransport := trn.NewTransport(
 		trn.WithTunnel(options.Tunnel),
 	)
 
-	// srv is network server
-	srv := server.NewServer(
+	// server is network server
+	server := server.NewServer(
+		server.Id(options.Id),
 		server.Address(options.Address),
 		server.Name(options.Name),
 		server.Transport(tunTransport),
@@ -86,7 +92,7 @@ func newNetwork(opts ...Option) Network {
 		Router:  options.Router,
 		Proxy:   options.Proxy,
 		Tunnel:  options.Tunnel,
-		srv:     srv,
+		server:  server,
 		client:  client,
 	}
 }
@@ -333,7 +339,7 @@ func (n *network) Connect() error {
 	go n.process(listener)
 
 	// start the server
-	if err := n.srv.Start(); err != nil {
+	if err := n.server.Start(); err != nil {
 		return err
 	}
 
@@ -345,7 +351,7 @@ func (n *network) Connect() error {
 
 func (n *network) close() error {
 	// stop the server
-	if err := n.srv.Stop(); err != nil {
+	if err := n.server.Stop(); err != nil {
 		return err
 	}
 
@@ -390,5 +396,5 @@ func (n *network) Client() client.Client {
 
 // Server returns network server
 func (n *network) Server() server.Server {
-	return n.srv
+	return n.server
 }

--- a/network/options.go
+++ b/network/options.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/google/uuid"
 	"github.com/micro/go-micro/network/resolver"
 	"github.com/micro/go-micro/network/resolver/registry"
 	"github.com/micro/go-micro/proxy"
@@ -13,6 +14,8 @@ type Option func(*Options)
 
 // Options configure network
 type Options struct {
+	// Id of the node
+	Id string
 	// Name of the network
 	Name string
 	// Address to bind to
@@ -27,14 +30,21 @@ type Options struct {
 	Resolver resolver.Resolver
 }
 
-// Name is the network name
+// Id sets the id of the network node
+func Id(id string) Option {
+	return func(o *Options) {
+		o.Id = id
+	}
+}
+
+// Name sets the network name
 func Name(n string) Option {
 	return func(o *Options) {
 		o.Name = n
 	}
 }
 
-// Address is the network address
+// Address sets the network address
 func Address(a string) Option {
 	return func(o *Options) {
 		o.Address = a
@@ -72,6 +82,7 @@ func Resolver(r resolver.Resolver) Option {
 // DefaultOptions returns network default options
 func DefaultOptions() Options {
 	return Options{
+		Id:       uuid.New().String(),
 		Name:     DefaultName,
 		Address:  DefaultAddress,
 		Tunnel:   tunnel.NewTunnel(),

--- a/router/query.go
+++ b/router/query.go
@@ -11,26 +11,35 @@ type QueryOptions struct {
 	Gateway string
 	// Network is network address
 	Network string
+	// Router is router id
+	Router string
 }
 
-// QueryService sets destination address
+// QueryService sets service to query
 func QueryService(s string) QueryOption {
 	return func(o *QueryOptions) {
 		o.Service = s
 	}
 }
 
-// QueryGateway sets route gateway
+// QueryGateway sets gateway address to query
 func QueryGateway(g string) QueryOption {
 	return func(o *QueryOptions) {
 		o.Gateway = g
 	}
 }
 
-// QueryNetwork sets route network address
+// QueryNetwork sets network name to query
 func QueryNetwork(n string) QueryOption {
 	return func(o *QueryOptions) {
 		o.Network = n
+	}
+}
+
+// QueryRouter sets router id to query
+func QueryRouter(r string) QueryOption {
+	return func(o *QueryOptions) {
+		o.Router = r
 	}
 }
 
@@ -52,6 +61,7 @@ func NewQuery(opts ...QueryOption) Query {
 		Service: "*",
 		Gateway: "*",
 		Network: "*",
+		Router:  "*",
 	}
 
 	for _, o := range opts {
@@ -66,9 +76,4 @@ func NewQuery(opts ...QueryOption) Query {
 // Options returns query options
 func (q *query) Options() QueryOptions {
 	return q.opts
-}
-
-// String prints routing table query in human readable form
-func (q query) String() string {
-	return "query"
 }

--- a/router/route.go
+++ b/router/route.go
@@ -7,9 +7,9 @@ import (
 var (
 	// DefaultLink is default network link
 	DefaultLink = "local"
-	// DefaultLocalMetric is default route cost metric for the local network
+	// DefaultLocalMetric is default route cost for a local route
 	DefaultLocalMetric = 1
-	// DefaultNetworkMetric is default route cost metric for the micro network
+	// DefaultNetworkMetric is default route cost for a network route
 	DefaultNetworkMetric = 10
 )
 
@@ -23,6 +23,8 @@ type Route struct {
 	Gateway string
 	// Network is network address
 	Network string
+	// Router is router id
+	Router string
 	// Link is network link
 	Link string
 	// Metric is the route cost metric
@@ -33,6 +35,6 @@ type Route struct {
 func (r *Route) Hash() uint64 {
 	h := fnv.New64()
 	h.Reset()
-	h.Write([]byte(r.Service + r.Address + r.Gateway + r.Network + r.Link))
+	h.Write([]byte(r.Service + r.Address + r.Gateway + r.Network + r.Router + r.Link))
 	return h.Sum64()
 }

--- a/router/table.go
+++ b/router/table.go
@@ -8,7 +8,14 @@ import (
 	"github.com/google/uuid"
 )
 
-// table is an in memory routing table
+var (
+	// ErrRouteNotFound is returned when no route was found in the routing table
+	ErrRouteNotFound = errors.New("route not found")
+	// ErrDuplicateRoute is returned when the route already exists
+	ErrDuplicateRoute = errors.New("duplicate route")
+)
+
+// table is an in-memory routing table
 type table struct {
 	sync.RWMutex
 	// routes stores service routes
@@ -22,6 +29,19 @@ func newTable(opts ...Option) *table {
 	return &table{
 		routes:   make(map[string]map[uint64]Route),
 		watchers: make(map[string]*tableWatcher),
+	}
+}
+
+// sendEvent sends events to all subscribed watchers
+func (t *table) sendEvent(e *Event) {
+	t.RLock()
+	defer t.RUnlock()
+
+	for _, w := range t.watchers {
+		select {
+		case w.resChan <- e:
+		case <-w.done:
+		}
 	}
 }
 
@@ -106,21 +126,23 @@ func (t *table) List() ([]Route, error) {
 	return routes, nil
 }
 
-// isMatch checks if the route matches given network and router
-func isMatch(route Route, network, router string) bool {
-	if network == "*" || network == route.Network {
-		if router == "*" || router == route.Gateway {
-			return true
+// isMatch checks if the route matches given query options
+func isMatch(route Route, gateway, network, router string) bool {
+	if gateway == "*" || gateway == route.Gateway {
+		if network == "*" || network == route.Network {
+			if router == "*" || router == route.Router {
+				return true
+			}
 		}
 	}
 	return false
 }
 
 // findRoutes finds all the routes for given network and router and returns them
-func findRoutes(routes map[uint64]Route, network, router string) []Route {
+func findRoutes(routes map[uint64]Route, gateway, network, router string) []Route {
 	var results []Route
 	for _, route := range routes {
-		if isMatch(route, network, router) {
+		if isMatch(route, gateway, network, router) {
 			results = append(results, route)
 		}
 	}
@@ -136,13 +158,13 @@ func (t *table) Query(q Query) ([]Route, error) {
 		if _, ok := t.routes[q.Options().Service]; !ok {
 			return nil, ErrRouteNotFound
 		}
-		return findRoutes(t.routes[q.Options().Service], q.Options().Network, q.Options().Gateway), nil
+		return findRoutes(t.routes[q.Options().Service], q.Options().Gateway, q.Options().Network, q.Options().Router), nil
 	}
 
 	var results []Route
 	// search through all destinations
 	for _, routes := range t.routes {
-		results = append(results, findRoutes(routes, q.Options().Network, q.Options().Gateway)...)
+		results = append(results, findRoutes(routes, q.Options().Gateway, q.Options().Network, q.Options().Router)...)
 	}
 
 	return results, nil
@@ -181,23 +203,3 @@ func (t *table) Watch(opts ...WatchOption) (Watcher, error) {
 
 	return w, nil
 }
-
-// sendEvent sends events to all subscribed watchers
-func (t *table) sendEvent(e *Event) {
-	t.RLock()
-	defer t.RUnlock()
-
-	for _, w := range t.watchers {
-		select {
-		case w.resChan <- e:
-		case <-w.done:
-		}
-	}
-}
-
-var (
-	// ErrRouteNotFound is returned when no route was found in the routing table
-	ErrRouteNotFound = errors.New("route not found")
-	// ErrDuplicateRoute is returned when the route already exists
-	ErrDuplicateRoute = errors.New("duplicate route")
-)

--- a/router/watcher.go
+++ b/router/watcher.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+var (
+	// ErrWatcherStopped is returned when routing table watcher has been stopped
+	ErrWatcherStopped = errors.New("watcher stopped")
+)
+
 // EventType defines routing table event
 type EventType int
 
@@ -42,9 +47,6 @@ type Event struct {
 	Route Route
 }
 
-// WatchOption is used to define what routes to watch in the table
-type WatchOption func(*WatchOptions)
-
 // Watcher defines routing table watcher interface
 // Watcher returns updates to the routing table
 type Watcher interface {
@@ -56,7 +58,11 @@ type Watcher interface {
 	Stop()
 }
 
+// WatchOption is used to define what routes to watch in the table
+type WatchOption func(*WatchOptions)
+
 // WatchOptions are table watcher options
+// TODO: expand the options to watch based on other criteria
 type WatchOptions struct {
 	// Service allows to watch specific service routes
 	Service string
@@ -70,6 +76,7 @@ func WatchService(s string) WatchOption {
 	}
 }
 
+// tableWatcher implements routing table Watcher
 type tableWatcher struct {
 	sync.RWMutex
 	id      string
@@ -113,8 +120,3 @@ func (w *tableWatcher) Stop() {
 		close(w.done)
 	}
 }
-
-var (
-	// ErrWatcherStopped is returned when routing table watcher has been stopped
-	ErrWatcherStopped = errors.New("watcher stopped")
-)


### PR DESCRIPTION
This also brings a bit of cleanup to the `router` code, mostly related to the organisation and consistency of the source rather than changing any of the core functionality.