### PR TITLE
Remove validator regexp as its no longer needed.

### DIFF
--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -7,11 +7,6 @@ import (
 	"github.com/micro/go-micro/util/log"
 )
 
-const (
-	// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go#L134
-	dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-)
-
 var (
 	// DefaultImage is default micro image
 	DefaultImage = "micro/go-micro"


### PR DESCRIPTION
Reading through the k8s code Ive noticed we no longer do the name validation - that's great - we should not have been doing it to start with.

But I also noticed that the validation `regexp` string was not removed from the code during refactoring so here I am shamelessly claiming cheap win.