### PR TITLE
add ability to filter routes based on headers

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -79,21 +79,6 @@ func newNetwork(opts ...Option) Network {
 		o(&options)
 	}
 
-	// init tunnel address to the network bind address
-	options.Tunnel.Init(
-		tunnel.Address(options.Address),
-	)
-
-	// init router Id to the network id
-	options.Router.Init(
-		router.Id(options.Id),
-	)
-
-	// create tunnel client with tunnel transport
-	tunTransport := tun.NewTransport(
-		tun.WithTunnel(options.Tunnel),
-	)
-
 	// set the address to a hashed address
 	hasher := fnv.New64()
 	hasher.Write([]byte(options.Address + options.Id))
@@ -110,6 +95,22 @@ func newNetwork(opts ...Option) Network {
 		advertise = options.Address
 		peerAddress = address
 	}
+
+	// init tunnel address to the network bind address
+	options.Tunnel.Init(
+		tunnel.Address(options.Address),
+	)
+
+	// init router Id to the network id
+	options.Router.Init(
+		router.Id(options.Id),
+		router.Address(peerAddress),
+	)
+
+	// create tunnel client with tunnel transport
+	tunTransport := tun.NewTransport(
+		tun.WithTunnel(options.Tunnel),
+	)
 
 	// server is network server
 	server := server.NewServer(


### PR DESCRIPTION
This PR enables route filtering based on headers:
- Micro-Gateway
- Micro-Router
- Micro-Network

Address is still difficult to do since we hash it. We should additionally add node metadata/labels to the routing table which woud allow flexible filtering on other fields also.

Using something like this from the command line:

```
MICRO_PROXY=go.micro.network micro call --metadata "Micro-Router=ea1ef7e5-6d26-4b0c-ade6-7002244a13eb" go.micro.registry Registry.GetService '{"service": "go.micro.network.dns"}'
```

Directionally to get to some endpoint we always want to use the origin Router. Gateway will likely introduce loops or pin the request badly.