### PR TITLE
E2E tests for certmagic ACME provider

### DIFF
--- a/api/server/acme/certmagic/certmagic.go
+++ b/api/server/acme/certmagic/certmagic.go
@@ -3,7 +3,9 @@ package certmagic
 
 import (
 	"log"
+	"math/rand"
 	"net"
+	"time"
 
 	"github.com/mholt/certmagic"
 
@@ -15,6 +17,7 @@ type certmagicProvider struct {
 }
 
 func (c *certmagicProvider) NewListener(ACMEHosts ...string) (net.Listener, error) {
+	certmagic.Default.CA = c.opts.CA
 	if c.opts.ChallengeProvider != nil {
 		// Enabling DNS Challenge disables the other challenges
 		certmagic.Default.DNSProvider = c.opts.ChallengeProvider
@@ -22,6 +25,16 @@ func (c *certmagicProvider) NewListener(ACMEHosts ...string) (net.Listener, erro
 	if c.opts.OnDemand {
 		certmagic.Default.OnDemand = new(certmagic.OnDemandConfig)
 	}
+	if c.opts.Cache != nil {
+		// already validated by new()
+		certmagic.Default.Storage = c.opts.Cache.(certmagic.Storage)
+	}
+	// If multiple instances of the provider are running, inject some
+	// randomness so they don't collide
+	rand.Seed(time.Now().UnixNano())
+	randomDuration := (7 * 24 * time.Hour) + (time.Duration(rand.Intn(504)) * time.Hour)
+	certmagic.Default.RenewDurationBefore = randomDuration
+
 	return certmagic.Listen(ACMEHosts)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/joncalhoun/qson v0.0.0-20170526102502-8a9cab3a62b1
 	github.com/json-iterator/go v1.1.7
+	github.com/kr/pretty v0.1.0
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/lucas-clemente/quic-go v0.12.1
 	github.com/mholt/certmagic v0.7.5

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/joncalhoun/qson v0.0.0-20170526102502-8a9cab3a62b1
 	github.com/json-iterator/go v1.1.7
-	github.com/kr/pretty v0.1.0
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/lucas-clemente/quic-go v0.12.1
 	github.com/mholt/certmagic v0.7.5


### PR DESCRIPTION
* Actually set the CA
* Fix the certmangic.storage interface to return the correct error type
* Write an e2e test for certmagic against the let's encrypt staging CA
* Randomise the time before renewing the cert so that multiple instances are unlikely to collide