### PR TITLE
Add the ability to only advertise local routes or don't advertise at all

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -147,6 +147,10 @@ const (
 	AdvertiseAll Strategy = iota
 	// AdvertiseBest advertises optimal routes to the network
 	AdvertiseBest
+	// AdvertiseLocal will only advertise the local routes
+	AdvertiseLocal
+	// AdvertiseNone will not advertise any routes
+	AdvertiseNone
 )
 
 // String returns human readable Strategy
@@ -156,6 +160,10 @@ func (s Strategy) String() string {
 		return "all"
 	case AdvertiseBest:
 		return "best"
+	case AdvertiseLocal:
+		return "local"
+	case AdvertiseNone:
+		return "none"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
This PR adds two new router advertise strategies; Local and None.

- AdvertiseLocal will only advertise the local routes. Related to https://github.com/micro/go-micro/issues/927
- AdvertiseNone will avoid advertising routes completely.

We now need to add the ability to set this as a flag/env var