### PR TITLE
improve code quality

### DIFF
--- a/agent/input/telegram/conn.go
+++ b/agent/input/telegram/conn.go
@@ -44,11 +44,9 @@ func (tc *telegramConn) run() {
 	tc.recv = updates
 	tc.syncCond.Signal()
 
-	for {
-		select {
-		case <-tc.exit:
-			return
-		}
+	select {
+	case <-tc.exit:
+		return
 	}
 }
 

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -339,7 +339,9 @@ func (g *grpcClient) Call(ctx context.Context, req client.Request, rsp interface
 	d, ok := ctx.Deadline()
 	if !ok {
 		// no deadline so we create a new one
-		ctx, _ = context.WithTimeout(ctx, callOpts.RequestTimeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, callOpts.RequestTimeout)
+		defer cancel()
 	} else {
 		// got a deadline so no need to setup context
 		// but we need to set the timeout we pass along

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -162,7 +162,6 @@ func (r *rpcClient) call(ctx context.Context, node *registry.Node, req Request, 
 
 	select {
 	case err := <-ch:
-		grr = err
 		return err
 	case <-ctx.Done():
 		grr = errors.Timeout("go.micro.client", fmt.Sprintf("%v", ctx.Err()))
@@ -378,7 +377,9 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 	d, ok := ctx.Deadline()
 	if !ok {
 		// no deadline so we create a new one
-		ctx, _ = context.WithTimeout(ctx, callOpts.RequestTimeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, callOpts.RequestTimeout)
+		defer cancel()
 	} else {
 		// got a deadline so no need to setup context
 		// but we need to set the timeout we pass along

--- a/codec/bytes/bytes.go
+++ b/codec/bytes/bytes.go
@@ -29,12 +29,10 @@ func (c *Codec) ReadBody(b interface{}) error {
 		return err
 	}
 
-	switch b.(type) {
+	switch v := b.(type) {
 	case *[]byte:
-		v := b.(*[]byte)
 		*v = buf
 	case *Frame:
-		v := b.(*Frame)
 		v.Data = buf
 	default:
 		return fmt.Errorf("failed to read body: %v is not type of *[]byte", b)
@@ -45,14 +43,13 @@ func (c *Codec) ReadBody(b interface{}) error {
 
 func (c *Codec) Write(m *codec.Message, b interface{}) error {
 	var v []byte
-	switch b.(type) {
+	switch vb := b.(type) {
 	case *Frame:
-		v = b.(*Frame).Data
+		v = vb.Data
 	case *[]byte:
-		ve := b.(*[]byte)
-		v = *ve
+		v = *vb
 	case []byte:
-		v = b.([]byte)
+		v = vb
 	default:
 		return fmt.Errorf("failed to write: %v is not type of *[]byte or []byte", b)
 	}

--- a/codec/bytes/marshaler.go
+++ b/codec/bytes/marshaler.go
@@ -12,25 +12,22 @@ type Message struct {
 }
 
 func (n Marshaler) Marshal(v interface{}) ([]byte, error) {
-	switch v.(type) {
+	switch ve := v.(type) {
 	case *[]byte:
-		ve := v.(*[]byte)
 		return *ve, nil
 	case []byte:
-		return v.([]byte), nil
+		return ve, nil
 	case *Message:
-		return v.(*Message).Body, nil
+		return ve.Body, nil
 	}
 	return nil, errors.New("invalid message")
 }
 
 func (n Marshaler) Unmarshal(d []byte, v interface{}) error {
-	switch v.(type) {
+	switch ve := v.(type) {
 	case *[]byte:
-		ve := v.(*[]byte)
 		*ve = d
 	case *Message:
-		ve := v.(*Message)
 		ve.Body = d
 	}
 	return errors.New("invalid message")

--- a/codec/text/text.go
+++ b/codec/text/text.go
@@ -29,15 +29,12 @@ func (c *Codec) ReadBody(b interface{}) error {
 		return err
 	}
 
-	switch b.(type) {
+	switch v := b.(type) {
 	case *string:
-		v := b.(*string)
 		*v = string(buf)
 	case *[]byte:
-		v := b.(*[]byte)
 		*v = buf
 	case *Frame:
-		v := b.(*Frame)
 		v.Data = buf
 	default:
 		return fmt.Errorf("failed to read body: %v is not type of *[]byte", b)
@@ -48,20 +45,17 @@ func (c *Codec) ReadBody(b interface{}) error {
 
 func (c *Codec) Write(m *codec.Message, b interface{}) error {
 	var v []byte
-	switch b.(type) {
+	switch ve := b.(type) {
 	case *Frame:
-		v = b.(*Frame).Data
+		v = ve.Data
 	case *[]byte:
-		ve := b.(*[]byte)
 		v = *ve
 	case *string:
-		ve := b.(*string)
 		v = []byte(*ve)
 	case string:
-		ve := b.(string)
 		v = []byte(ve)
 	case []byte:
-		v = b.([]byte)
+		v = ve
 	default:
 		return fmt.Errorf("failed to write: %v is not type of *[]byte or []byte", b)
 	}

--- a/network/default.go
+++ b/network/default.go
@@ -823,7 +823,7 @@ func (n *network) processCtrlChan(listener tunnel.Listener) {
 					log.Tracef("Network metric for router %s and gateway %s: %v", event.Route.Router, event.Route.Gateway, metric)
 
 					// check we don't overflow max int 64
-					if d := route.Metric + metric; d > math.MaxInt64 || d <= 0 {
+					if d := route.Metric + metric; d <= 0 {
 						// set to max int64 if we overflow
 						route.Metric = math.MaxInt64
 					} else {

--- a/network/service/handler/handler.go
+++ b/network/service/handler/handler.go
@@ -94,11 +94,6 @@ func (n *Network) Connect(ctx context.Context, req *pbNet.ConnectRequest, resp *
 
 // Nodes returns the list of nodes
 func (n *Network) Nodes(ctx context.Context, req *pbNet.NodesRequest, resp *pbNet.NodesResponse) error {
-	depth := uint(req.Depth)
-	if depth <= 0 || depth > network.MaxDepth {
-		depth = network.MaxDepth
-	}
-
 	// root node
 	nodes := map[string]network.Node{}
 

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -274,7 +274,7 @@ func (p *Proxy) watchRoutes() {
 			return
 		}
 
-		if err := p.manageRoutes(event.Route, fmt.Sprintf("%s", event.Type)); err != nil {
+		if err := p.manageRoutes(event.Route, event.Type.String()); err != nil {
 			// TODO: should we bail here?
 			continue
 		}
@@ -562,12 +562,9 @@ func NewProxy(opts ...options.Option) proxy.Proxy {
 		defer t.Stop()
 
 		// we must refresh route metrics since they do not trigger new events
-		for {
-			select {
-			case <-t.C:
-				// refresh route metrics
-				p.refreshMetrics()
-			}
+		for range t.C {
+			// refresh route metrics
+			p.refreshMetrics()
 		}
 	}()
 

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -230,7 +230,9 @@ func (m *mdnsRegistry) GetService(service string) ([]*Service, error) {
 
 	p := mdns.DefaultParams(service)
 	// set context with timeout
-	p.Context, _ = context.WithTimeout(context.Background(), m.opts.Timeout)
+	var cancel context.CancelFunc
+	p.Context, cancel = context.WithTimeout(context.Background(), m.opts.Timeout)
+	defer cancel()
 	// set entries channel
 	p.Entries = entries
 	// set the domain
@@ -308,7 +310,9 @@ func (m *mdnsRegistry) ListServices() ([]*Service, error) {
 
 	p := mdns.DefaultParams("_services")
 	// set context with timeout
-	p.Context, _ = context.WithTimeout(context.Background(), m.opts.Timeout)
+	var cancel context.CancelFunc
+	p.Context, cancel = context.WithTimeout(context.Background(), m.opts.Timeout)
+	defer cancel()
 	// set entries channel
 	p.Entries = entries
 	// set domain

--- a/registry/service/watcher.go
+++ b/registry/service/watcher.go
@@ -11,24 +11,22 @@ type serviceWatcher struct {
 }
 
 func (s *serviceWatcher) Next() (*registry.Result, error) {
-	for {
-		// check if closed
-		select {
-		case <-s.closed:
-			return nil, registry.ErrWatcherStopped
-		default:
-		}
-
-		r, err := s.stream.Recv()
-		if err != nil {
-			return nil, err
-		}
-
-		return &registry.Result{
-			Action:  r.Action,
-			Service: ToService(r.Service),
-		}, nil
+	// check if closed
+	select {
+	case <-s.closed:
+		return nil, registry.ErrWatcherStopped
+	default:
 	}
+
+	r, err := s.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return &registry.Result{
+		Action:  r.Action,
+		Service: ToService(r.Service),
+	}, nil
 }
 
 func (s *serviceWatcher) Stop() {

--- a/router/default.go
+++ b/router/default.go
@@ -718,7 +718,7 @@ func (r *router) Process(a *Advert) error {
 		route := event.Route
 		action := event.Type
 		log.Debugf("Router %s applying %s from router %s for service %s %s", r.options.Id, action, route.Router, route.Service, route.Address)
-		if err := r.manageRoute(route, fmt.Sprintf("%s", action)); err != nil {
+		if err := r.manageRoute(route, action.String()); err != nil {
 			return fmt.Errorf("failed applying action %s to routing table: %s", action, err)
 		}
 	}

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -222,7 +222,9 @@ func (g *grpcServer) handler(srv interface{}, stream grpc.ServerStream) error {
 	// set the timeout if we have it
 	if len(to) > 0 {
 		if n, err := strconv.ParseUint(to, 10, 64); err == nil {
-			ctx, _ = context.WithTimeout(ctx, time.Duration(n))
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(n))
+			defer cancel()
 		}
 	}
 

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -277,7 +277,9 @@ func (s *rpcServer) ServeConn(sock transport.Socket) {
 		// set the timeout from the header if we have it
 		if len(to) > 0 {
 			if n, err := strconv.ParseUint(to, 10, 64); err == nil {
-				ctx, _ = context.WithTimeout(ctx, time.Duration(n))
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(n))
+				defer cancel()
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -201,7 +201,7 @@ func Run() error {
 	}
 
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
 	log.Logf("Received signal %s", <-ch)
 
 	return Stop()

--- a/sync/leader/etcd/etcd.go
+++ b/sync/leader/etcd/etcd.go
@@ -39,9 +39,7 @@ func (e *etcdLeader) Elect(id string, opts ...leader.ElectOption) (leader.Electe
 
 	l := cc.NewElection(s, path)
 
-	ctx, _ := context.WithCancel(context.Background())
-
-	if err := l.Campaign(ctx, id); err != nil {
+	if err := l.Campaign(context.TODO(), id); err != nil {
 		return nil, err
 	}
 
@@ -63,14 +61,8 @@ func (e *etcdLeader) Follow() chan string {
 	ech := l.Observe(context.Background())
 
 	go func() {
-		for {
-			select {
-			case r, ok := <-ech:
-				if !ok {
-					return
-				}
-				ch <- string(r.Kvs[0].Value)
-			}
+		for r := range ech {
+			ch <- string(r.Kvs[0].Value)
 		}
 	}()
 
@@ -82,8 +74,7 @@ func (e *etcdLeader) String() string {
 }
 
 func (e *etcdElected) Reelect() error {
-	ctx, _ := context.WithCancel(context.Background())
-	return e.e.Campaign(ctx, e.id)
+	return e.e.Campaign(context.TODO(), e.id)
 }
 
 func (e *etcdElected) Revoked() chan bool {

--- a/sync/lock/etcd/etcd.go
+++ b/sync/lock/etcd/etcd.go
@@ -49,9 +49,7 @@ func (e *etcdLock) Acquire(id string, opts ...lock.AcquireOption) error {
 
 	m := cc.NewMutex(s, path)
 
-	ctx, _ := context.WithCancel(context.Background())
-
-	if err := m.Lock(ctx); err != nil {
+	if err := m.Lock(context.TODO()); err != nil {
 		return err
 	}
 

--- a/sync/task/task.go
+++ b/sync/task/task.go
@@ -63,7 +63,9 @@ func (s Schedule) Run() <-chan time.Time {
 		}
 
 		// start ticker
-		for t := range time.Tick(s.Interval) {
+		ticker := time.NewTicker(s.Interval)
+		defer ticker.Stop()
+		for t := range ticker.C {
 			ch <- t
 		}
 	}()

--- a/tunnel/link.go
+++ b/tunnel/link.go
@@ -228,7 +228,7 @@ func (l *link) manage() {
 			}
 			// check the type of message
 			switch {
-			case bytes.Compare(p.message.Body, linkRequest) == 0:
+			case bytes.Equal(p.message.Body, linkRequest):
 				log.Tracef("Link %s received link request %v", l.id, p.message.Body)
 				// send response
 				if err := send(linkResponse); err != nil {
@@ -236,7 +236,7 @@ func (l *link) manage() {
 					l.errCount++
 					l.Unlock()
 				}
-			case bytes.Compare(p.message.Body, linkResponse) == 0:
+			case bytes.Equal(p.message.Body, linkResponse):
 				// set round trip time
 				d := time.Since(now)
 				log.Tracef("Link %s received link response in %v", p.message.Body, d)

--- a/web/service.go
+++ b/web/service.go
@@ -376,7 +376,7 @@ func (s *service) Run() error {
 	go s.run(ex)
 
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
 
 	select {
 	// wait on kill signal


### PR DESCRIPTION
1. the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)
2. assigning the result of this type assertion to a variable (switch b := b.(type)) could eliminate the following type assertions (gosimple)
3. using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (staticcheck)
4. should use a simple channel send/receive instead of `select` with a single case (gosimple)