### PR TITLE
preallocation of slices

### DIFF
--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -153,7 +153,7 @@ func (m *memory) reload() error {
 }
 
 func (m *memory) update() {
-	var watchers []*watcher
+	watchers := make([]*watcher, 0, len(m.watchers))
 
 	m.RLock()
 	for _, w := range m.watchers {

--- a/network/node.go
+++ b/network/node.go
@@ -158,7 +158,7 @@ func (n *node) Nodes() []Node {
 
 	visited := n.walk(untilNoMorePeers, justWalk)
 
-	var nodes []Node
+	nodes := make([]Node, 0, len(visited))
 	// collect all the nodes and return them
 	for _, node := range visited {
 		nodes = append(nodes, node)

--- a/network/resolver/dns/dns.go
+++ b/network/resolver/dns/dns.go
@@ -27,7 +27,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		return nil, err
 	}
 
-	var records []*resolver.Record
+	records := make([]*resolver.Record, 0, len(addrs))
 
 	for _, addr := range addrs {
 		// join resolved record with port

--- a/network/resolver/static/static.go
+++ b/network/resolver/static/static.go
@@ -21,7 +21,7 @@ func (r *Resolver) Resolve(name string) ([]*resolver.Record, error) {
 		}, nil
 	}
 
-	var records []*resolver.Record
+	records := make([]*resolver.Record, 0, len(r.Nodes))
 
 	for _, node := range r.Nodes {
 		records = append(records, &resolver.Record{

--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -341,7 +341,7 @@ func (e *etcdRegistry) GetService(name string) ([]*registry.Service, error) {
 		}
 	}
 
-	var services []*registry.Service
+	services := make([]*registry.Service, 0, len(serviceMap))
 	for _, service := range serviceMap {
 		services = append(services, service)
 	}
@@ -350,7 +350,6 @@ func (e *etcdRegistry) GetService(name string) ([]*registry.Service, error) {
 }
 
 func (e *etcdRegistry) ListServices() ([]*registry.Service, error) {
-	var services []*registry.Service
 	versions := make(map[string]*registry.Service)
 
 	ctx, cancel := context.WithTimeout(context.Background(), e.options.Timeout)
@@ -379,6 +378,7 @@ func (e *etcdRegistry) ListServices() ([]*registry.Service, error) {
 		v.Nodes = append(v.Nodes, sn.Nodes...)
 	}
 
+	services := make([]*registry.Service, 0, len(versions))
 	for _, service := range versions {
 		services = append(services, service)
 	}

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -292,7 +292,7 @@ func (m *mdnsRegistry) GetService(service string) ([]*Service, error) {
 	<-done
 
 	// create list and return
-	var services []*Service
+	services := make([]*Service, 0, len(serviceMap))
 
 	for _, service := range serviceMap {
 		services = append(services, service)

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -111,7 +111,7 @@ func (m *Registry) ttlPrune() {
 }
 
 func (m *Registry) sendEvent(r *registry.Result) {
-	var watchers []*Watcher
+	watchers := make([]*Watcher, 0, len(m.Watchers))
 
 	m.RLock()
 	for _, w := range m.Watchers {

--- a/registry/service/util.go
+++ b/registry/service/util.go
@@ -10,7 +10,7 @@ func values(v []*registry.Value) []*pb.Value {
 		return []*pb.Value{}
 	}
 
-	var vs []*pb.Value
+	vs := make([]*pb.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &pb.Value{
 			Name:   vi.Name,
@@ -26,7 +26,7 @@ func toValues(v []*pb.Value) []*registry.Value {
 		return []*registry.Value{}
 	}
 
-	var vs []*registry.Value
+	vs := make([]*registry.Value, 0, len(v))
 	for _, vi := range v {
 		vs = append(vs, &registry.Value{
 			Name:   vi.Name,
@@ -66,7 +66,7 @@ func ToProto(s *registry.Service) *pb.Service {
 		})
 	}
 
-	var nodes []*pb.Node
+	nodes := make([]*pb.Node, 0, len(s.Nodes))
 
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &pb.Node{
@@ -86,7 +86,7 @@ func ToProto(s *registry.Service) *pb.Service {
 }
 
 func ToService(s *pb.Service) *registry.Service {
-	var endpoints []*registry.Endpoint
+	endpoints := make([]*registry.Endpoint, 0, len(s.Endpoints))
 	for _, ep := range s.Endpoints {
 		var request, response *registry.Value
 
@@ -114,7 +114,7 @@ func ToService(s *pb.Service) *registry.Service {
 		})
 	}
 
-	var nodes []*registry.Node
+	nodes := make([]*registry.Node, 0, len(s.Nodes))
 	for _, node := range s.Nodes {
 		nodes = append(nodes, &registry.Node{
 			Id:       node.Id,

--- a/router/handler/table.go
+++ b/router/handler/table.go
@@ -70,7 +70,7 @@ func (t *Table) List(ctx context.Context, req *pb.Request, resp *pb.ListResponse
 		return errors.InternalServerError("go.micro.router", "failed to list routes: %s", err)
 	}
 
-	var respRoutes []*pb.Route
+	respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,
@@ -95,7 +95,7 @@ func (t *Table) Query(ctx context.Context, req *pb.QueryRequest, resp *pb.QueryR
 		return errors.InternalServerError("go.micro.router", "failed to lookup routes: %s", err)
 	}
 
-	var respRoutes []*pb.Route
+	respRoutes := make([]*pb.Route, 0, len(routes))
 	for _, route := range routes {
 		respRoute := &pb.Route{
 			Service: route.Service,

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -582,7 +582,7 @@ func (g *grpcServer) Register() error {
 		return subscriberList[i].topic > subscriberList[j].topic
 	})
 
-	var endpoints []*registry.Endpoint
+	endpoints := make([]*registry.Endpoint, 0, len(handlerList)+len(subscriberList))
 	for _, n := range handlerList {
 		endpoints = append(endpoints, g.handlers[n].Endpoints()...)
 	}


### PR DESCRIPTION
"While the Go does attempt to avoid reallocation by growing the capacity in advance, this sometimes isn't enough for longer slices. If the size of a slice is known at the time of its creation, it should be specified."