### PR TITLE
Flap detection vol2

### DIFF
--- a/router/default_test.go
+++ b/router/default_test.go
@@ -1,0 +1,127 @@
+package router
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/micro/go-micro/registry/memory"
+	"github.com/micro/go-micro/util/log"
+)
+
+func routerTestSetup() Router {
+	r := memory.NewRegistry()
+	return newRouter(Registry(r))
+}
+
+func TestRouterStartStop(t *testing.T) {
+	r := routerTestSetup()
+
+	log.Debugf("TestRouterStartStop STARTING")
+	if err := r.Start(); err != nil {
+		t.Errorf("failed to start router: %v", err)
+	}
+
+	_, err := r.Advertise()
+	if err != nil {
+		t.Errorf("failed to start advertising: %v", err)
+	}
+
+	if err := r.Stop(); err != nil {
+		t.Errorf("failed to stop router: %v", err)
+	}
+	log.Debugf("TestRouterStartStop STOPPED")
+}
+
+func TestRouterAdvertise(t *testing.T) {
+	r := routerTestSetup()
+
+	// lower the advertise interval
+	AdvertiseEventsTick = 500 * time.Millisecond
+	AdvertiseTableTick = 1 * time.Second
+
+	if err := r.Start(); err != nil {
+		t.Errorf("failed to start router: %v", err)
+	}
+
+	ch, err := r.Advertise()
+	if err != nil {
+		t.Errorf("failed to start advertising: %v", err)
+	}
+
+	// receive announce event
+	ann := <-ch
+	log.Debugf("received announce advert: %v", ann)
+
+	// Generate random unique routes
+	nrRoutes := 5
+	routes := make([]Route, nrRoutes)
+	route := Route{
+		Service: "dest.svc",
+		Address: "dest.addr",
+		Gateway: "dest.gw",
+		Network: "dest.network",
+		Router:  "src.router",
+		Link:    "det.link",
+		Metric:  10,
+	}
+
+	for i := 0; i < nrRoutes; i++ {
+		testRoute := route
+		testRoute.Service = fmt.Sprintf("%s-%d", route.Service, i)
+		routes[i] = testRoute
+	}
+
+	var advertErr error
+
+	errChan := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		for _, route := range routes {
+			log.Debugf("Creating route %v", route)
+			if err := r.Table().Create(route); err != nil {
+				log.Debugf("Failed to create route: %v", err)
+				errChan <- err
+				return
+			}
+		}
+	}()
+
+	var adverts int
+	doneChan := make(chan bool)
+
+	wg.Add(1)
+	go func() {
+		defer func() {
+			wg.Done()
+			doneChan <- true
+		}()
+		for advert := range ch {
+			select {
+			case advertErr = <-errChan:
+				t.Errorf("failed advertising events: %v", advertErr)
+			default:
+				// do nothing for now
+				log.Debugf("Router advert received: %v", advert)
+				adverts += len(advert.Events)
+			}
+			return
+		}
+	}()
+
+	<-doneChan
+
+	if adverts != nrRoutes {
+		t.Errorf("Expected %d adverts, received: %d", nrRoutes, adverts)
+	}
+
+	wg.Wait()
+
+	if err := r.Stop(); err != nil {
+		t.Errorf("failed to stop router: %v", err)
+	}
+}

--- a/router/table_test.go
+++ b/router/table_test.go
@@ -7,6 +7,7 @@ func testSetup() (*table, Route) {
 
 	route := Route{
 		Service: "dest.svc",
+		Address: "dest.addr",
 		Gateway: "dest.gw",
 		Network: "dest.network",
 		Router:  "src.router",


### PR DESCRIPTION
This PR improves on the work started in https://github.com/micro/go-micro/pull/914

It makes the flap detection code more readable and arguably also more correct.

The core algorithm has not changed. There are two changes:

* advert processing has been moved to dedicated method (`process()`) of a dedicated type (`adverts` which used to be called `advertMap`)
*we now suppress events as soon as they've been received from the table

**NOTE:** previously we only suppressed events when `AdvertiseEventsTick` time has been reached, which is set to `5s` and by which time the events may have decayed to the point of recovery -- we want to suppress them as soon as we can and potentially even remove them should they have reached `MaxSuppressTime` threshold. (**This threshold should probably be lowered to something like 1 minute from the current 5 minutes**)

There is a small program I wrote to play with this implementation available in [this gist](https://gist.github.com/milosgajdos83/4b20724acc124e0db78860c98ba8d5c7) which lets you play with the code by artificially simulating table events (these are stored in the `test.txt` file which is also present in the gist)