### PR TITLE
lower the mdns timeout to 10ms

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -51,7 +51,7 @@ type mdnsRegistry struct {
 func newRegistry(opts ...Option) Registry {
 	options := Options{
 		Context: context.Background(),
-		Timeout: time.Millisecond * 100,
+		Timeout: time.Millisecond * 10,
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
Lower the mdns request timeout to 10ms. In the majority of cases mdns is only used on local machines in which case the roundtrip to retrieve any data should be very fast. With running services we also using the caching registry to improve performance so this should be a non issue. In the cli case we always have an artificial upper bound timeout of 100ms on the request to the registry so its 100ms + request time. This shold really be lower.