### PR TITLE
Optimizations to connect fast

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -476,6 +476,24 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 				n.Lock()
 				delete(n.peerLinks, pbNetClose.Node.Address)
 				n.Unlock()
+			case "solicit":
+				// received a peer solicit message
+				pbRtrSolicit := &pbRtr.Solicit{}
+				if err := proto.Unmarshal(m.msg.Body, pbRtrSolicit); err != nil {
+					log.Debugf("Network fail to unmarshal solicit message: %v", err)
+					continue
+				}
+				log.Debugf("Network received peer solicit message from: %s", pbRtrSolicit.Id)
+				// ignore solicitation when requested by you
+				if pbRtrSolicit.Id == n.options.Id {
+					continue
+				}
+				// get node peers down to MaxDepth encoded in protobuf
+				msg := PeersToProto(n.node, MaxDepth)
+				// advertise yourself to the network
+				if err := n.sendMsg("peer", msg, NetworkChannel); err != nil {
+					log.Debugf("Network failed to advertise peers: %v", err)
+				}
 			}
 		case <-n.closed:
 			return
@@ -767,6 +785,13 @@ func (n *network) processCtrlChan(listener tunnel.Listener) {
 				// loookup advertising node in our peer topology
 				advertNode := n.node.GetPeerNode(pbRtrAdvert.Id)
 				if advertNode == nil {
+					msg := &pbRtr.Solicit{
+						Id: pbRtrAdvert.Id,
+					}
+					// go solicit the peer
+					if err := n.sendMsg("solicit", msg, NetworkChannel); err != nil {
+						log.Debugf("Network failed to send solicit message: %s", err)
+					}
 					// if we can't find the node in our topology (MaxDepth) we skipp prcessing adverts
 					log.Debugf("Network skipping advert message from unknown peer: %s", pbRtrAdvert.Id)
 					continue
@@ -1020,8 +1045,23 @@ func (n *network) Connect() error {
 	}
 	n.Unlock()
 
-	// send the connect message
-	n.sendConnect()
+	// send connect after there's a link established
+	go func() {
+		// wait for 30 ticks e.g 30 seconds
+		for i := 0; i < 30; i++ {
+			// get the current links
+			links := n.tunnel.Links()
+
+			// if there are no links wait until we have one
+			if len(links) == 0 {
+				time.Sleep(time.Second)
+				continue
+			}
+
+			// send the connect message
+			n.sendConnect()
+		}
+	}()
 
 	// go resolving network nodes
 	go n.resolve()


### PR DESCRIPTION
Some ideas to connect faster.

1. Only send "connect" on startup after there is 1 tunnel link established. Wait for 30 seconds to do this.
2. When receiving an advert for which we have no peer issue a "solicit" on the peer channel to start the peer broadcast flow to get all the info. It's sub-optimal that routes are re-solicited but its a fast hack when joining in the midst of flow.