### PR TITLE
stream bug

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -212,7 +212,7 @@ func (r *rpcClient) stream(ctx context.Context, node *registry.Node, req Request
 		dOpts = append(dOpts, transport.WithTimeout(opts.DialTimeout))
 	}
 
-	c, err := r.pool.Get(address, dOpts...)
+	c, err := r.opts.Transport.Dial(address, dOpts...)
 	if err != nil {
 		return nil, errors.InternalServerError("go.micro.client", "connection error: %v", err)
 	}
@@ -246,7 +246,7 @@ func (r *rpcClient) stream(ctx context.Context, node *registry.Node, req Request
 		// signal the end of stream,
 		sendEOS: true,
 		// release func
-		release: func(err error) { r.pool.Release(c, err) },
+		release: func(err error) { c.Close() },
 	}
 
 	// wait for error response


### PR DESCRIPTION
in the `stream` function,  need a client connection with flag `Stream = true`
https://github.com/micro/go-micro/blob/a4f5772555f017fdfde44c5a352c5ae42eb207eb/client/rpc_client.go#L208

if use pool get Connection
https://github.com/micro/go-micro/blob/a4f5772555f017fdfde44c5a352c5ae42eb207eb/client/rpc_client.go#L215
there will be a bug, maybe get an  old client connect with  `Stream = false`
and  will get stuck here
https://github.com/micro/go-micro/blob/a4f5772555f017fdfde44c5a352c5ae42eb207eb/transport/http_transport.go#L129
