### PR TITLE
named return value for error defer modify.

### DIFF
--- a/server/grpc/subscriber.go
+++ b/server/grpc/subscriber.go
@@ -167,8 +167,7 @@ func validateSubscriber(sub server.Subscriber) error {
 }
 
 func (g *grpcServer) createSubHandler(sb *subscriber, opts server.Options) broker.Handler {
-	return func(p broker.Event) error {
-		var err error
+	return func(p broker.Event) (err error) {
 
 		defer func() {
 			if r := recover(); r != nil {

--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -506,8 +506,7 @@ func (router *router) Subscribe(s Subscriber) error {
 	return nil
 }
 
-func (router *router) ProcessMessage(ctx context.Context, msg Message) error {
-	var err error
+func (router *router) ProcessMessage(ctx context.Context, msg Message) (err error) {
 
 	defer func() {
 		// recover any panics

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -16,8 +16,7 @@ type microTransport struct {
 	fn   func(transport.Socket)
 }
 
-func (m *microTransport) Stream(ts pb.Transport_StreamServer) error {
-	var err error
+func (m *microTransport) Stream(ts pb.Transport_StreamServer) (err error) {
 
 	sock := &grpcTransportSocket{
 		stream: ts,


### PR DESCRIPTION
```
        fn := func() error {
            var err error
            defer func() {
                if r := recover(); r != nil {
                    err = fmt.Errorf("%v", r)
                }   
            }() 
            panic("micro")
            return err
        }   

        fmt.Println(fn()) // print nil
```

```
        fn := func() (err error) {
            defer func() {
                if r := recover(); r != nil {
                    err = fmt.Errorf("%v", r)
                }   
            }() 
            panic("micro")
            return err
        }   

        fmt.Println(fn()) // print micro
```