### PR TITLE
Update tunnel to send discovery on connect and multicast messages. An…

### DIFF
--- a/tunnel/default.go
+++ b/tunnel/default.go
@@ -821,8 +821,8 @@ func (t *tun) close() error {
 	}
 
 	// close the listener
-	//return t.listener.Close()
-	return nil
+	// this appears to be blocking
+	return t.listener.Close()
 }
 
 func (t *tun) Address() string {

--- a/tunnel/listener.go
+++ b/tunnel/listener.go
@@ -24,7 +24,7 @@ type tunListener struct {
 
 // periodically announce self
 func (t *tunListener) announce() {
-	tick := time.NewTicker(time.Minute)
+	tick := time.NewTicker(time.Second * 30)
 	defer tick.Stop()
 
 	// first announcement

--- a/tunnel/session.go
+++ b/tunnel/session.go
@@ -180,6 +180,8 @@ func (s *session) Announce() error {
 	msg := s.newMessage("announce")
 	// we don't need an error back
 	msg.errChan = nil
+	// announce to all
+	msg.broadcast = true
 	// we don't need the link
 	msg.link = ""
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -9,10 +9,12 @@ import (
 )
 
 var (
-	// ErrDialTimeout is returned by a call to Dial where the timeout occurs
-	ErrDialTimeout = errors.New("dial timeout")
 	// DefaultDialTimeout is the dial timeout if none is specified
 	DefaultDialTimeout = time.Second * 5
+	// ErrDialTimeout is returned by a call to Dial where the timeout occurs
+	ErrDialTimeout = errors.New("dial timeout")
+	// ErrDiscoverChan is returned when we failed to receive the "announce" back from a discovery
+	ErrDiscoverChan = errors.New("failed to discover channel")
 )
 
 // Tunnel creates a gre tunnel on top of the go-micro/transport.


### PR DESCRIPTION
This PR includes a number of updates to try help convergence in tunnelling.

1. Send discover message to all links once connected (todo: send on reconnect or new link setup)
2. The announce returns all channels at once when the first discover is sent
3. We sent a discover message on multicast Dial (this however can be blocking startup speed)
4. Reduce announce time for channels to 30 seconds
5. Broadcast the announce for the listener rather than just directly back to the link

TODO
1. Send discover on reconnect or new link setup. We only do this in tunnel.Connect
2. Send channels from the second node more promptly after the connect
3. Ensure we're not blasting information to everyone in a flooded way
