### PR TITLE
Limit the number of outbound connections to MaxConnections

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -171,9 +171,16 @@ func (n *network) resolveNodes() ([]string, error) {
 
 	// collect network node addresses
 	var nodes []string
+
+	i := 0
 	for _, record := range records {
 		nodes = append(nodes, record.Address)
 		nodeMap[record.Address] = true
+		i++
+		// break once MaxConnection nodes has been reached
+		if i == MaxConnections {
+			break
+		}
 	}
 
 	// use the dns resolver to expand peers
@@ -193,15 +200,6 @@ func (n *network) resolveNodes() ([]string, error) {
 				nodes = append(nodes, record.Address)
 			}
 		}
-	}
-
-	// only return MaxConnections nodes
-	if len(nodes) > MaxConnections {
-		resNodes := make([]string, MaxConnections)
-		for i, _ := range resNodes {
-			resNodes[i] = nodes[i]
-		}
-		return resNodes, nil
 	}
 
 	return nodes, nil

--- a/network/default.go
+++ b/network/default.go
@@ -29,8 +29,8 @@ var (
 	ControlChannel = "control"
 	// DefaultLink is default network link
 	DefaultLink = "network"
-	// MaxCconnections is the max number of network client connections
-	MaxCconnections = 3
+	// MaxConnections is the max number of network client connections
+	MaxConnections = 3
 )
 
 var (
@@ -195,9 +195,9 @@ func (n *network) resolveNodes() ([]string, error) {
 		}
 	}
 
-	// only return MaxCconnections nodes
-	if len(nodes) > MaxCconnections {
-		resNodes := make([]string, MaxCconnections)
+	// only return MaxConnections nodes
+	if len(nodes) > MaxConnections {
+		resNodes := make([]string, MaxConnections)
 		for i, _ := range resNodes {
 			resNodes[i] = nodes[i]
 		}


### PR DESCRIPTION
This commit also fixes control channel shenanigans:
- recover error in control channel `Accept()`