### PR TITLE
Add dialoptions and calloptions

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -109,7 +109,7 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	maxSendMsgSize := g.maxSendMsgSizeValue()
 
 	var grr error
-	
+
 	grpcDialOptions := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(grpc.ForceCodec(cf)),
 		grpc.WithTimeout(opts.DialTimeout),
@@ -119,7 +119,7 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 			grpc.MaxCallSendMsgSize(maxSendMsgSize),
 		),
 	}
-	
+
 	if opts := g.getGrpcDialOptions(); opts != nil {
 		grpcDialOptions = append(grpcDialOptions, opts...)
 	}
@@ -187,12 +187,12 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 	defer cancel()
 
 	wc := wrapCodec{cf}
-	
+
 	grpcDialOptions := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.ForceCodec(wc)), 
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(wc)),
 		g.secure(),
 	}
-	
+
 	if opts := g.getGrpcDialOptions(); opts != nil {
 		grpcDialOptions = append(grpcDialOptions, opts...)
 	}
@@ -541,11 +541,11 @@ func (g *grpcClient) String() string {
 }
 
 func (g *grpcClient) getGrpcDialOptions() []grpc.DialOption {
-	if g.opts.Context == nil {
+	if g.opts.CallOptions.Context == nil {
 		return nil
 	}
 
-	v := g.opts.Context.Value(grpcDialOptions{})
+	v := g.opts.CallOptions.Context.Value(grpcDialOptions{})
 
 	if v == nil {
 		return nil

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -109,13 +109,22 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	maxSendMsgSize := g.maxSendMsgSizeValue()
 
 	var grr error
-
-	cc, err := g.pool.getConn(address, grpc.WithDefaultCallOptions(grpc.ForceCodec(cf)),
-		grpc.WithTimeout(opts.DialTimeout), g.secure(),
+	
+	grpcDialOptions := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(cf)),
+		grpc.WithTimeout(opts.DialTimeout),
+		g.secure(),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(maxRecvMsgSize),
 			grpc.MaxCallSendMsgSize(maxSendMsgSize),
-		))
+		),
+	}
+	
+	if opts := g.getGrpcDialOptions(); opts != nil {
+		grpcDialOptions = append(grpcDialOptions, opts...)
+	}
+
+	cc, err := g.pool.getConn(address, grpcDialOptions...)
 	if err != nil {
 		return errors.InternalServerError("go.micro.client", fmt.Sprintf("Error sending request: %v", err))
 	}
@@ -127,7 +136,11 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	ch := make(chan error, 1)
 
 	go func() {
-		err := cc.Invoke(ctx, methodToGRPC(req.Service(), req.Endpoint()), req.Body(), rsp, grpc.CallContentSubtype(cf.Name()))
+		grpcCallOptions := []grpc.CallOption{grpc.CallContentSubtype(cf.Name())}
+		if opts := g.getGrpcCallOptions(); opts != nil {
+			grpcCallOptions = append(grpcCallOptions, opts...)
+		}
+		err := cc.Invoke(ctx, methodToGRPC(req.Service(), req.Endpoint()), req.Body(), rsp, grpcCallOptions...)
 		ch <- microError(err)
 	}()
 
@@ -174,8 +187,17 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 	defer cancel()
 
 	wc := wrapCodec{cf}
+	
+	grpcDialOptions := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(wc)), 
+		g.secure(),
+	}
+	
+	if opts := g.getGrpcDialOptions(); opts != nil {
+		grpcDialOptions = append(grpcDialOptions, opts...)
+	}
 
-	cc, err := grpc.DialContext(dialCtx, address, grpc.WithDefaultCallOptions(grpc.ForceCodec(wc)), g.secure())
+	cc, err := grpc.DialContext(dialCtx, address, grpcDialOptions...)
 	if err != nil {
 		return nil, errors.InternalServerError("go.micro.client", fmt.Sprintf("Error sending request: %v", err))
 	}
@@ -186,7 +208,11 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 		ServerStreams: true,
 	}
 
