### PR TITLE
set grpc by default

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,17 @@
+package micro
+
+import (
+	"github.com/micro/go-micro/client"
+	"github.com/micro/go-micro/server"
+
+	// set defaults
+	gcli "github.com/micro/go-micro/client/grpc"
+	gsrv "github.com/micro/go-micro/server/grpc"
+)
+
+func init() {
+	// default client
+	client.DefaultClient = gcli.NewClient()
+	// default server
+	server.DefaultServer = gsrv.NewServer()
+}


### PR DESCRIPTION
Enable grpc service by default.

Currently there is painful rewriting of code to make something a default so I'm opting for a high level switch. I think ideally we should move the current defaults into their own packages and then initialise the pkg.DefaultX values from some external method.