### PR TITLE
Signal handling try #2: through the context

### DIFF
--- a/options.go
+++ b/options.go
@@ -31,6 +31,8 @@ type Options struct {
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
+
+	Signal bool
 }
 
 func newOptions(opts ...Option) Options {
@@ -42,6 +44,7 @@ func newOptions(opts ...Option) Options {
 		Registry:  registry.DefaultRegistry,
 		Transport: transport.DefaultTransport,
 		Context:   context.Background(),
+		Signal:    true,
 	}
 
 	for _, o := range opts {
@@ -78,6 +81,15 @@ func Client(c client.Client) Option {
 func Context(ctx context.Context) Option {
 	return func(o *Options) {
 		o.Context = ctx
+	}
+}
+
+// HandleSignal toggles automatic installation of the signal handler that
+// traps TERM, INT, and QUIT.  Users of this feature to disable the signal
+// handler, should control liveness of the service through the context.
+func HandleSignal(b bool) Option {
+	return func(o *Options) {
+		o.Signal = b
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -169,7 +169,9 @@ func (s *service) Run() error {
 	}
 
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	if s.opts.Signal {
+		signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	}
 
 	select {
 	// wait on kill signal


### PR DESCRIPTION
This approach expects the user to control their context to manage the
service. A signal handler is installed by default by you can specify the
option `NoSignalHandler()` to turn it off.

The choice of keeping the signal handler in was intended to preserve
backwards compatibility so that users of go-micro today were not
surprised by the signal handling changes.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>