### PR TITLE
fix: http header `Timeout` field not applied

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -87,16 +87,17 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	address := node.Address
 
 	header := make(map[string]string)
-	if md, ok := metadata.FromContext(ctx); ok {
-		for k, v := range md {
-			header[k] = v
-		}
-	}
 
 	// set timeout in nanoseconds
 	header["timeout"] = fmt.Sprintf("%d", opts.RequestTimeout)
 	// set the content type for the request
 	header["x-content-type"] = req.ContentType()
+
+	if md, ok := metadata.FromContext(ctx); ok {
+		for k, v := range md {
+			header[k] = v
+		}
+	}
 
 	md := gmetadata.New(header)
 	ctx = gmetadata.NewOutgoingContext(ctx, md)
@@ -159,16 +160,17 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 	address := node.Address
 
 	header := make(map[string]string)
-	if md, ok := metadata.FromContext(ctx); ok {
-		for k, v := range md {
-			header[k] = v
-		}
-	}
 
 	// set timeout in nanoseconds
 	header["timeout"] = fmt.Sprintf("%d", opts.RequestTimeout)
 	// set the content type for the request
 	header["x-content-type"] = req.ContentType()
+
+	if md, ok := metadata.FromContext(ctx); ok {
+		for k, v := range md {
+			header[k] = v
+		}
+	}
 
 	md := gmetadata.New(header)
 	ctx = gmetadata.NewOutgoingContext(ctx, md)

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -71,19 +71,19 @@ func (r *rpcClient) call(ctx context.Context, node *registry.Node, req Request, 
 		Header: make(map[string]string),
 	}
 
-	md, ok := metadata.FromContext(ctx)
-	if ok {
-		for k, v := range md {
-			msg.Header[k] = v
-		}
-	}
-
 	// set timeout in nanoseconds
 	msg.Header["Timeout"] = fmt.Sprintf("%d", opts.RequestTimeout)
 	// set the content type for the request
 	msg.Header["Content-Type"] = req.ContentType()
 	// set the accept header
 	msg.Header["Accept"] = req.ContentType()
+
+	md, ok := metadata.FromContext(ctx)
+	if ok {
+		for k, v := range md {
+			msg.Header[k] = v
+		}
+	}
 
 	// setup old protocol
 	cf := setupProtocol(msg, node)
@@ -186,19 +186,19 @@ func (r *rpcClient) stream(ctx context.Context, node *registry.Node, req Request
 		Header: make(map[string]string),
 	}
 
-	md, ok := metadata.FromContext(ctx)
-	if ok {
-		for k, v := range md {
-			msg.Header[k] = v
-		}
-	}
-
 	// set timeout in nanoseconds
 	msg.Header["Timeout"] = fmt.Sprintf("%d", opts.RequestTimeout)
 	// set the content type for the request
 	msg.Header["Content-Type"] = req.ContentType()
 	// set the accept header
 	msg.Header["Accept"] = req.ContentType()
+
+	md, ok := metadata.FromContext(ctx)
+	if ok {
+		for k, v := range md {
+			msg.Header[k] = v
+		}
+	}
 
 	// set old codecs
 	cf := setupProtocol(msg, node)


### PR DESCRIPTION
I have some problems when i using MicroApi.

```
                                             K8S
                        -----------------------------------------------
                        |
outSideApp----HTTP----> |-> MicroApi ---- Request ----> GoMicroServer
                        |
                        -----------------------------------------------
```

 When i in `outSideApp`,i set a `Timeout: 10000000` field in Http header, i want to change the `MicroApi Client timeout` only in this request . but it not work.

so i read `micro/go-micro` source code , although i found it reads the `msg.Header["Timeout"]`  in  `server/rpc_server.go:281` , but it used `client default config` overwrites the `Timeout field`  in `client/rpc_client.go:75`, so I submitted this PR application For modifying this bug, or is there any other way to achieve my purpose.thanks.

Best Regards !