### PR TITLE
nlopes/slack dep update to fix broken unmarshal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/miekg/dns v1.1.22
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/nats-io/nats.go v1.9.1
-	github.com/nlopes/slack@d06c2a2b3249b44a9c5dee8485f5a87497beb9ea
+	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/miekg/dns v1.1.22
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/nats-io/nats.go v1.9.1
-	github.com/nlopes/slack v0.6.0
+	github.com/nlopes/slack@d06c2a2b3249b44a9c5dee8485f5a87497beb9ea
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
+github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249 h1:Pr5gZa2VcmktVwq0lyC39MsN5tz356vC/pQHKvq+QBo=
+github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/nrdcg/auroradns v1.0.0/go.mod h1:6JPXKzIRzZzMqtTDgueIhTi6rFf1QvYE/HzqidhOhjw=
 github.com/nrdcg/goinwx v0.6.1/go.mod h1:XPiut7enlbEdntAqalBIqcYcTEVhpv/dKWgDCX2SwKQ=
 github.com/nrdcg/namesilo v0.2.1/go.mod h1:lwMvfQTyYq+BbjJd30ylEG4GPSS6PII0Tia4rRpRiyw=


### PR DESCRIPTION
About a month ago Slack introduced the updated structure of RTM messages which resulted in an inability to unmarshal received msg (original issue: https://github.com/nlopes/slack/issues/630). It's not an issue of micro itself, but of the github.com/nlopes/slack lib. The fix was already merged into master (https://github.com/nlopes/slack/pull/618), but the lib has not been released in any new version.

Thus so I propose to update directly to the commit:

go get github.com/nlopes/slack@d06c2a2b3249b44a9c5dee8485f5a87497beb9ea

The MicroBot does now work now with any Slack client newer than around a month old.

Pardon me please, if using @commit in go.mod is anyhow against your rules or methods, I didn't find anywhere a "code of conduct" or so. Thank you.