### PR TITLE
hash address based on service name + node address

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -865,7 +865,10 @@ func (n *network) advertise(advertChan <-chan *router.Advert) {
 				if event.Route.Router == advert.Id {
 					// hash the service before advertising it
 					hasher.Reset()
-					hasher.Write([]byte(event.Route.Address + n.node.id))
+					// routes for multiple instances of a service will be collapsed here.
+					// TODO: once we store labels in the table this may need to change
+					// to include the labels in case they differ but highly unlikely
+					hasher.Write([]byte(event.Route.Service + n.node.Address()))
 					address = fmt.Sprintf("%d", hasher.Sum64())
 				}
 				// calculate route metric to advertise


### PR DESCRIPTION
Introducing this change to collapse routes advertised by a node. Hashing on service + node address will result in 1 route per service originating from that router. In the event multiple instances of a service are running, they'll be shredded down to just 1. This prevents scenarios in which we're running 3, 6, 9, 100 instances of a service in an environment.

This does not however prevent the wider distribution of routes. It also may have to change if we add labels to the routes as different instances of a service may have different labels, but it is more likely this is a regional or core/edge/dev related thing.