### PR TITLE
Fix a runtime deadlock as well as fixing some graceful exiting issues

### DIFF
--- a/runtime/process/os/os.go
+++ b/runtime/process/os/os.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 
 	"github.com/micro/go-micro/runtime/process"
 )
@@ -23,6 +24,9 @@ func (p *Process) Fork(exe *process.Executable) (*process.PID, error) {
 	cmd := exec.Command(exe.Binary.Path, exe.Args...)
 	// set env vars
 	cmd.Env = append(cmd.Env, exe.Env...)
+
+	// create process group
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	in, err := cmd.StdinPipe()
 	if err != nil {
@@ -61,7 +65,16 @@ func (p *Process) Kill(pid *process.PID) error {
 		return err
 	}
 
-	return pr.Kill()
+	// now kill it
+	err = pr.Kill()
+
+	// kill the group
+	if pgid, err := syscall.Getpgid(id); err == nil {
+		syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+
+	// return the kill error
+	return err
 }
 
 func (p *Process) Wait(pid *process.PID) error {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -129,7 +129,12 @@ func (s *service) Stop() error {
 		if s.PID == nil {
 			return nil
 		}
-		return s.Process.Kill(s.PID)
+		// kill the process
+		err := s.Process.Kill(s.PID)
+		// wait for it to exit
+		s.Process.Wait(s.PID)
+		// return the kill error
+		return err
 	}
 }
 


### PR DESCRIPTION
This PR fixes:

- A runtime deadlock when calling Update since Delete/Create also lock
- Readds any output passed in via create initially so we preserve logging to stdout
- Waits for a process to die before exiting from Delete
- Kills child processes via the use of a group pid