### PR TITLE
Router strategy

### DIFF
--- a/router/default.go
+++ b/router/default.go
@@ -682,11 +682,7 @@ func (r *router) flushRouteEvents(evType EventType) ([]*Event, error) {
 		return nil, fmt.Errorf("failed listing routes: %s", err)
 	}
 
-	r.RLock()
-	advertStrategy := r.options.Advertise
-	r.RUnlock()
-
-	if advertStrategy == All {
+	if r.options.Advertise == All {
 		// build a list of events to advertise
 		events := make([]*Event, len(routes))
 		for i, route := range routes {

--- a/router/options.go
+++ b/router/options.go
@@ -76,9 +76,10 @@ func Advertise(a Strategy) Option {
 // DefaultOptions returns router default options
 func DefaultOptions() Options {
 	return Options{
-		Id:       uuid.New().String(),
-		Address:  DefaultAddress,
-		Network:  DefaultNetwork,
-		Registry: registry.DefaultRegistry,
+		Id:        uuid.New().String(),
+		Address:   DefaultAddress,
+		Network:   DefaultNetwork,
+		Registry:  registry.DefaultRegistry,
+		Advertise: Optimal,
 	}
 }

--- a/router/options.go
+++ b/router/options.go
@@ -18,6 +18,8 @@ type Options struct {
 	Network string
 	// Registry is the local registry
 	Registry registry.Registry
+	// Advertise is the advertising strategy
+	Advertise Strategy
 	// Client for calling router
 	Client client.Client
 }
@@ -61,6 +63,13 @@ func Network(n string) Option {
 func Registry(r registry.Registry) Option {
 	return func(o *Options) {
 		o.Registry = r
+	}
+}
+
+// Strategy sets route advertising strategy
+func Advertise(a Strategy) Option {
+	return func(o *Options) {
+		o.Advertise = a
 	}
 }
 

--- a/router/options.go
+++ b/router/options.go
@@ -80,6 +80,6 @@ func DefaultOptions() Options {
 		Address:   DefaultAddress,
 		Network:   DefaultNetwork,
 		Registry:  registry.DefaultRegistry,
-		Advertise: Optimal,
+		Advertise: AdvertiseBest,
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -149,6 +149,18 @@ const (
 	Optimal
 )
 
+// String returns human readable Strategy
+func (s Strategy) String() string {
+	switch s {
+	case All:
+		return "all"
+	case Optimal:
+		return "optimal"
+	default:
+		return "unknown"
+	}
+}
+
 // NewRouter creates new Router and returns it
 func NewRouter(opts ...Option) Router {
 	return newRouter(opts...)

--- a/router/router.go
+++ b/router/router.go
@@ -143,19 +143,19 @@ type Advert struct {
 type Strategy int
 
 const (
-	// All advertises all routes to the network
-	All Strategy = iota
-	// Optimal advertises optimal routes to the network
-	Optimal
+	// AdvertiseAll advertises all routes to the network
+	AdvertiseAll Strategy = iota
+	// AdvertiseBest advertises optimal routes to the network
+	AdvertiseBest
 )
 
 // String returns human readable Strategy
 func (s Strategy) String() string {
 	switch s {
-	case All:
+	case AdvertiseAll:
 		return "all"
-	case Optimal:
-		return "optimal"
+	case AdvertiseBest:
+		return "best"
 	default:
 		return "unknown"
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -139,6 +139,16 @@ type Advert struct {
 	Events []*Event
 }
 
+// Strategy is route advertisement strategy
+type Strategy int
+
+const (
+	// All advertises all routes to the network
+	All Strategy = iota
+	// Optimal advertises optimal routes to the network
+	Optimal
+)
+
 // NewRouter creates new Router and returns it
 func NewRouter(opts ...Option) Router {
 	return newRouter(opts...)


### PR DESCRIPTION
This PR adds a router advertising strategy option:
- `All` advertises all routes
- `Optimal` advertises optimal routes only

Optimal routes are a collapsed list of routes per service:
- prefer routes with lowest metric
- when routes with equal metric are found, prefer to advertise your route i.e. the route that originates at your router.