-	st, err := cc.NewStream(ctx, desc, methodToGRPC(req.Service(), req.Endpoint()))
+	grpcCallOptions := []grpc.CallOption{}
+	if opts := g.getGrpcCallOptions(); opts != nil {
+		grpcCallOptions = append(grpcCallOptions, opts...)
+	}
+	st, err := cc.NewStream(ctx, desc, methodToGRPC(req.Service(), req.Endpoint()), grpcCallOptions...)
 	if err != nil {
 		return nil, errors.InternalServerError("go.micro.client", fmt.Sprintf("Error creating stream: %v", err))
 	}
@@ -512,6 +538,46 @@ func (g *grpcClient) Publish(ctx context.Context, p client.Message, opts ...clie
 
 func (g *grpcClient) String() string {
 	return "grpc"
+}
+
+func (g *grpcClient) getGrpcDialOptions() []grpc.DialOption {
+	if g.opts.Context == nil {
+		return nil
+	}
+
+	v := g.opts.Context.Value(grpcDialOptions{})
+
+	if v == nil {
+		return nil
+	}
+
+	opts, ok := v.([]grpc.DialOption)
+
+	if !ok {
+		return nil
+	}
+
+	return opts
+}
+
+func (g *grpcClient) getGrpcCallOptions() []grpc.CallOption {
+	if g.opts.CallOptions.Context == nil {
+		return nil
+	}
+
+	v := g.opts.CallOptions.Context.Value(grpcCallOptions{})
+
+	if v == nil {
+		return nil
+	}
+
+	opts, ok := v.([]grpc.CallOption)
+
+	if !ok {
+		return nil
+	}
+
+	return opts
 }
 
 func newClient(opts ...client.Option) client.Client {

--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -79,8 +79,8 @@ func MaxSendMsgSize(s int) client.Option {
 //
 // DialOptions to be used to configure gRPC dial options
 //
-func DialOptions(opts ...grpc.DialOption) client.Option {
-	return func(o *client.Options) {
+func DialOptions(opts ...grpc.DialOption) client.CallOption {
+	return func(o *client.CallOptions) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
@@ -91,11 +91,11 @@ func DialOptions(opts ...grpc.DialOption) client.Option {
 //
 // CallOptions to be used to configure gRPC call options
 //
-func CallOptions(opts ...grpc.CallOption) client.Option {
-	return func(o *client.Options) {
-		if o.CallOptions.Context == nil {
-			o.CallOptions.Context = context.Background()
+func CallOptions(opts ...grpc.CallOption) client.CallOption {
+	return func(o *client.CallOptions) {
+		if o.Context == nil {
+			o.Context = context.Background()
 		}
-		o.CallOptions.Context = context.WithValue(o.CallOptions.Context, grpcCallOptions{}, opts)
+		o.Context = context.WithValue(o.Context, grpcCallOptions{}, opts)
 	}
 }

--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -23,6 +23,8 @@ type codecsKey struct{}
 type tlsAuth struct{}
 type maxRecvMsgSizeKey struct{}
 type maxSendMsgSizeKey struct{}
+type grpcDialOptions struct{}
+type grpcCallOptions struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) client.Option {
@@ -70,5 +72,29 @@ func MaxSendMsgSize(s int) client.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, maxSendMsgSizeKey{}, s)
+	}
+}
+
+//
+// DialOptions to be used to configure gRPC dial options
+//
+func DialOptions(opts ...grpc.DialOption) client.Option {
+	return func(o *client.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, grpcDialOptions{}, opts)
+	}
+}
+
+//
+// CallOptions to be used to configure gRPC call options
+//
+func CallOptions(opts ...grpc.CallOption) client.Option {
+	return func(o *client.Options) {
+		if o.CallOptions.Context == nil {
+			o.CallOptions.Context = context.Background()
+		}
+		o.CallOptions.Context = context.WithValue(o.CallOptions.Context, grpcCallOptions{}, opts)
 	}
 }

--- a/client/grpc/options.go
+++ b/client/grpc/options.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 
 	"github.com/micro/go-micro/client"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 )
 


### PR DESCRIPTION
Adding dial options and call options to `go-micro/client/grpc`

Major changes:
1. Adding `go-micro/client.option` converter at `client/grpc/options.go`
2. Adding options behaviour to `go-micro/client/grpc.grpcClient.call` and `go-micro/client/grpc.grpcClient.stream` to implement the dial options and call options

Questions for it to be used:
1. Would it affect behaviour of go-micro dialoptions / calloptions usage?
2. Not yet tested. Does it work?