### PR TITLE
fix etcd LogConfig bug & add etcd grpc log setter

### DIFF
--- a/registry/etcd/etcd.go
+++ b/registry/etcd/etcd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/micro/go-micro/util/log"
 	hash "github.com/mitchellh/hashstructure"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/grpclog"
 )
 
 var (
@@ -77,6 +78,10 @@ func configure(e *etcdRegistry, opts ...registry.Option) error {
 		cfg, ok := e.options.Context.Value(logConfigKey{}).(*zap.Config)
 		if ok && cfg != nil {
 			config.LogConfig = cfg
+		}
+		grpclog, ok := e.options.Context.Value(logSetKey{}).(grpclog.LoggerV2)
+		if ok && grpclog != nil {
+			clientv3.SetLogger(grpclog)
 		}
 	}
 

--- a/registry/etcd/options.go
+++ b/registry/etcd/options.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/micro/go-micro/registry"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/grpclog"
 )
 
 type authKey struct{}
 
 type logConfigKey struct{}
+
+type logSetKey struct{}
 
 type authCreds struct {
 	Username string
@@ -32,6 +35,18 @@ func LogConfig(config *zap.Config) registry.Option {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, authKey{}, config)
+		o.Context = context.WithValue(o.Context, logConfigKey{}, config)
+	}
+}
+
+// LogSet allows you to set etcd grpc log config
+// LogSet is different from LogConfig. LogSet set the grpc communicate log between etcd client and server.
+// LogConfig set the log in etcd client
+func LogSet(l grpclog.LoggerV2) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, logSetKey{}, l)
 	}
 }


### PR DESCRIPTION
fix etcd LogConfig bug & add etcd grpc log setter
LogSet is different from LogConfig. LogSet set the grpc communicate log between etcd client and server.
LogConfig only set the log in etcd client