### PR TITLE
Preallocation of slices when known at the time of its creation

### DIFF
--- a/api/handler/api/util_test.go
+++ b/api/handler/api/util_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRequestToProto(t *testing.T) {
 	testData := []*http.Request{
-		&http.Request{
+		{
 			Method: "GET",
 			Header: http.Header{
 				"Header": []string{"test"},

--- a/api/handler/http/http_test.go
+++ b/api/handler/http/http_test.go
@@ -27,7 +27,7 @@ func testHttp(t *testing.T, path, service, ns string) {
 	s := &registry.Service{
 		Name: service,
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      service + "-1",
 				Address: l.Addr().String(),
 			},

--- a/broker/common_test.go
+++ b/broker/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/broker/http_broker_test.go
+++ b/broker/http_broker_test.go
@@ -125,7 +125,7 @@ func pub(be *testing.B, c int) {
 
 	for i := 0; i < c; i++ {
 		go func() {
-			for _ = range ch {
+			for range ch {
 				if err := b.Publish(topic, msg); err != nil {
 					be.Fatalf("Unexpected publish error: %v", err)
 				}

--- a/client/common_test.go
+++ b/client/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/client/grpc/grpc_test.go
+++ b/client/grpc/grpc_test.go
@@ -42,7 +42,7 @@ func TestGRPCClient(t *testing.T) {
 		Name:    "helloworld",
 		Version: "test",
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      "test-1",
 				Address: l.Addr().String(),
 			},

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -143,7 +143,7 @@ func TestCallWrapper(t *testing.T) {
 		Name:    service,
 		Version: "latest",
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      id,
 				Address: address,
 			},

--- a/client/selector/common_test.go
+++ b/client/selector/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/client/selector/dns/dns.go
+++ b/client/selector/dns/dns.go
@@ -63,7 +63,7 @@ func (d *dnsSelector) Select(service string, opts ...selector.SelectOption) (sel
 		}
 	}
 
-	var nodes []*registry.Node
+  nodes := make([]*registry.Node, 0, len(srv))
 	for _, node := range srv {
 		nodes = append(nodes, &registry.Node{
 			Id:      node.Target,

--- a/client/selector/dns/dns.go
+++ b/client/selector/dns/dns.go
@@ -63,7 +63,7 @@ func (d *dnsSelector) Select(service string, opts ...selector.SelectOption) (sel
 		}
 	}
 
-  nodes := make([]*registry.Node, 0, len(srv))
+	nodes := make([]*registry.Node, 0, len(srv))
 	for _, node := range srv {
 		nodes = append(nodes, &registry.Node{
 			Id:      node.Target,
@@ -72,7 +72,7 @@ func (d *dnsSelector) Select(service string, opts ...selector.SelectOption) (sel
 	}
 
 	services := []*registry.Service{
-		&registry.Service{
+		{
 			Name:  service,
 			Nodes: nodes,
 		},

--- a/client/selector/filter_test.go
+++ b/client/selector/filter_test.go
@@ -14,20 +14,20 @@ func TestFilterEndpoint(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Baz.Bar",
 						},
 					},
@@ -38,20 +38,20 @@ func TestFilterEndpoint(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
@@ -95,11 +95,11 @@ func TestFilterLabel(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-1",
 							Address: "localhost",
 							Metadata: map[string]string{
@@ -108,11 +108,11 @@ func TestFilterLabel(t *testing.T) {
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-2",
 							Address: "localhost",
 							Metadata: map[string]string{
@@ -127,21 +127,21 @@ func TestFilterLabel(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-1",
 							Address: "localhost",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-2",
 							Address: "localhost",
 						},
@@ -187,11 +187,11 @@ func TestFilterVersion(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 				},
@@ -201,11 +201,11 @@ func TestFilterVersion(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 				},

--- a/client/selector/router/router.go
+++ b/client/selector/router/router.go
@@ -101,7 +101,7 @@ func (r *routerSelector) getRoutes(service string) ([]router.Route, error) {
 		return nil, selector.ErrNoneAvailable
 	}
 
-	var routes []router.Route
+  routes := make([]router.Route, 0, len(pbRoutes.Routes))
 
 	// convert from pb to []*router.Route
 	for _, r := range pbRoutes.Routes {

--- a/client/selector/router/router.go
+++ b/client/selector/router/router.go
@@ -101,7 +101,7 @@ func (r *routerSelector) getRoutes(service string) ([]router.Route, error) {
 		return nil, selector.ErrNoneAvailable
 	}
 
-  routes := make([]router.Route, 0, len(pbRoutes.Routes))
+	routes := make([]router.Route, 0, len(pbRoutes.Routes))
 
 	// convert from pb to []*router.Route
 	for _, r := range pbRoutes.Routes {

--- a/client/selector/strategy.go
+++ b/client/selector/strategy.go
@@ -14,7 +14,7 @@ func init() {
 
 // Random is a random strategy algorithm for node selection
 func Random(services []*registry.Service) Next {
-	var nodes []*registry.Node
+  nodes := make([]*registry.Node, 0, len(services))
 
 	for _, service := range services {
 		nodes = append(nodes, service.Nodes...)
@@ -32,7 +32,7 @@ func Random(services []*registry.Service) Next {
 
 // RoundRobin is a roundrobin strategy algorithm for node selection
 func RoundRobin(services []*registry.Service) Next {
-	var nodes []*registry.Node
+  nodes := make([]*registry.Node, 0, len(services))
 
 	for _, service := range services {
 		nodes = append(nodes, service.Nodes...)

--- a/client/selector/strategy.go
+++ b/client/selector/strategy.go
@@ -14,7 +14,7 @@ func init() {
 
 // Random is a random strategy algorithm for node selection
 func Random(services []*registry.Service) Next {
-  nodes := make([]*registry.Node, 0, len(services))
+	nodes := make([]*registry.Node, 0, len(services))
 
 	for _, service := range services {
 		nodes = append(nodes, service.Nodes...)
@@ -32,7 +32,7 @@ func Random(services []*registry.Service) Next {
 
 // RoundRobin is a roundrobin strategy algorithm for node selection
 func RoundRobin(services []*registry.Service) Next {
-  nodes := make([]*registry.Node, 0, len(services))
+	nodes := make([]*registry.Node, 0, len(services))
 
 	for _, service := range services {
 		nodes = append(nodes, service.Nodes...)

--- a/client/selector/strategy_test.go
+++ b/client/selector/strategy_test.go
@@ -8,29 +8,29 @@ import (
 
 func TestStrategies(t *testing.T) {
 	testData := []*registry.Service{
-		&registry.Service{
+		{
 			Name:    "test1",
 			Version: "latest",
 			Nodes: []*registry.Node{
-				&registry.Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:1001",
 				},
-				&registry.Node{
+				{
 					Id:      "test1-2",
 					Address: "10.0.0.2:1002",
 				},
 			},
 		},
-		&registry.Service{
+		{
 			Name:    "test1",
 			Version: "default",
 			Nodes: []*registry.Node{
-				&registry.Node{
+				{
 					Id:      "test1-3",
 					Address: "10.0.0.3:1003",
 				},
-				&registry.Node{
+				{
 					Id:      "test1-4",
 					Address: "10.0.0.4:1004",
 				},

--- a/common_test.go
+++ b/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -153,7 +153,7 @@ func (m *memory) reload() error {
 }
 
 func (m *memory) update() {
-  watchers := make([]*watcher, 0, len(m.watchers))
+	watchers := make([]*watcher, 0, len(m.watchers))
 
 	m.RLock()
 	for _, w := range m.watchers {

--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -153,7 +153,7 @@ func (m *memory) reload() error {
 }
 
 func (m *memory) update() {
-	var watchers []*watcher
+  watchers := make([]*watcher, 0, len(m.watchers))
 
 	m.RLock()
 	for _, w := range m.watchers {

--- a/config/reader/json/values_test.go
+++ b/config/reader/json/values_test.go
@@ -62,7 +62,7 @@ func TestStructArray(t *testing.T) {
 		{
 			[]byte(`[{"foo": "bar"}]`),
 			emptyTSlice,
-			[]T{T{Foo: "bar"}},
+			[]T{{Foo: "bar"}},
 		},
 	}
 

--- a/config/source/etcd/etcd.go
+++ b/config/source/etcd/etcd.go
@@ -38,7 +38,7 @@ func (c *etcd) Read() (*source.ChangeSet, error) {
 		return nil, fmt.Errorf("source not found: %s", c.prefix)
 	}
 
-  kvs := make([]*mvccpb.KeyValue, 0, len(rsp.Kvs))
+	kvs := make([]*mvccpb.KeyValue, 0, len(rsp.Kvs))
 	for _, v := range rsp.Kvs {
 		kvs = append(kvs, (*mvccpb.KeyValue)(v))
 	}

--- a/config/source/etcd/etcd.go
+++ b/config/source/etcd/etcd.go
@@ -38,7 +38,7 @@ func (c *etcd) Read() (*source.ChangeSet, error) {
 		return nil, fmt.Errorf("source not found: %s", c.prefix)
 	}
 
-	var kvs []*mvccpb.KeyValue
+  kvs := make([]*mvccpb.KeyValue, 0, len(rsp.Kvs))
 	for _, v := range rsp.Kvs {
 		kvs = append(kvs, (*mvccpb.KeyValue)(v))
 	}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestErrors(t *testing.T) {
 	testData := []*Error{
-		&Error{
+		{
 			Id:     "test",
 			Code:   500,
 			Detail: "Internal server error",

--- a/monitor/default.go
+++ b/monitor/default.go
@@ -140,7 +140,7 @@ func (m *monitor) reap() {
 	defer m.Unlock()
 
 	// range over our watched services
-	for service, _ := range m.services {
+	for service := range m.services {
 		// check if the service exists in the registry
 		if !serviceMap[service] {
 			// if not, delete it in our status map
@@ -195,14 +195,14 @@ func (m *monitor) run() {
 			serviceMap := make(map[string]bool)
 
 			m.RLock()
-			for service, _ := range m.services {
+			for service := range m.services {
 				serviceMap[service] = true
 			}
 			m.RUnlock()
 
 			go func() {
 				// check the status of all watched services
-				for service, _ := range serviceMap {
+				for service := range serviceMap {
 					select {
 					case <-m.exit:
 						return
@@ -307,7 +307,7 @@ func (m *monitor) Stop() error {
 		return nil
 	default:
 		close(m.exit)
-		for s, _ := range m.services {
+		for s := range m.services {
 			delete(m.services, s)
 		}
 		m.registry.Stop()

--- a/network/node.go
+++ b/network/node.go
@@ -158,8 +158,8 @@ func (n *node) Nodes() []Node {
 
 	visited := n.walk(untilNoMorePeers, justWalk)
 
-	var nodes []Node
-	// collect all the nodes and return them
+  nodes := make([]Node, 0, len(visited))
+  // collect all the nodes and return them
 	for _, node := range visited {
 		nodes = append(nodes, node)
 	}
@@ -282,8 +282,9 @@ func (n *node) Peers() []Node {
 	n.RLock()
 	defer n.RUnlock()
 
-	var peers []Node
-	for _, nodePeer := range n.peers {
+  peers := make([]Node, 0, len(n.peers))
+
+  for _, nodePeer := range n.peers {
 		peer := nodePeer.getTopology(MaxDepth)
 		peers = append(peers, peer)
 	}

--- a/network/node.go
+++ b/network/node.go
@@ -158,8 +158,8 @@ func (n *node) Nodes() []Node {
 
 	visited := n.walk(untilNoMorePeers, justWalk)
 
-  nodes := make([]Node, 0, len(visited))
-  // collect all the nodes and return them
+	nodes := make([]Node, 0, len(visited))
+	// collect all the nodes and return them
 	for _, node := range visited {
 		nodes = append(nodes, node)
 	}
@@ -282,9 +282,9 @@ func (n *node) Peers() []Node {
 	n.RLock()
 	defer n.RUnlock()
 
-  peers := make([]Node, 0, len(n.peers))
+	peers := make([]Node, 0, len(n.peers))
 
-  for _, nodePeer := range n.peers {
+	for _, nodePeer := range n.peers {
 		peer := nodePeer.getTopology(MaxDepth)
 		peers = append(peers, peer)
 	}

--- a/network/resolver/dns/dns.go
+++ b/network/resolver/dns/dns.go
@@ -27,7 +27,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		return nil, err
 	}
 
-  records := make([]*resolver.Record, 0, len(addrs))
+	records := make([]*resolver.Record, 0, len(addrs))
 
 	for _, addr := range addrs {
 		// join resolved record with port

--- a/network/resolver/dns/dns.go
+++ b/network/resolver/dns/dns.go
@@ -27,7 +27,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		return nil, err
 	}
 
-	var records []*resolver.Record
+  records := make([]*resolver.Record, 0, len(addrs))
 
 	for _, addr := range addrs {
 		// join resolved record with port

--- a/network/resolver/dnssrv/dnssrv.go
+++ b/network/resolver/dnssrv/dnssrv.go
@@ -17,7 +17,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	var records []*resolver.Record
+  records := make([]*resolver.Record, 0, len(addrs))
 	for _, addr := range addrs {
 		address := addr.Target
 		if addr.Port > 0 {

--- a/network/resolver/dnssrv/dnssrv.go
+++ b/network/resolver/dnssrv/dnssrv.go
@@ -17,7 +17,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-  records := make([]*resolver.Record, 0, len(addrs))
+	records := make([]*resolver.Record, 0, len(addrs))
 	for _, addr := range addrs {
 		address := addr.Target
 		if addr.Port > 0 {

--- a/network/resolver/static/static.go
+++ b/network/resolver/static/static.go
@@ -21,7 +21,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		}, nil
 	}
 
-	var records []*resolver.Record
+  records := make([]*resolver.Record, 0, len(r.Nodes))
 
 	for _, node := range r.Nodes {
 		records = append(records, &resolver.Record{

--- a/network/resolver/static/static.go
+++ b/network/resolver/static/static.go
@@ -21,7 +21,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		}, nil
 	}
 
-  records := make([]*resolver.Record, 0, len(r.Nodes))
+	records := make([]*resolver.Record, 0, len(r.Nodes))
 
 	for _, node := range r.Nodes {
 		records = append(records, &resolver.Record{

--- a/network/service/handler/handler.go
+++ b/network/service/handler/handler.go
@@ -29,7 +29,7 @@ func flatten(n network.Node, visited map[string]bool) []network.Node {
 	}
 
 	// create new list of nodes
-  nodes := make([]network.Node, 0, len(n.Peers()))
+	nodes := make([]network.Node, 0, len(n.Peers()))
 
 	// check if already visited
 	if visited[n.Id()] == false {
@@ -171,7 +171,7 @@ func (n *Network) Routes(ctx context.Context, req *pbNet.RoutesRequest, resp *pb
 		return errors.InternalServerError("go.micro.network", "failed to list routes: %s", err)
 	}
 
-  respRoutes := make([]*pbRtr.Route, 0, len(routes))
+	respRoutes := make([]*pbRtr.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pbRtr.Route{
 			Service: route.Service,

--- a/network/service/handler/handler.go
+++ b/network/service/handler/handler.go
@@ -29,7 +29,7 @@ func flatten(n network.Node, visited map[string]bool) []network.Node {
 	}
 
 	// create new list of nodes
-	var nodes []network.Node
+  nodes := make([]network.Node, 0, len(n.Peers()))
 
 	// check if already visited
 	if visited[n.Id()] == false {
@@ -171,7 +171,7 @@ func (n *Network) Routes(ctx context.Context, req *pbNet.RoutesRequest, resp *pb
 		return errors.InternalServerError("go.micro.network", "failed to list routes: %s", err)
 	}
 
-	var respRoutes []*pbRtr.Route
+  respRoutes := make([]*pbRtr.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pbRtr.Route{
 			Service: route.Service,

--- a/proxy/http/http.go
+++ b/proxy/http/http.go
@@ -113,7 +113,7 @@ func (p *Proxy) ServeRequest(ctx context.Context, req server.Request, rsp server
 
 		// set response headers
 		hdr = map[string]string{}
-		for k, _ := range hrsp.Header {
+		for k := range hrsp.Header {
 			hdr[k] = hrsp.Header.Get(k)
 		}
 		// write the header

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -82,7 +82,7 @@ func readLoop(r server.Request, s client.Stream) error {
 
 // toNodes returns a list of node addresses from given routes
 func toNodes(routes []router.Route) []string {
-  nodes := make([]string, 0, len(routes))
+	nodes := make([]string, 0, len(routes))
 	for _, node := range routes {
 		address := node.Address
 		if len(node.Gateway) > 0 {
@@ -94,7 +94,7 @@ func toNodes(routes []router.Route) []string {
 }
 
 func toSlice(r map[uint64]router.Route) []router.Route {
-  routes := make([]router.Route, 0, len(r))
+	routes := make([]router.Route, 0, len(r))
 	for _, v := range r {
 		routes = append(routes, v)
 	}
@@ -165,11 +165,11 @@ func (p *Proxy) cacheRoutes(service string) ([]router.Route, error) {
 // refreshMetrics will refresh any metrics for our local cached routes.
 // we may not receive new watch events for these as they change.
 func (p *Proxy) refreshMetrics() {
-  services := make([]string, 0, len(p.Routes))
+	services := make([]string, 0, len(p.Routes))
 
 	// get a list of services to update
 	p.RLock()
-	for service, _ := range p.Routes {
+	for service := range p.Routes {
 		services = append(services, service)
 	}
 	p.RUnlock()

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -82,7 +82,7 @@ func readLoop(r server.Request, s client.Stream) error {
 
 // toNodes returns a list of node addresses from given routes
 func toNodes(routes []router.Route) []string {
-	var nodes []string
+  nodes := make([]string, 0, len(routes))
 	for _, node := range routes {
 		address := node.Address
 		if len(node.Gateway) > 0 {
@@ -94,7 +94,7 @@ func toNodes(routes []router.Route) []string {
 }
 
 func toSlice(r map[uint64]router.Route) []router.Route {
-	var routes []router.Route
+  routes := make([]router.Route, 0, len(r))
 	for _, v := range r {
 		routes = append(routes, v)
 	}
@@ -165,7 +165,7 @@ func (p *Proxy) cacheRoutes(service string) ([]router.Route, error) {
 // refreshMetrics will refresh any metrics for our local cached routes.
 // we may not receive new watch events for these as they change.
 func (p *Proxy) refreshMetrics() {
-	var services []string
+  services := make([]string, 0, len(p.Routes))
 
 	// get a list of services to update
 	p.RLock()

--- a/registry/encoding_test.go
+++ b/registry/encoding_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestEncoding(t *testing.T) {
 	testData := []*mdnsTxt{
-		&mdnsTxt{
+		{
 			Version: "1.0.0",
 			Metadata: map[string]string{
 				"foo": "bar",
 			},
 			Endpoints: []*Endpoint{
-				&Endpoint{
+				{
 					Name: "endpoint1",
 					Request: &Value{
 						Name: "request",

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -282,7 +282,7 @@ func (m *mdnsRegistry) GetService(service string) ([]*Service, error) {
 	<-done
 
 	// create list and return
-	var services []*Service
+  services := make([]*Service, 0, len(serviceMap))
 
 	for _, service := range serviceMap {
 		services = append(services, service)

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -282,7 +282,7 @@ func (m *mdnsRegistry) GetService(service string) ([]*Service, error) {
 	<-done
 
 	// create list and return
-  services := make([]*Service, 0, len(serviceMap))
+	services := make([]*Service, 0, len(serviceMap))
 
 	for _, service := range serviceMap {
 		services = append(services, service)

--- a/registry/mdns_test.go
+++ b/registry/mdns_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestMDNS(t *testing.T) {
 	testData := []*Service{
-		&Service{
+		{
 			Name:    "test1",
 			Version: "1.0.1",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:10001",
 					Metadata: map[string]string{
@@ -20,11 +20,11 @@ func TestMDNS(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test2",
 			Version: "1.0.2",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test2-1",
 					Address: "10.0.0.2:10002",
 					Metadata: map[string]string{
@@ -33,11 +33,11 @@ func TestMDNS(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test3",
 			Version: "1.0.3",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test3-1",
 					Address: "10.0.0.3:10003",
 					Metadata: map[string]string{

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -111,7 +111,7 @@ func (m *Registry) ttlPrune() {
 }
 
 func (m *Registry) sendEvent(r *registry.Result) {
-  watchers := make([]*Watcher, 0, len(m.Watchers))
+	watchers := make([]*Watcher, 0, len(m.Watchers))
 
 	m.RLock()
 	for _, w := range m.Watchers {
@@ -165,7 +165,7 @@ func (m *Registry) GetService(name string) ([]*registry.Service, error) {
 }
 
 func (m *Registry) ListServices() ([]*registry.Service, error) {
-  services := make([]*registry.Service, 0, len(m.Services))
+	services := make([]*registry.Service, 0, len(m.Services))
 	m.RLock()
 	for _, service := range m.Services {
 		services = append(services, service...)

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -111,7 +111,7 @@ func (m *Registry) ttlPrune() {
 }
 
 func (m *Registry) sendEvent(r *registry.Result) {
-	var watchers []*Watcher
+  watchers := make([]*Watcher, 0, len(m.Watchers))
 
 	m.RLock()
 	for _, w := range m.Watchers {
@@ -165,7 +165,7 @@ func (m *Registry) GetService(name string) ([]*registry.Service, error) {
 }
 
 func (m *Registry) ListServices() ([]*registry.Service, error) {
-	var services []*registry.Service
+  services := make([]*registry.Service, 0, len(m.Services))
 	m.RLock()
 	for _, service := range m.Services {
 		services = append(services, service...)

--- a/registry/memory/memory_test.go
+++ b/registry/memory/memory_test.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",
@@ -44,7 +44,7 @@ var (
 				},
 			},
 		},
-		"bar": []*registry.Service{
+		"bar": {
 			{
 				Name:    "bar",
 				Version: "default",

--- a/registry/service/service.go
+++ b/registry/service/service.go
@@ -89,7 +89,7 @@ func (s *serviceRegistry) GetService(name string) ([]*registry.Service, error) {
 		return nil, err
 	}
 
-	var services []*registry.Service
+  services := make([]*registry.Service, 0, len(rsp.Services))
 	for _, service := range rsp.Services {
 		services = append(services, ToService(service))
 	}
@@ -102,7 +102,7 @@ func (s *serviceRegistry) ListServices() ([]*registry.Service, error) {
 		return nil, err
 	}
 
-	var services []*registry.Service
+  services := make([]*registry.Service, 0, len(rsp.Services))
 	for _, service := range rsp.Services {
 		services = append(services, ToService(service))
 	}

--- a/registry/service/service.go
+++ b/registry/service/service.go
@@ -89,7 +89,7 @@ func (s *serviceRegistry) GetService(name string) ([]*registry.Service, error) {
 		return nil, err
 	}
 
-  services := make([]*registry.Service, 0, len(rsp.Services))
+	services := make([]*registry.Service, 0, len(rsp.Services))
 	for _, service := range rsp.Services {
 		services = append(services, ToService(service))
 	}
@@ -102,7 +102,7 @@ func (s *serviceRegistry) ListServices() ([]*registry.Service, error) {
 		return nil, err
 	}
 
-  services := make([]*registry.Service, 0, len(rsp.Services))
+	services := make([]*registry.Service, 0, len(rsp.Services))
 	for _, service := range rsp.Services {
 		services = append(services, ToService(service))
 	}

--- a/registry/service/util.go
+++ b/registry/service/util.go
@@ -10,7 +10,7 @@ func values(v []*registry.Value) []*pb.Value {
 		return []*pb.Value{}
 	}
 
-  vs := make([]*pb.Value, 0, len(v))
+	vs := make([]*pb.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &pb.Value{
 			Name:   vi.Name,
@@ -26,7 +26,7 @@ func toValues(v []*pb.Value) []*registry.Value {
 		return []*registry.Value{}
 	}
 
-  vs := make([]*registry.Value, 0, len(v))
+	vs := make([]*registry.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &registry.Value{
 			Name:   vi.Name,
@@ -38,8 +38,8 @@ func toValues(v []*pb.Value) []*registry.Value {
 }
 
 func ToProto(s *registry.Service) *pb.Service {
-  endpoints := make([]*pb.Endpoint, 0, len(s.Endpoints))
-  for _, ep := range s.Endpoints {
+	endpoints := make([]*pb.Endpoint, 0, len(s.Endpoints))
+	for _, ep := range s.Endpoints {
 		var request, response *pb.Value
 
 		if ep.Request != nil {
@@ -66,7 +66,7 @@ func ToProto(s *registry.Service) *pb.Service {
 		})
 	}
 
-  nodes := make([]*pb.Node, 0, len(s.Nodes))
+	nodes := make([]*pb.Node, 0, len(s.Nodes))
 
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &pb.Node{
@@ -86,7 +86,7 @@ func ToProto(s *registry.Service) *pb.Service {
 }
 
 func ToService(s *pb.Service) *registry.Service {
-  endpoints := make([]*registry.Endpoint, 0, len(s.Endpoints))
+	endpoints := make([]*registry.Endpoint, 0, len(s.Endpoints))
 	for _, ep := range s.Endpoints {
 		var request, response *registry.Value
 
@@ -114,7 +114,7 @@ func ToService(s *pb.Service) *registry.Service {
 		})
 	}
 
-  nodes := make([]*registry.Node, 0, len(s.Nodes))
+	nodes := make([]*registry.Node, 0, len(s.Nodes))
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &registry.Node{
 			Id:       node.Id,

--- a/registry/service/util.go
+++ b/registry/service/util.go
@@ -10,7 +10,7 @@ func values(v []*registry.Value) []*pb.Value {
 		return []*pb.Value{}
 	}
 
-	var vs []*pb.Value
+  vs := make([]*pb.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &pb.Value{
 			Name:   vi.Name,
@@ -26,7 +26,7 @@ func toValues(v []*pb.Value) []*registry.Value {
 		return []*registry.Value{}
 	}
 
-	var vs []*registry.Value
+  vs := make([]*registry.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &registry.Value{
 			Name:   vi.Name,
@@ -38,8 +38,8 @@ func toValues(v []*pb.Value) []*registry.Value {
 }
 
 func ToProto(s *registry.Service) *pb.Service {
-	var endpoints []*pb.Endpoint
-	for _, ep := range s.Endpoints {
+  endpoints := make([]*pb.Endpoint, 0, len(s.Endpoints))
+  for _, ep := range s.Endpoints {
 		var request, response *pb.Value
 
 		if ep.Request != nil {
@@ -66,7 +66,7 @@ func ToProto(s *registry.Service) *pb.Service {
 		})
 	}
 
-	var nodes []*pb.Node
+  nodes := make([]*pb.Node, 0, len(s.Nodes))
 
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &pb.Node{
@@ -86,7 +86,7 @@ func ToProto(s *registry.Service) *pb.Service {
 }
 
 func ToService(s *pb.Service) *registry.Service {
-	var endpoints []*registry.Endpoint
+  endpoints := make([]*registry.Endpoint, 0, len(s.Endpoints))
 	for _, ep := range s.Endpoints {
 		var request, response *registry.Value
 
@@ -114,7 +114,7 @@ func ToService(s *pb.Service) *registry.Service {
 		})
 	}
 
-	var nodes []*registry.Node
+  nodes := make([]*registry.Node, 0, len(s.Nodes))
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &registry.Node{
 			Id:       node.Id,

--- a/registry/watcher_test.go
+++ b/registry/watcher_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestWatcher(t *testing.T) {
 	testData := []*Service{
-		&Service{
+		{
 			Name:    "test1",
 			Version: "1.0.1",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:10001",
 					Metadata: map[string]string{
@@ -19,11 +19,11 @@ func TestWatcher(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test2",
 			Version: "1.0.2",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test2-1",
 					Address: "10.0.0.2:10002",
 					Metadata: map[string]string{
@@ -32,11 +32,11 @@ func TestWatcher(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test3",
 			Version: "1.0.3",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test3-1",
 					Address: "10.0.0.3:10003",
 					Metadata: map[string]string{

--- a/router/handler/router.go
+++ b/router/handler/router.go
@@ -22,7 +22,7 @@ func (r *Router) Lookup(ctx context.Context, req *pb.LookupRequest, resp *pb.Loo
 		return errors.InternalServerError("go.micro.router", "failed to lookup routes: %v", err)
 	}
 
-	var respRoutes []*pb.Route
+  respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,

--- a/router/handler/router.go
+++ b/router/handler/router.go
@@ -22,7 +22,7 @@ func (r *Router) Lookup(ctx context.Context, req *pb.LookupRequest, resp *pb.Loo
 		return errors.InternalServerError("go.micro.router", "failed to lookup routes: %v", err)
 	}
 
-  respRoutes := make([]*pb.Route, 0, len(routes))
+	respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,

--- a/router/handler/table.go
+++ b/router/handler/table.go
@@ -70,7 +70,7 @@ func (t *Table) List(ctx context.Context, req *pb.Request, resp *pb.ListResponse
 		return errors.InternalServerError("go.micro.router", "failed to list routes: %s", err)
 	}
 
-	var respRoutes []*pb.Route
+  respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,
@@ -95,7 +95,7 @@ func (t *Table) Query(ctx context.Context, req *pb.QueryRequest, resp *pb.QueryR
 		return errors.InternalServerError("go.micro.router", "failed to lookup routes: %s", err)
 	}
 
-	var respRoutes []*pb.Route
+  respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,

--- a/router/handler/table.go
+++ b/router/handler/table.go
@@ -70,7 +70,7 @@ func (t *Table) List(ctx context.Context, req *pb.Request, resp *pb.ListResponse
 		return errors.InternalServerError("go.micro.router", "failed to list routes: %s", err)
 	}
 
-  respRoutes := make([]*pb.Route, 0, len(routes))
+	respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,
@@ -95,7 +95,7 @@ func (t *Table) Query(ctx context.Context, req *pb.QueryRequest, resp *pb.QueryR
 		return errors.InternalServerError("go.micro.router", "failed to lookup routes: %s", err)
 	}
 
-  respRoutes := make([]*pb.Route, 0, len(routes))
+	respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,

--- a/router/service/service.go
+++ b/router/service/service.go
@@ -188,7 +188,7 @@ func (s *svc) Advertise() (<-chan *router.Advert, error) {
 
 // Process processes incoming adverts
 func (s *svc) Process(advert *router.Advert) error {
-  events := make([]*pb.Event, 0, len(advert.Events))
+	events := make([]*pb.Event, 0, len(advert.Events))
 	for _, event := range advert.Events {
 		route := &pb.Route{
 			Service: event.Route.Service,
@@ -230,7 +230,7 @@ func (s *svc) Solicit() error {
 
 	// build events to advertise
 	events := make([]*router.Event, len(routes))
-	for i, _ := range events {
+	for i := range events {
 		events[i] = &router.Event{
 			Type:      router.Update,
 			Timestamp: time.Now(),

--- a/router/service/service.go
+++ b/router/service/service.go
@@ -188,7 +188,7 @@ func (s *svc) Advertise() (<-chan *router.Advert, error) {
 
 // Process processes incoming adverts
 func (s *svc) Process(advert *router.Advert) error {
-	var events []*pb.Event
+  events := make([]*pb.Event, 0, len(advert.Events))
 	for _, event := range advert.Events {
 		route := &pb.Route{
 			Service: event.Route.Service,

--- a/router/table.go
+++ b/router/table.go
@@ -194,9 +194,9 @@ func (t *table) Query(q ...QueryOption) ([]Route, error) {
 		return findRoutes(t.routes[opts.Service], opts.Address, opts.Gateway, opts.Network, opts.Router), nil
 	}
 
-  results := make([]Route, 0, len(t.routes))
+	results := make([]Route, 0, len(t.routes))
 
-  // search through all destinations
+	// search through all destinations
 	for _, routes := range t.routes {
 		results = append(results, findRoutes(routes, opts.Address, opts.Gateway, opts.Network, opts.Router)...)
 	}

--- a/router/table.go
+++ b/router/table.go
@@ -194,8 +194,9 @@ func (t *table) Query(q ...QueryOption) ([]Route, error) {
 		return findRoutes(t.routes[opts.Service], opts.Address, opts.Gateway, opts.Network, opts.Router), nil
 	}
 
-	var results []Route
-	// search through all destinations
+  results := make([]Route, 0, len(t.routes))
+
+  // search through all destinations
 	for _, routes := range t.routes {
 		results = append(results, findRoutes(routes, opts.Address, opts.Gateway, opts.Network, opts.Router)...)
 	}

--- a/runtime/default.go
+++ b/runtime/default.go
@@ -263,7 +263,7 @@ func (r *runtime) Update(s *Service) error {
 }
 
 func (r *runtime) List() ([]*Service, error) {
-  services := make([]*Service, 0, len(r.services))
+	services := make([]*Service, 0, len(r.services))
 	r.RLock()
 	defer r.RUnlock()
 

--- a/runtime/default.go
+++ b/runtime/default.go
@@ -263,7 +263,7 @@ func (r *runtime) Update(s *Service) error {
 }
 
 func (r *runtime) List() ([]*Service, error) {
-	var services []*Service
+  services := make([]*Service, 0, len(r.services))
 	r.RLock()
 	defer r.RUnlock()
 

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -580,7 +580,7 @@ func (g *grpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-  endpoints := make([]*registry.Endpoint, 0, len(handlerList))
+  endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
 	for _, n := range handlerList {
 		endpoints = append(endpoints, g.handlers[n].Endpoints()...)
 	}

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -580,7 +580,7 @@ func (g *grpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-  endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
+	endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
 	for _, n := range handlerList {
 		endpoints = append(endpoints, g.handlers[n].Endpoints()...)
 	}
@@ -621,7 +621,7 @@ func (g *grpcServer) Register() error {
 
 	g.registered = true
 
-	for sb, _ := range g.subscribers {
+	for sb := range g.subscribers {
 		handler := g.createSubHandler(sb, g.opts)
 		var opts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -580,7 +580,7 @@ func (g *grpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-	var endpoints []*registry.Endpoint
+  endpoints := make([]*registry.Endpoint, 0, len(handlerList))
 	for _, n := range handlerList {
 		endpoints = append(endpoints, g.handlers[n].Endpoints()...)
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -490,8 +490,9 @@ func (s *rpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-	var endpoints []*registry.Endpoint
-	for _, n := range handlerList {
+  endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
+
+  for _, n := range handlerList {
 		endpoints = append(endpoints, s.handlers[n].Endpoints()...)
 	}
 	for _, e := range subscriberList {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -490,9 +490,9 @@ func (s *rpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-  endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
+	endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
 
-  for _, n := range handlerList {
+	for _, n := range handlerList {
 		endpoints = append(endpoints, s.handlers[n].Endpoints()...)
 	}
 	for _, e := range subscriberList {
@@ -532,7 +532,7 @@ func (s *rpcServer) Register() error {
 
 	s.registered = true
 
-	for sb, _ := range s.subscribers {
+	for sb := range s.subscribers {
 		handler := s.createSubHandler(sb, s.opts)
 		var opts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {

--- a/store/cloudflare/cloudflare.go
+++ b/store/cloudflare/cloudflare.go
@@ -123,7 +123,7 @@ func (w *workersKV) List() ([]*store.Record, error) {
 		return nil, errors.New(messages)
 	}
 
-	var keys []string
+  keys := make([]string, 0, len(a.Result))
 
 	for _, r := range a.Result {
 		keys = append(keys, r.Name)

--- a/store/cloudflare/cloudflare.go
+++ b/store/cloudflare/cloudflare.go
@@ -123,7 +123,7 @@ func (w *workersKV) List() ([]*store.Record, error) {
 		return nil, errors.New(messages)
 	}
 
-  keys := make([]string, 0, len(a.Result))
+	keys := make([]string, 0, len(a.Result))
 
 	for _, r := range a.Result {
 		keys = append(keys, r.Name)

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -32,7 +32,7 @@ func (e *ekv) Read(keys ...string) ([]*store.Record, error) {
 		values = append(values, keyval.Kvs...)
 	}
 
-	var records []*store.Record
+  records := make([]*store.Record, 0, len(values))
 
 	for _, kv := range values {
 		records = append(records, &store.Record{

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -32,7 +32,7 @@ func (e *ekv) Read(keys ...string) ([]*store.Record, error) {
 		values = append(values, keyval.Kvs...)
 	}
 
-  records := make([]*store.Record, 0, len(values))
+	records := make([]*store.Record, 0, len(values))
 
 	for _, kv := range values {
 		records = append(records, &store.Record{

--- a/store/service/handler/handler.go
+++ b/store/service/handler/handler.go
@@ -30,7 +30,7 @@ func (s *Store) Read(ctx context.Context, req *pb.ReadRequest, rsp *pb.ReadRespo
 }
 
 func (s *Store) Write(ctx context.Context, req *pb.WriteRequest, rsp *pb.WriteResponse) error {
-	var records []*store.Record
+  records := make([]*store.Record, 0, len(req.Records))
 
 	for _, record := range req.Records {
 		records = append(records, &store.Record{

--- a/store/service/handler/handler.go
+++ b/store/service/handler/handler.go
@@ -30,7 +30,7 @@ func (s *Store) Read(ctx context.Context, req *pb.ReadRequest, rsp *pb.ReadRespo
 }
 
 func (s *Store) Write(ctx context.Context, req *pb.WriteRequest, rsp *pb.WriteResponse) error {
-  records := make([]*store.Record, 0, len(req.Records))
+	records := make([]*store.Record, 0, len(req.Records))
 
 	for _, record := range req.Records {
 		records = append(records, &store.Record{

--- a/store/service/service.go
+++ b/store/service/service.go
@@ -60,7 +60,7 @@ func (s *serviceStore) Read(keys ...string) ([]*store.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-  records := make([]*store.Record, 0, len(rsp.Records))
+	records := make([]*store.Record, 0, len(rsp.Records))
 	for _, val := range rsp.Records {
 		records = append(records, &store.Record{
 			Key:    val.Key,
@@ -73,9 +73,9 @@ func (s *serviceStore) Read(keys ...string) ([]*store.Record, error) {
 
 // Write a record
 func (s *serviceStore) Write(recs ...*store.Record) error {
-  records := make([]*pb.Record, 0, len(recs))
+	records := make([]*pb.Record, 0, len(recs))
 
-  for _, record := range recs {
+	for _, record := range recs {
 		records = append(records, &pb.Record{
 			Key:    record.Key,
 			Value:  record.Value,

--- a/store/service/service.go
+++ b/store/service/service.go
@@ -60,7 +60,7 @@ func (s *serviceStore) Read(keys ...string) ([]*store.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	var records []*store.Record
+  records := make([]*store.Record, 0, len(rsp.Records))
 	for _, val := range rsp.Records {
 		records = append(records, &store.Record{
 			Key:    val.Key,
@@ -73,9 +73,9 @@ func (s *serviceStore) Read(keys ...string) ([]*store.Record, error) {
 
 // Write a record
 func (s *serviceStore) Write(recs ...*store.Record) error {
-	var records []*pb.Record
+  records := make([]*pb.Record, 0, len(recs))
 
-	for _, record := range recs {
+  for _, record := range recs {
 		records = append(records, &pb.Record{
 			Key:    record.Key,
 			Value:  record.Value,

--- a/tunnel/default.go
+++ b/tunnel/default.go
@@ -589,7 +589,7 @@ func (t *tun) listen(link *link) {
 		}
 
 		// strip tunnel message header
-		for k, _ := range msg.Header {
+		for k := range msg.Header {
 			if strings.HasPrefix(k, "Micro-Tunnel") {
 				delete(msg.Header, k)
 			}
@@ -1185,7 +1185,7 @@ func (t *tun) Links() []Link {
 	t.RLock()
 	defer t.RUnlock()
 
-  links := make([]Link, 0, len(t.links))
+	links := make([]Link, 0, len(t.links))
 
 	for _, link := range t.links {
 		links = append(links, link)

--- a/tunnel/default.go
+++ b/tunnel/default.go
@@ -1185,7 +1185,7 @@ func (t *tun) Links() []Link {
 	t.RLock()
 	defer t.RUnlock()
 
-	var links []Link
+  links := make([]Link, 0, len(t.links))
 
 	for _, link := range t.links {
 		links = append(links, link)

--- a/web/service.go
+++ b/web/service.go
@@ -82,7 +82,7 @@ func (s *service) genSrv() *registry.Service {
 	return &registry.Service{
 		Name:    s.opts.Name,
 		Version: s.opts.Version,
-		Nodes: []*registry.Node{&registry.Node{
+		Nodes: []*registry.Node{{
 			Id:       s.opts.Id,
 			Address:  fmt.Sprintf("%s:%d", addr, port),
 			Metadata: s.opts.Metadata,


### PR DESCRIPTION
The size of a slice can be specified at the time of creation when its known. This can have significant impact on performance when a lot of appending to slices is happening.

Consider this benchmark:

```
package main
import "testing"

func BenchmarkNoPreallocate(b *testing.B) {
  b.ReportAllocs()
	e := make([]int64, 10, 10)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		// Don't preallocate initial slice
		var i []int64
		for _, el := range e {
			i = append(i, el)
		}
	}
}


func BenchmarkPreallocate(b *testing.B) {
  b.ReportAllocs()
	e := make([]int64, 10, 10)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		// Preallocate initial slice
		i := make([]int64, 0, len(e))
		for _, el := range e {
			i = append(i, el)
		}
	}
}

```

```
BenchmarkNoPreallocate-12    	 6262358	       316 ns/op	     248 B/op	       5 allocs/op
BenchmarkPreallocate-12      	39661172	        56.7 ns/op	      80 B/op	       1 allocs/op
```
go version go1.13.3 linux/amd64