### PR TITLE
Rename Tunnel ID to Channel

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -179,10 +179,10 @@ func (n *network) resolve() {
 }
 
 // handleNetConn handles network announcement messages
-func (n *network) handleNetConn(conn tunnel.Conn, msg chan *transport.Message) {
+func (n *network) handleNetConn(sess tunnel.Session, msg chan *transport.Message) {
 	for {
 		m := new(transport.Message)
-		if err := conn.Recv(m); err != nil {
+		if err := sess.Recv(m); err != nil {
 			// TODO: should we bail here?
 			log.Debugf("Network tunnel [%s] receive error: %v", NetworkChannel, err)
 			return
@@ -349,10 +349,10 @@ func (n *network) announce(client transport.Client) {
 }
 
 // handleCtrlConn handles ControlChannel connections
-func (n *network) handleCtrlConn(conn tunnel.Conn, msg chan *transport.Message) {
+func (n *network) handleCtrlConn(sess tunnel.Session, msg chan *transport.Message) {
 	for {
 		m := new(transport.Message)
-		if err := conn.Recv(m); err != nil {
+		if err := sess.Recv(m); err != nil {
 			// TODO: should we bail here?
 			log.Debugf("Network tunnel advert receive error: %v", err)
 			return

--- a/tunnel/link.go
+++ b/tunnel/link.go
@@ -1,9 +1,33 @@
 package tunnel
 
 import (
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/micro/go-micro/transport"
 )
+
+type link struct {
+	sync.RWMutex
+
+	transport.Socket
+	// unique id of this link e.g uuid
+	// which we define for ourselves
+	id string
+	// whether its a loopback connection
+	// this flag is used by the transport listener
+	// which accepts inbound quic connections
+	loopback bool
+	// whether its actually connected
+	// dialled side sets it to connected
+	// after sending the message. the
+	// listener waits for the connect
+	connected bool
+	// the last time we received a keepalive
+	// on this link from the remote side
+	lastKeepAlive time.Time
+}
 
 func newLink(s transport.Socket) *link {
 	return &link{

--- a/tunnel/options.go
+++ b/tunnel/options.go
@@ -9,6 +9,8 @@ import (
 var (
 	// DefaultAddress is default tunnel bind address
 	DefaultAddress = ":0"
+	// The shared default token
+	DefaultToken = "micro"
 )
 
 type Option func(*Options)
@@ -21,6 +23,8 @@ type Options struct {
 	Address string
 	// Nodes are remote nodes
 	Nodes []string
+	// The shared auth token
+	Token string
 	// Transport listens to incoming connections
 	Transport transport.Transport
 }
@@ -46,6 +50,13 @@ func Nodes(n ...string) Option {
 	}
 }
 
+// Token sets the shared token for auth
+func Token(t string) Option {
+	return func(o *Options) {
+		o.Token = t
+	}
+}
+
 // Transport listens for incoming connections
 func Transport(t transport.Transport) Option {
 	return func(o *Options) {
@@ -58,6 +69,7 @@ func DefaultOptions() Options {
 	return Options{
 		Id:        uuid.New().String(),
 		Address:   DefaultAddress,
+		Token:     DefaultToken,
 		Transport: quic.NewTransport(),
 	}
 }

--- a/tunnel/transport/listener.go
+++ b/tunnel/transport/listener.go
@@ -10,7 +10,7 @@ type tunListener struct {
 }
 
 func (t *tunListener) Addr() string {
-	return t.l.Addr()
+	return t.l.Channel()
 }
 
 func (t *tunListener) Close() error {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -17,27 +17,27 @@ type Tunnel interface {
 	Connect() error
 	// Close closes the tunnel
 	Close() error
-	// Dial an endpoint
-	Dial(addr string) (Conn, error)
-	// Accept connections
-	Listen(addr string) (Listener, error)
+	// Connect to a channel
+	Dial(channel string) (Session, error)
+	// Accept connections on a channel
+	Listen(channel string) (Listener, error)
 	// Name of the tunnel implementation
 	String() string
 }
 
 // The listener provides similar constructs to the transport.Listener
 type Listener interface {
-	Addr() string
+	Channel() string
 	Close() error
-	Accept() (Conn, error)
+	Accept() (Session, error)
 }
 
-// Conn is a connection dialed or accepted which includes the tunnel id and session
-type Conn interface {
+// Session is a unique session created when dialling or accepting connections on the tunnel
+type Session interface {
 	// Specifies the tunnel id
 	Id() string
 	// The session
-	Session() string
+	Channel() string
 	// a transport socket
 	transport.Socket
 }


### PR DESCRIPTION
This PR includes the rework of Tunnel ID to Channel. Where we use tunnel ID as the unique identifier for each new instance of the tunnel over which you can create channels with unique sessions. 

We also now use Token as a mechanism for auth in that the token is a shared token that must match.

Additionally there is a fix to return errors to the Send side of a connection in the event messages cannot be sent. This also turns send into a blocking send which we don't really know is ideal or not. Otherwise we were effectively blackholing messages.