### PR TITLE
Change flap detection configuration

### DIFF
--- a/router/default.go
+++ b/router/default.go
@@ -21,7 +21,7 @@ const (
 	// AdvertiseFlushTick is time the yet unconsumed advertisements are flush i.e. discarded
 	AdvertiseFlushTick = 15 * time.Second
 	// AdvertSuppress is advert suppression threshold
-	AdvertSuppress = 250.0
+	AdvertSuppress = 200.0
 	// AdvertRecover is advert recovery threshold
 	AdvertRecover = 120.0
 	// DefaultAdvertTTL is default advertisement TTL

--- a/router/default.go
+++ b/router/default.go
@@ -21,15 +21,15 @@ const (
 	// AdvertiseFlushTick is time the yet unconsumed advertisements are flush i.e. discarded
 	AdvertiseFlushTick = 15 * time.Second
 	// AdvertSuppress is advert suppression threshold
-	AdvertSuppress = 2000.0
+	AdvertSuppress = 250.0
 	// AdvertRecover is advert recovery threshold
-	AdvertRecover = 500.0
+	AdvertRecover = 120.0
 	// DefaultAdvertTTL is default advertisement TTL
 	DefaultAdvertTTL = 1 * time.Minute
 	// Penalty for routes processed multiple times
-	Penalty = 2000.0
+	Penalty = 100.0
 	// PenaltyHalfLife is the time the advert penalty decays to half its value
-	PenaltyHalfLife = 2.5
+	PenaltyHalfLife = 30
 	// MaxSuppressTime defines time after which the suppressed advert is deleted
 	MaxSuppressTime = 5 * time.Minute
 )
@@ -396,21 +396,24 @@ func (r *router) advertiseEvents() error {
 					advert.isSuppressed = false
 				}
 
-				// max suppression time threshold has been reached, delete the advert
 				if advert.isSuppressed {
+					// max suppression time threshold has been reached, delete the advert
 					if time.Since(advert.suppressTime) > MaxSuppressTime {
 						delete(advertMap, key)
 						continue
 					}
+					// process next advert
+					continue
 				}
 
-				if !advert.isSuppressed {
-					e := new(Event)
-					*e = *(advert.event)
-					events = append(events, e)
-					// delete the advert from the advertMap
-					delete(advertMap, key)
-				}
+				// copy the event and append
+				e := new(Event)
+				// this is ok, because router.Event only contains builtin types
+				// and no references so this creates a deep struct copy of Event
+				*e = *(advert.event)
+				events = append(events, e)
+				// delete the advert from the advertMap
+				delete(advertMap, key)
 			}
 
 			// advertise all Update events to subscribers

--- a/router/default.go
+++ b/router/default.go
@@ -29,7 +29,7 @@ const (
 	// Penalty for routes processed multiple times
 	Penalty = 100.0
 	// PenaltyHalfLife is the time the advert penalty decays to half its value
-	PenaltyHalfLife = 30
+	PenaltyHalfLife = 30.0
 	// MaxSuppressTime defines time after which the suppressed advert is deleted
 	MaxSuppressTime = 5 * time.Minute
 )


### PR DESCRIPTION
This PR changes the configuration of flap detection in the following way:

```
SuppressionThreshold =2.5 x Penalty
RecoveryThreshold = 1.2 x Penalty or RecoveryThreshold = SuppressionThreshold / 2
HalfLife = 30s
```

What this means in laymen terms:
In order for the event to get suppressed there must be at least 3 consecutive events for the same route happening in 15 seconds (remember we tick every 5s).

Once the suppression threshold is reached it will take 30s to half **if no more events for the same route occur**

Sample timeline for the situation when 3 events happen for the same route:
1 event -> `event.Penalty = 100`
...
Penalty decaying to `89 = (100*(exp(-5*ln(2)/30))`
...
2 event -> `event.Penalty = 89 + 100 = 189`
...
Penalty decaying to `169 = (189*(exp(-5*ln(2)/30))`
...
3 event -> `event.Penalty = 169 + 100 = 269`
**EVENT SUPPRESSED**

If no event is received for the same route, the penalty will half to 269/2 = 134.5 in 30s:
```
269*(exp(-30*ln(2)/30)) = 134.5
```

In another 5s the penalty decays to the value lower than `RecoveryThreshold`:
```
134.5*(exp(-5*ln(2)/30)) = 119.8
```
**EVENT RECOVERED**

You can see a simple program that simulate the above described timeline in [Go playground](https://play.golang.org/p/cr8ztfU5zHS)