### PR TITLE
Clean up dead tunnel code

### DIFF
--- a/tunnel/default.go
+++ b/tunnel/default.go
@@ -919,14 +919,12 @@ func (t *tun) Close() error {
 	default:
 		close(t.closed)
 		t.connected = false
-
-		// send a close message
-		// we don't close the link
-		// just the tunnel
-		return t.close()
 	}
 
-	return nil
+	// send a close message
+	// we don't close the link
+	// just the tunnel
+	return t.close()
 }
 
 // Dial an address

--- a/tunnel/link.go
+++ b/tunnel/link.go
@@ -98,7 +98,6 @@ func (l *link) Close() error {
 		return nil
 	default:
 		close(l.closed)
-		return nil
 	}
 
 	return nil

--- a/tunnel/listener.go
+++ b/tunnel/listener.go
@@ -181,5 +181,4 @@ func (t *tunListener) Accept() (Session, error) {
 		}
 		return c, nil
 	}
-	return nil, nil
 }

--- a/tunnel/session.go
+++ b/tunnel/session.go
@@ -237,8 +237,6 @@ func (s *session) Send(m *transport.Message) error {
 	case <-s.closed:
 		return io.EOF
 	}
-
-	return nil
 }
 
 // Recv is used to receive a message


### PR DESCRIPTION
Running go vet on tunnel package returns:
```shell
$ go vet ./...
./default.go:929:2: unreachable code
./link.go:104:2: unreachable code
./listener.go:184:2: unreachable code
./session.go:241:2: unreachable code
```