### PR TITLE
K8s list deployments

### DIFF
--- a/runtime/kubernetes/client/api/request.go
+++ b/runtime/kubernetes/client/api/request.go
@@ -103,7 +103,7 @@ func (r *Request) Body(in interface{}) *Request {
 // Params isused to set paramters on a request
 func (r *Request) Params(p *Params) *Request {
 	for k, v := range p.LabelSelector {
-		r.params.Add("labelSelectors", k+"="+v)
+		r.params.Add("labelSelector", k+"="+v)
 	}
 
 	return r

--- a/runtime/kubernetes/client/client.go
+++ b/runtime/kubernetes/client/client.go
@@ -90,7 +90,7 @@ func detectNamespace() (string, error) {
 	}
 }
 
-// UpdateDeployment
+// UpdateDeployment patches kubernetes deployment with metadata provided in body
 func (c *client) UpdateDeployment(name string, body interface{}) error {
 	return api.NewRequest(c.opts).
 		Patch().
@@ -101,7 +101,15 @@ func (c *client) UpdateDeployment(name string, body interface{}) error {
 		Error()
 }
 
-// ListDeployments
-func (c *client) ListDeployments() (*DeploymentList, error) {
-	return nil, nil
+// ListDeployments lists all kubernetes deployments with given labels
+func (c *client) ListDeployments(labels map[string]string) (*DeploymentList, error) {
+	var deployments DeploymentList
+	err := api.NewRequest(c.opts).
+		Get().
+		Resource("deployments").
+		Params(&api.Params{LabelSelector: labels}).
+		Do().
+		Into(&deployments)
+
+	return &deployments, err
 }

--- a/runtime/kubernetes/client/client.go
+++ b/runtime/kubernetes/client/client.go
@@ -100,3 +100,8 @@ func (c *client) UpdateDeployment(name string, body interface{}) error {
 		Do().
 		Error()
 }
+
+// ListDeployments
+func (c *client) ListDeployments() (*DeploymentList, error) {
+	return nil, nil
+}

--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -5,11 +5,13 @@ type Kubernetes interface {
 	// UpdateDeployment patches deployment annotations with new metadata
 	UpdateDeployment(string, interface{}) error
 	// ListDeployments lists all micro deployments
-	ListDeployments() (*DeploymentList, error)
+	ListDeployments(labels map[string]string) (*DeploymentList, error)
 }
 
 // Metadata defines api request metadata
 type Metadata struct {
+	Name        string            `json:"name,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -20,8 +22,8 @@ type DeploymentList struct {
 
 // Deployment is Kubernetes deployment
 type Deployment struct {
-	Name   string  `json:"name"`
-	Status *Status `json:"status"`
+	Metadata *Metadata `json:"metadata"`
+	Status   *Status   `json:"status"`
 }
 
 // Status is Kubernetes deployment status

--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -4,9 +4,28 @@ package client
 type Kubernetes interface {
 	// UpdateDeployment patches deployment annotations with new metadata
 	UpdateDeployment(string, interface{}) error
+	// ListDeployments lists all micro deployments
+	ListDeployments() (*DeploymentList, error)
 }
 
 // Metadata defines api request metadata
 type Metadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// DeploymentList
+type DeploymentList struct {
+	Items []Deployment `json:"items"`
+}
+
+// Deployment is Kubernetes deployment
+type Deployment struct {
+	Name   string  `json:"name"`
+	Status *Status `json:"status"`
+}
+
+// Status is Kubernetes deployment status
+type Status struct {
+	Replicas          int `json:"replicas"`
+	AvailableReplicas int `json:"availablereplicas"`
 }


### PR DESCRIPTION
Adds `ListDeployments` method to list `micro` deployments in Kubernetes runtime.

**NOTE:** For now this method is used on every tick to query K8s API and log the found deployments. We should probably not hammer K8s API every 10s, though, so let's discuss what the right time/tick should be.