### PR TITLE
SignalChan provides a way to override micro's signal behavior

### DIFF
--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package micro
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/micro/cli"
@@ -31,6 +32,8 @@ type Options struct {
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
+
+	SignalChan chan os.Signal
 }
 
 func newOptions(opts ...Option) Options {
@@ -153,6 +156,20 @@ func Metadata(md map[string]string) Option {
 func Flags(flags ...cli.Flag) Option {
 	return func(o *Options) {
 		o.Cmd.App().Flags = append(o.Cmd.App().Flags, flags...)
+	}
+}
+
+// SignalChan replaces the signal handler with the channel provided to the
+// option; if this is not specified, a standard handler that traps TERM, INT
+// and QUIT will be installed.
+//
+// If you wish to have no signals handled, simply pass nil.
+func SignalChan(sigChan chan os.Signal) Option {
+	return func(o *Options) {
+		if sigChan == nil {
+			sigChan = make(chan os.Signal)
+		}
+		o.SignalChan = sigChan
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -168,8 +168,14 @@ func (s *service) Run() error {
 		return err
 	}
 
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	var ch chan os.Signal
+
+	if s.opts.SignalChan != nil {
+		ch = s.opts.SignalChan
+	} else {
+		ch = make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	}
 
 	select {
 	// wait on kill signal


### PR DESCRIPTION
If provided, it will use this provided channel and not install a signal
handler of its own.

This is the simplest approach I could think of.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>