### PR TITLE
List nodes now works properly. Send solicit message on ControlChannel

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -352,6 +352,7 @@ func (n *network) processNetChan(client transport.Client, listener tunnel.Listen
 				// only add the neighbour if it is NOT already in node's list of neighbours
 				_, exists := n.neighbours[pbNetNeighbour.Node.Id]
 				if !exists {
+					log.Debugf("Network neighbour message node exists: %s", pbNetNeighbour.Node.Id)
 					n.neighbours[pbNetNeighbour.Node.Id] = &node{
 						id:         pbNetNeighbour.Node.Id,
 						address:    pbNetNeighbour.Node.Address,
@@ -373,13 +374,13 @@ func (n *network) processNetChan(client transport.Client, listener tunnel.Listen
 						address:    pbNeighbour.Address,
 						neighbours: make(map[string]*node),
 					}
-					n.neighbours[pbNetNeighbour.Node.Id].neighbours[neighbourNode.id] = neighbourNode
+					n.neighbours[pbNetNeighbour.Node.Id].neighbours[pbNeighbour.Id] = neighbourNode
 				}
 				n.Unlock()
 				// send a solicit message when discovering a new node
 				// NOTE: we need to send the solicit message here after the Lock is released as sendMsg locks, too
 				if !exists {
-					if err := n.sendMsg("solicit", NetworkChannel); err != nil {
+					if err := n.sendMsg("solicit", ControlChannel); err != nil {
 						log.Debugf("Network failed to send solicit message: %s", err)
 					}
 				}
@@ -696,8 +697,10 @@ func (n *network) processCtrlChan(client transport.Client, listener tunnel.Liste
 					}
 					// set the route metric
 					n.setRouteMetric(&route)
+					log.Debugf("Network node %s metric: %d", route.Router, route.Metric)
 					// throw away metric bigger than 1000
 					if route.Metric > 1000 {
+						log.Debugf("Network dropping node: %s", route.Router)
 						continue
 					}
 					// create router event
@@ -721,6 +724,16 @@ func (n *network) processCtrlChan(client transport.Client, listener tunnel.Liste
 					continue
 				}
 			case "solicit":
+				pbNetSolicit := &pbNet.Solicit{}
+				if err := proto.Unmarshal(m.Body, pbNetSolicit); err != nil {
+					log.Debugf("Network fail to unmarshal solicit message: %v", err)
+					continue
+				}
+				log.Debugf("Network received solicit message from: %s", pbNetSolicit.Node.Id)
+				// don't process your own messages
+				if pbNetSolicit.Node.Id == n.options.Id {
+					continue
+				}
 				// advertise all the routes when a new node has connected
 				if err := n.Router.Solicit(); err != nil {
 					log.Debugf("Network failed to solicit routes: %s", err)
@@ -907,8 +920,9 @@ func (n *network) Nodes() []Node {
 	visited[n.node.id] = n.node
 
 	// keep iterating over the queue until its empty
-	for qnode := queue.Front(); qnode != nil; qnode = qnode.Next() {
-		queue.Remove(qnode)
+	for queue.Len() > 0 {
+		// pop the node from the front of the queue
+		qnode := queue.Front()
 		// iterate through all of its neighbours
 		// mark the visited nodes; enqueue the non-visted
 		for id, node := range qnode.Value.(*node).neighbours {
@@ -917,11 +931,13 @@ func (n *network) Nodes() []Node {
 				queue.PushBack(node)
 			}
 		}
+		// remove the node from the queue
+		queue.Remove(qnode)
 	}
 
 	var nodes []Node
 	// collect all the nodes and return them
-	for _, node := range visited {
+	for id, node := range visited {
 		nodes = append(nodes, node)
 	}
 

--- a/network/default.go
+++ b/network/default.go
@@ -352,7 +352,6 @@ func (n *network) processNetChan(client transport.Client, listener tunnel.Listen
 				// only add the neighbour if it is NOT already in node's list of neighbours
 				_, exists := n.neighbours[pbNetNeighbour.Node.Id]
 				if !exists {
-					log.Debugf("Network neighbour message node exists: %s", pbNetNeighbour.Node.Id)
 					n.neighbours[pbNetNeighbour.Node.Id] = &node{
 						id:         pbNetNeighbour.Node.Id,
 						address:    pbNetNeighbour.Node.Address,
@@ -697,10 +696,9 @@ func (n *network) processCtrlChan(client transport.Client, listener tunnel.Liste
 					}
 					// set the route metric
 					n.setRouteMetric(&route)
-					log.Debugf("Network node %s metric: %d", route.Router, route.Metric)
 					// throw away metric bigger than 1000
 					if route.Metric > 1000 {
-						log.Debugf("Network dropping node: %s", route.Router)
+						log.Debugf("Network route metric %d dropping node: %s", route.Metric, route.Router)
 						continue
 					}
 					// create router event
@@ -937,7 +935,7 @@ func (n *network) Nodes() []Node {
 
 	var nodes []Node
 	// collect all the nodes and return them
-	for id, node := range visited {
+	for _, node := range visited {
 		nodes = append(nodes, node)
 	}
 

--- a/router/proto/router.proto
+++ b/router/proto/router.proto
@@ -41,10 +41,12 @@ message LookupResponse {
 	repeated Route routes = 1;
 }
 
+// QueryRequest queries Table for Routes
 message QueryRequest{
 	Query query = 1;
 }
 
+// QueryResponse is returned by Query
 message QueryResponse {
 	repeated Route routes = 1;
 }


### PR DESCRIPTION
Turns out we were sending `solicit` messages on `NetworkChannel` and never handled them

We're now sending them on `ControlChannel` and handling them properly.