### PR TITLE
Patch deployment spec metadata

### DIFF
--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -8,6 +8,16 @@ type Kubernetes interface {
 	ListDeployments(labels map[string]string) (*DeploymentList, error)
 }
 
+// Template is micro deployment template
+type Template struct {
+	Metadata *Metadata `json:"metadata,omitempty"`
+}
+
+// Spec defines micro deployment spec
+type Spec struct {
+	Template *Template `json:"template,omitempty"`
+}
+
 // Metadata defines api request metadata
 type Metadata struct {
 	Name        string            `json:"name,omitempty"`

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -116,7 +116,7 @@ func (k *kubernetes) Delete(s *runtime.Service) error {
 // Update the service in place
 func (k *kubernetes) Update(s *runtime.Service) error {
 	type body struct {
-		Metadata *client.Metadata `json:"metadata"`
+		Spec *client.Spec `json:"spec"`
 	}
 	// parse version into human readable timestamp
 	updateTimeStamp, err := strconv.ParseInt(s.Version, 10, 64)
@@ -126,9 +126,13 @@ func (k *kubernetes) Update(s *runtime.Service) error {
 	unixTimeUTC := time.Unix(updateTimeStamp, 0)
 	// metada which we will PATCH deployment with
 	reqBody := body{
-		Metadata: &client.Metadata{
-			Annotations: map[string]string{
-				"build": unixTimeUTC.Format(time.RFC3339),
+		Spec: &client.Spec{
+			Template: &client.Template{
+				Metadata: &client.Metadata{
+					Annotations: map[string]string{
+						"build": unixTimeUTC.Format(time.RFC3339),
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Originally we were patching metadata annotations which was not triggering Deployment rollout; this PR patches `spec.template.metadata.annotations` which should roll out new deployment.