### PR TITLE
Prune nodes that have not announced themselves for certain time period.

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -17,6 +17,9 @@ var (
 	ResolveTime = 1 * time.Minute
 	// AnnounceTime defines time interval to periodically announce node neighbours
 	AnnounceTime = 30 * time.Second
+	// PruneTime defines time interval to periodically check nodes that need to be pruned
+	// due to their not announcing their presence within this time interval
+	PruneTime = 90 * time.Second
 )
 
 // Node is network node


### PR DESCRIPTION
We prune the nodes that have not announced themselves for `network.PruneTime` seconds from the list of node neighbours and remove all of the routes originated by them.