### PR TITLE
No newlines at end of log messages

### DIFF
--- a/web/service.go
+++ b/web/service.go
@@ -216,7 +216,7 @@ func (s *service) start() error {
 		ch <- l.Close()
 	}()
 
-	log.Logf("Listening on %v\n", l.Addr().String())
+	log.Logf("Listening on %v", l.Addr().String())
 	return nil
 }
 
@@ -381,7 +381,7 @@ func (s *service) Run() error {
 	select {
 	// wait on kill signal
 	case sig := <-ch:
-		log.Logf("Received signal %s\n", sig)
+		log.Logf("Received signal %s", sig)
 	// wait on context cancel
 	case <-s.opts.Context.Done():
 		log.Logf("Received context shutdown")


### PR DESCRIPTION
Log messages should not end with a new line, this should be entirely
handled by the underlying log library.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>