### PR TITLE
Tunnel Direction Fix

### DIFF
--- a/tunnel/link.go
+++ b/tunnel/link.go
@@ -1,0 +1,13 @@
+package tunnel
+
+import (
+	"github.com/google/uuid"
+	"github.com/micro/go-micro/transport"
+)
+
+func newLink(s transport.Socket) *link {
+	return &link{
+		Socket: s,
+		id:     uuid.New().String(),
+	}
+}

--- a/tunnel/listener.go
+++ b/tunnel/listener.go
@@ -41,6 +41,8 @@ func (t *tunListener) process() {
 					id: m.id,
 					// the session id
 					session: m.session,
+					// is loopback conn
+					loopback: m.loopback,
 					// close chan
 					closed: make(chan bool),
 					// recv called by the acceptor

--- a/tunnel/listener.go
+++ b/tunnel/listener.go
@@ -43,6 +43,8 @@ func (t *tunListener) process() {
 					session: m.session,
 					// is loopback conn
 					loopback: m.loopback,
+					// the link the message was received on
+					link: m.link,
 					// close chan
 					closed: make(chan bool),
 					// recv called by the acceptor

--- a/tunnel/socket.go
+++ b/tunnel/socket.go
@@ -25,8 +25,10 @@ type socket struct {
 	recv chan *message
 	// wait until we have a connection
 	wait chan bool
-	// outbound marks the socket as outbound
+	// outbound marks the socket as outbound dialled connection
 	outbound bool
+	// lookback marks the socket as a loopback on the inbound
+	loopback bool
 }
 
 // message is sent over the send channel
@@ -37,6 +39,8 @@ type message struct {
 	session string
 	// outbound marks the message as outbound
 	outbound bool
+	// loopback marks the message intended for loopback
+	loopback bool
 	// transport data
 	data *transport.Message
 }
@@ -80,6 +84,7 @@ func (s *socket) Send(m *transport.Message) error {
 		id:       s.id,
 		session:  s.session,
 		outbound: s.outbound,
+		loopback: s.loopback,
 		data:     data,
 	}
 	log.Debugf("Appending %+v to send backlog", msg)

--- a/tunnel/socket.go
+++ b/tunnel/socket.go
@@ -29,10 +29,14 @@ type socket struct {
 	outbound bool
 	// lookback marks the socket as a loopback on the inbound
 	loopback bool
+	// the link on which this message was received
+	link string
 }
 
 // message is sent over the send channel
 type message struct {
+	// type of message
+	typ string
 	// tunnel id
 	id string
 	// the session id
@@ -41,6 +45,8 @@ type message struct {
 	outbound bool
 	// loopback marks the message intended for loopback
 	loopback bool
+	// the link to send the message on
+	link string
 	// transport data
 	data *transport.Message
 }
@@ -81,11 +87,15 @@ func (s *socket) Send(m *transport.Message) error {
 
 	// append to backlog
 	msg := &message{
+		typ:      "message",
 		id:       s.id,
 		session:  s.session,
 		outbound: s.outbound,
 		loopback: s.loopback,
 		data:     data,
+		// specify the link on which to send this
+		// it will be blank for dialled sockets
+		link: s.link,
 	}
 	log.Debugf("Appending %+v to send backlog", msg)
 	s.send <- msg


### PR DESCRIPTION
This PR fixes loopback issues with listeners processing their own messages being sent outbound and also provides unidirectional responses in the sense that listeners will always respond back on the link they received a request. This starts the path towards creating a virtual circuit. Now we must do the same on the send side.