### PR TITLE
used gofmt with -s flag on whole project

### DIFF
--- a/api/handler/api/util_test.go
+++ b/api/handler/api/util_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRequestToProto(t *testing.T) {
 	testData := []*http.Request{
-		&http.Request{
+		{
 			Method: "GET",
 			Header: http.Header{
 				"Header": []string{"test"},

--- a/api/handler/http/http_test.go
+++ b/api/handler/http/http_test.go
@@ -27,7 +27,7 @@ func testHttp(t *testing.T, path, service, ns string) {
 	s := &registry.Service{
 		Name: service,
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      service + "-1",
 				Address: l.Addr().String(),
 			},

--- a/broker/common_test.go
+++ b/broker/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/broker/http_broker_test.go
+++ b/broker/http_broker_test.go
@@ -125,7 +125,7 @@ func pub(be *testing.B, c int) {
 
 	for i := 0; i < c; i++ {
 		go func() {
-			for _ = range ch {
+			for range ch {
 				if err := b.Publish(topic, msg); err != nil {
 					be.Fatalf("Unexpected publish error: %v", err)
 				}

--- a/client/common_test.go
+++ b/client/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/client/grpc/grpc_test.go
+++ b/client/grpc/grpc_test.go
@@ -42,7 +42,7 @@ func TestGRPCClient(t *testing.T) {
 		Name:    "helloworld",
 		Version: "test",
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      "test-1",
 				Address: l.Addr().String(),
 			},

--- a/client/rpc_client_test.go
+++ b/client/rpc_client_test.go
@@ -143,7 +143,7 @@ func TestCallWrapper(t *testing.T) {
 		Name:    service,
 		Version: "latest",
 		Nodes: []*registry.Node{
-			&registry.Node{
+			{
 				Id:      id,
 				Address: address,
 			},

--- a/client/selector/common_test.go
+++ b/client/selector/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/client/selector/dns/dns.go
+++ b/client/selector/dns/dns.go
@@ -72,7 +72,7 @@ func (d *dnsSelector) Select(service string, opts ...selector.SelectOption) (sel
 	}
 
 	services := []*registry.Service{
-		&registry.Service{
+		{
 			Name:  service,
 			Nodes: nodes,
 		},

--- a/client/selector/filter_test.go
+++ b/client/selector/filter_test.go
@@ -14,20 +14,20 @@ func TestFilterEndpoint(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Baz.Bar",
 						},
 					},
@@ -38,20 +38,20 @@ func TestFilterEndpoint(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Endpoints: []*registry.Endpoint{
-						&registry.Endpoint{
+						{
 							Name: "Foo.Bar",
 						},
 					},
@@ -95,11 +95,11 @@ func TestFilterLabel(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-1",
 							Address: "localhost",
 							Metadata: map[string]string{
@@ -108,11 +108,11 @@ func TestFilterLabel(t *testing.T) {
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-2",
 							Address: "localhost",
 							Metadata: map[string]string{
@@ -127,21 +127,21 @@ func TestFilterLabel(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-1",
 							Address: "localhost",
 						},
 					},
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 					Nodes: []*registry.Node{
-						&registry.Node{
+						{
 							Id:      "test-2",
 							Address: "localhost",
 						},
@@ -187,11 +187,11 @@ func TestFilterVersion(t *testing.T) {
 	}{
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 				},
@@ -201,11 +201,11 @@ func TestFilterVersion(t *testing.T) {
 		},
 		{
 			services: []*registry.Service{
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.0.0",
 				},
-				&registry.Service{
+				{
 					Name:    "test",
 					Version: "1.1.0",
 				},

--- a/client/selector/strategy_test.go
+++ b/client/selector/strategy_test.go
@@ -8,29 +8,29 @@ import (
 
 func TestStrategies(t *testing.T) {
 	testData := []*registry.Service{
-		&registry.Service{
+		{
 			Name:    "test1",
 			Version: "latest",
 			Nodes: []*registry.Node{
-				&registry.Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:1001",
 				},
-				&registry.Node{
+				{
 					Id:      "test1-2",
 					Address: "10.0.0.2:1002",
 				},
 			},
 		},
-		&registry.Service{
+		{
 			Name:    "test1",
 			Version: "default",
 			Nodes: []*registry.Node{
-				&registry.Node{
+				{
 					Id:      "test1-3",
 					Address: "10.0.0.3:1003",
 				},
-				&registry.Node{
+				{
 					Id:      "test1-4",
 					Address: "10.0.0.4:1004",
 				},

--- a/common_test.go
+++ b/common_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	// mock data
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",

--- a/config/reader/json/values_test.go
+++ b/config/reader/json/values_test.go
@@ -62,7 +62,7 @@ func TestStructArray(t *testing.T) {
 		{
 			[]byte(`[{"foo": "bar"}]`),
 			emptyTSlice,
-			[]T{T{Foo: "bar"}},
+			[]T{{Foo: "bar"}},
 		},
 	}
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestErrors(t *testing.T) {
 	testData := []*Error{
-		&Error{
+		{
 			Id:     "test",
 			Code:   500,
 			Detail: "Internal server error",

--- a/monitor/default.go
+++ b/monitor/default.go
@@ -140,7 +140,7 @@ func (m *monitor) reap() {
 	defer m.Unlock()
 
 	// range over our watched services
-	for service, _ := range m.services {
+	for service := range m.services {
 		// check if the service exists in the registry
 		if !serviceMap[service] {
 			// if not, delete it in our status map
@@ -195,14 +195,14 @@ func (m *monitor) run() {
 			serviceMap := make(map[string]bool)
 
 			m.RLock()
-			for service, _ := range m.services {
+			for service := range m.services {
 				serviceMap[service] = true
 			}
 			m.RUnlock()
 
 			go func() {
 				// check the status of all watched services
-				for service, _ := range serviceMap {
+				for service := range serviceMap {
 					select {
 					case <-m.exit:
 						return
@@ -307,7 +307,7 @@ func (m *monitor) Stop() error {
 		return nil
 	default:
 		close(m.exit)
-		for s, _ := range m.services {
+		for s := range m.services {
 			delete(m.services, s)
 		}
 		m.registry.Stop()

--- a/proxy/http/http.go
+++ b/proxy/http/http.go
@@ -113,7 +113,7 @@ func (p *Proxy) ServeRequest(ctx context.Context, req server.Request, rsp server
 
 		// set response headers
 		hdr = map[string]string{}
-		for k, _ := range hrsp.Header {
+		for k := range hrsp.Header {
 			hdr[k] = hrsp.Header.Get(k)
 		}
 		// write the header

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -228,7 +228,7 @@ func (p *Proxy) refreshMetrics() {
 
 	// get a list of services to update
 	p.RLock()
-	for service, _ := range p.Routes {
+	for service := range p.Routes {
 		services = append(services, service)
 	}
 	p.RUnlock()

--- a/registry/encoding_test.go
+++ b/registry/encoding_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestEncoding(t *testing.T) {
 	testData := []*mdnsTxt{
-		&mdnsTxt{
+		{
 			Version: "1.0.0",
 			Metadata: map[string]string{
 				"foo": "bar",
 			},
 			Endpoints: []*Endpoint{
-				&Endpoint{
+				{
 					Name: "endpoint1",
 					Request: &Value{
 						Name: "request",

--- a/registry/mdns_test.go
+++ b/registry/mdns_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestMDNS(t *testing.T) {
 	testData := []*Service{
-		&Service{
+		{
 			Name:    "test1",
 			Version: "1.0.1",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:10001",
 					Metadata: map[string]string{
@@ -20,11 +20,11 @@ func TestMDNS(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test2",
 			Version: "1.0.2",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test2-1",
 					Address: "10.0.0.2:10002",
 					Metadata: map[string]string{
@@ -33,11 +33,11 @@ func TestMDNS(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test3",
 			Version: "1.0.3",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test3-1",
 					Address: "10.0.0.3:10003",
 					Metadata: map[string]string{

--- a/registry/memory/memory_test.go
+++ b/registry/memory/memory_test.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	testData = map[string][]*registry.Service{
-		"foo": []*registry.Service{
+		"foo": {
 			{
 				Name:    "foo",
 				Version: "1.0.0",
@@ -44,7 +44,7 @@ var (
 				},
 			},
 		},
-		"bar": []*registry.Service{
+		"bar": {
 			{
 				Name:    "bar",
 				Version: "default",

--- a/registry/watcher_test.go
+++ b/registry/watcher_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestWatcher(t *testing.T) {
 	testData := []*Service{
-		&Service{
+		{
 			Name:    "test1",
 			Version: "1.0.1",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test1-1",
 					Address: "10.0.0.1:10001",
 					Metadata: map[string]string{
@@ -19,11 +19,11 @@ func TestWatcher(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test2",
 			Version: "1.0.2",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test2-1",
 					Address: "10.0.0.2:10002",
 					Metadata: map[string]string{
@@ -32,11 +32,11 @@ func TestWatcher(t *testing.T) {
 				},
 			},
 		},
-		&Service{
+		{
 			Name:    "test3",
 			Version: "1.0.3",
 			Nodes: []*Node{
-				&Node{
+				{
 					Id:      "test3-1",
 					Address: "10.0.0.3:10003",
 					Metadata: map[string]string{

--- a/router/service/service.go
+++ b/router/service/service.go
@@ -230,7 +230,7 @@ func (s *svc) Solicit() error {
 
 	// build events to advertise
 	events := make([]*router.Event, len(routes))
-	for i, _ := range events {
+	for i := range events {
 		events[i] = &router.Event{
 			Type:      router.Update,
 			Timestamp: time.Now(),

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -621,7 +621,7 @@ func (g *grpcServer) Register() error {
 
 	g.registered = true
 
-	for sb, _ := range g.subscribers {
+	for sb := range g.subscribers {
 		handler := g.createSubHandler(sb, g.opts)
 		var opts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -531,7 +531,7 @@ func (s *rpcServer) Register() error {
 
 	s.registered = true
 
-	for sb, _ := range s.subscribers {
+	for sb := range s.subscribers {
 		handler := s.createSubHandler(sb, s.opts)
 		var opts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {

--- a/tunnel/default.go
+++ b/tunnel/default.go
@@ -590,7 +590,7 @@ func (t *tun) listen(link *link) {
 		}
 
 		// strip tunnel message header
-		for k, _ := range msg.Header {
+		for k := range msg.Header {
 			if strings.HasPrefix(k, "Micro-Tunnel") {
 				delete(msg.Header, k)
 			}

--- a/web/service.go
+++ b/web/service.go
@@ -82,7 +82,7 @@ func (s *service) genSrv() *registry.Service {
 	return &registry.Service{
 		Name:    s.opts.Name,
 		Version: s.opts.Version,
-		Nodes: []*registry.Node{&registry.Node{
+		Nodes: []*registry.Node{{
 			Id:       s.opts.Id,
 			Address:  fmt.Sprintf("%s:%d", addr, port),
 			Metadata: s.opts.Metadata,


### PR DESCRIPTION
I think its very reasonable to reformat the code base with gofmt -s as for example `for _ = range ch` or `for i, _ := range events ` is not something that is nice to read.