### PR TITLE
runtime.Packager is now runtime.Builder

### DIFF
--- a/runtime/build/build.go
+++ b/runtime/build/build.go
@@ -1,16 +1,16 @@
-// Package packager creates a binary image. Due to package being a reserved keyword we use packager.
-package packager
+// Package build builds a micro runtime package
+package build
 
 import (
 	"github.com/micro/go-micro/runtime/source"
 )
 
-// Package builds binaries
-type Packager interface {
-	// Compile builds a binary
-	Compile(*Source) (*Binary, error)
-	// Deletes the binary
-	Delete(*Binary) error
+// Builder builds binaries
+type Builder interface {
+	// Build builds a package
+	Build(*Source) (*Package, error)
+	// Clean deletes the package
+	Clean(*Package) error
 }
 
 // Source is the source of a build
@@ -21,8 +21,8 @@ type Source struct {
 	Repository *source.Repository
 }
 
-// Binary is the representation of a binary
-type Binary struct {
+// Package is micro service package
+type Package struct {
 	// Name of the binary
 	Name string
 	// Location of the binary

--- a/runtime/build/docker/docker.go
+++ b/runtime/build/docker/docker.go
@@ -8,17 +8,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/fsouza/go-dockerclient"
-	"github.com/micro/go-micro/runtime/package"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/micro/go-micro/runtime/build"
 	"github.com/micro/go-micro/util/log"
 )
 
-type Packager struct {
-	Options packager.Options
+type Builder struct {
+	Options build.Options
 	Client  *docker.Client
 }
 
-func (d *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
+func (d *Builder) Build(s *build.Source) (*build.Package, error) {
 	image := filepath.Join(s.Repository.Path, s.Repository.Name)
 
 	buf := new(bytes.Buffer)
@@ -63,7 +63,7 @@ func (d *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &packager.Binary{
+	return &build.Package{
 		Name:   image,
 		Path:   image,
 		Type:   "docker",
@@ -71,13 +71,13 @@ func (d *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
 	}, nil
 }
 
-func (d *Packager) Delete(b *packager.Binary) error {
+func (d *Builder) Clean(b *build.Package) error {
 	image := filepath.Join(b.Path, b.Name)
 	return d.Client.RemoveImage(image)
 }
 
-func NewPackager(opts ...packager.Option) packager.Packager {
-	options := packager.Options{}
+func NewBuilder(opts ...build.Option) build.Builder {
+	options := build.Options{}
 	for _, o := range opts {
 		o(&options)
 	}
@@ -86,7 +86,7 @@ func NewPackager(opts ...packager.Option) packager.Packager {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return &Packager{
+	return &Builder{
 		Options: options,
 		Client:  client,
 	}

--- a/runtime/build/go/golang.go
+++ b/runtime/build/go/golang.go
@@ -6,11 +6,11 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/micro/go-micro/runtime/package"
+	"github.com/micro/go-micro/runtime/build"
 )
 
-type Packager struct {
-	Options packager.Options
+type Builder struct {
+	Options build.Options
 	Cmd     string
 	Path    string
 }
@@ -34,7 +34,7 @@ func whichGo() string {
 	return "go"
 }
 
-func (g *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
+func (g *Builder) Build(s *build.Source) (*build.Package, error) {
 	binary := filepath.Join(g.Path, s.Repository.Name)
 	source := filepath.Join(s.Repository.Path, s.Repository.Name)
 
@@ -42,7 +42,7 @@ func (g *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
-	return &packager.Binary{
+	return &build.Package{
 		Name:   s.Repository.Name,
 		Path:   binary,
 		Type:   "go",
@@ -50,19 +50,19 @@ func (g *Packager) Compile(s *packager.Source) (*packager.Binary, error) {
 	}, nil
 }
 
-func (g *Packager) Delete(b *packager.Binary) error {
+func (g *Builder) Clean(b *build.Package) error {
 	binary := filepath.Join(b.Path, b.Name)
 	return os.Remove(binary)
 }
 
-func NewPackager(opts ...packager.Option) packager.Packager {
-	options := packager.Options{
+func NewBuild(opts ...build.Option) build.Builder {
+	options := build.Options{
 		Path: os.TempDir(),
 	}
 	for _, o := range opts {
 		o(&options)
 	}
-	return &Packager{
+	return &Builder{
 		Options: options,
 		Cmd:     whichGo(),
 		Path:    options.Path,

--- a/runtime/build/options.go
+++ b/runtime/build/options.go
@@ -1,4 +1,4 @@
-package packager
+package build
 
 type Options struct {
 	// local path to download source

--- a/runtime/process/os/os.go
+++ b/runtime/process/os/os.go
@@ -15,13 +15,13 @@ type Process struct {
 }
 
 func (p *Process) Exec(exe *process.Executable) error {
-	cmd := exec.Command(exe.Binary.Path)
+	cmd := exec.Command(exe.Package.Path)
 	return cmd.Run()
 }
 
 func (p *Process) Fork(exe *process.Executable) (*process.PID, error) {
 	// create command
-	cmd := exec.Command(exe.Binary.Path, exe.Args...)
+	cmd := exec.Command(exe.Package.Path, exe.Args...)
 	// set env vars
 	cmd.Env = append(cmd.Env, exe.Env...)
 

--- a/runtime/process/process.go
+++ b/runtime/process/process.go
@@ -4,7 +4,7 @@ package process
 import (
 	"io"
 
-	"github.com/micro/go-micro/runtime/package"
+	"github.com/micro/go-micro/runtime/build"
 )
 
 // Process manages a running process
@@ -20,8 +20,8 @@ type Process interface {
 }
 
 type Executable struct {
-	// The executable binary
-	Binary *packager.Binary
+	// Package containing executable
+	Package *build.Package
 	// The env variables
 	Env []string
 	// Args to pass

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"sync"
 
-	packager "github.com/micro/go-micro/runtime/package"
+	"github.com/micro/go-micro/runtime/build"
+
 	"github.com/micro/go-micro/runtime/process"
 	proc "github.com/micro/go-micro/runtime/process/os"
 	"github.com/micro/go-micro/util/log"
@@ -56,7 +57,7 @@ func newService(s *Service, c CreateOptions) *service {
 		Service: s,
 		Process: new(proc.Process),
 		Exec: &process.Executable{
-			Binary: &packager.Binary{
+			Package: &build.Package{
 				Name: s.Name,
 				Path: exec,
 			},


### PR DESCRIPTION
As a consequence of the package name change the following methods were changed:

* `Compile` -> `Build`
* `Delete` -> `Clean`

Other small fixes (comments, docs)