### PR TITLE
First interface for auth

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,26 @@
+// Package auth provides authentication and authorization capability
+package auth
+
+// Auth providers authentication and authorization
+type Auth interface {
+	// Generate a new authorization token
+	Generate(u string) (*Token, error)
+	// Revoke an authorization token
+	Revoke(t *Token) error
+	// Verify a token
+	Verify(t *Token) error
+}
+
+// Token providers by an auth provider
+type Token struct {
+	// Unique token id
+	Id string `json: "id"`
+	// Time of token creation
+	Created time.Time `json:"created"`
+	// Time of token expiry
+	Expiry time.Time `json:"expiry"`
+	// Roles associated with the token
+	Roles []string `json:"roles"`
+	// Any other associated metadata
+	Metadata map[string]string `json:"metadata"`
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -7,12 +7,20 @@ import (
 
 // Auth providers authentication and authorization
 type Auth interface {
-	// Generate a new authorization token
-	Generate(u string) (*Token, error)
+	// Generate a new auth token
+	Generate(string) (*Token, error)
 	// Revoke an authorization token
-	Revoke(t *Token) error
-	// Verify a token
-	Verify(t *Token) error
+	Revoke(*Token) error
+	// Grant access to a resource
+	Grant(*Token, *Resource) error
+	// Verify a token can access a resource
+	Verify(*Token, *Resource) error
+}
+
+// Resource is some thing to provide access to
+type Resource struct {
+	// Name of the resource
+	Name string
 }
 
 // Token providers by an auth provider

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,6 +1,10 @@
 // Package auth provides authentication and authorization capability
 package auth
 
+import (
+	"time"
+)
+
 // Auth providers authentication and authorization
 type Auth interface {
 	// Generate a new authorization token

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,15 +12,17 @@ type Auth interface {
 	// Revoke an authorization token
 	Revoke(*Token) error
 	// Grant access to a resource
-	Grant(*Token, *Resource) error
+	Grant(*Token, *Service) error
 	// Verify a token can access a resource
-	Verify(*Token, *Resource) error
+	Verify(*Token, *Service) error
 }
 
-// Resource is some thing to provide access to
-type Resource struct {
+// Service is some thing to provide access to
+type Service struct {
 	// Name of the resource
 	Name string
+	// Endpoint is the specific endpoint 
+	Endpoint string
 }
 
 // Token providers by an auth provider


### PR DESCRIPTION
The start of an auth interface. We have deferred authentication in Micro for a long time, mostly because auth was not believed to be a core networking concern. As we move to a fully integrated framework for all things microservices its clear that auth has to be part of the core system. Every service should transparently have auth built in, without the requirement for configuration. It does not have to be mandatory but it should be there.