### PR TITLE
Cleanup of tunnel.Dial(). Clean up network channel processors

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -296,7 +296,7 @@ func (n *network) acceptNetConn(l tunnel.Listener, recv chan *transport.Message)
 }
 
 // processNetChan processes messages received on NetworkChannel
-func (n *network) processNetChan(client transport.Client, listener tunnel.Listener) {
+func (n *network) processNetChan(listener tunnel.Listener) {
 	// receive network message queue
 	recv := make(chan *transport.Message, 128)
 
@@ -629,7 +629,7 @@ func (n *network) setRouteMetric(route *router.Route) {
 }
 
 // processCtrlChan processes messages received on ControlChannel
-func (n *network) processCtrlChan(client transport.Client, listener tunnel.Listener) {
+func (n *network) processCtrlChan(listener tunnel.Listener) {
 	// receive control message queue
 	recv := make(chan *transport.Message, 128)
 
@@ -739,7 +739,7 @@ func (n *network) processCtrlChan(client transport.Client, listener tunnel.Liste
 }
 
 // advertise advertises routes to the network
-func (n *network) advertise(client transport.Client, advertChan <-chan *router.Advert) {
+func (n *network) advertise(advertChan <-chan *router.Advert) {
 	hasher := fnv.New64()
 	for {
 		select {
@@ -910,11 +910,11 @@ func (n *network) Connect() error {
 	// prune stale nodes
 	go n.prune()
 	// listen to network messages
-	go n.processNetChan(netClient, netListener)
+	go n.processNetChan(netListener)
 	// advertise service routes
-	go n.advertise(ctrlClient, advertChan)
+	go n.advertise(advertChan)
 	// accept and process routes
-	go n.processCtrlChan(ctrlClient, ctrlListener)
+	go n.processCtrlChan(ctrlListener)
 
 	n.Lock()
 	n.connected = true


### PR DESCRIPTION
This PR fixes the following:
* we now delete the newly created session from the tunnel sessions map every time an error happens in `tunnel.Dial()` -- this way we avoid potentially growing the sessions map when a lot of errors accumulate and leaking memory
* cleaned up some logic in `tunnel.Dial`; when `options.Link` is not set, the `if` condition which checks if the `link.id` matches `options.Link` will *never* fire, so we end up unnecessarily iterating over all the tunnel `links` when `options.Link` is empty string

Finally
* this PR removes `transport.Client`  from the list of parameters passed to channel processing functions in network as they no longer use the client in their bodies -- this was overlooked when we refactored sending messages to dedicated `sendMsg` function