### PR TITLE
Change the k8s runtime notifier update to get the deployment and upda…

### DIFF
--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -2,9 +2,7 @@
 package client
 
 import (
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/micro/go-micro/util/log"
 )
@@ -92,16 +90,6 @@ func NewDeployment(name, version string) *Deployment {
 		Version:     version,
 		Labels:      Labels,
 		Annotations: map[string]string{},
-	}
-
-	// TODO: we need to figure out this version stuff
-	// might have to add Build to runtime.Service
-	buildTime, err := strconv.ParseInt(version, 10, 64)
-	if err == nil {
-		buildUnixTimeUTC := time.Unix(buildTime, 0)
-		Metadata.Annotations["build"] = buildUnixTimeUTC.Format(time.RFC3339)
-	} else {
-		log.Tracef("could not parse build: %v", err)
 	}
 
 	// enable go modules by default

--- a/runtime/kubernetes/service.go
+++ b/runtime/kubernetes/service.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"strings"
+	"time"
 
 	"github.com/micro/go-micro/runtime"
 	"github.com/micro/go-micro/runtime/kubernetes/client"
@@ -33,6 +34,9 @@ func newService(s *runtime.Service, c runtime.CreateOptions) *service {
 	// associate owner:group to be later augmented
 	kdeploy.Metadata.Annotations["owner"] = "micro"
 	kdeploy.Metadata.Annotations["group"] = "micro"
+
+	// set a build timestamp to the current time
+	kdeploy.Metadata.Annotations["build"] = time.Now().Format(time.RFC3339)
 
 	// define the environment values used by the container
 	env := make([]client.EnvVar, 0, len(c.Env))


### PR DESCRIPTION
This PR addresses how we use the "build" timestamp in the k8s annotations of a deployment. The timestamp for the build will represent the time at which this deployment was rebuilt rather than using the service version. The service version should be independent of build time. Version could be semver, git commit hash, "latest", or anything else.

We also now retrieve the deployment in the update notifier before hand rather than creating a new service. We may want to do the same for the runtime.Update method since the update implies something is already there.