### PR TITLE
remove ignore error in method publish

### DIFF
--- a/broker/http_broker.go
+++ b/broker/http_broker.go
@@ -533,8 +533,7 @@ func (h *httpBroker) Publish(topic string, msg *Message, opts ...PublishOption) 
 	s, err := h.r.GetService(serviceName)
 	if err != nil {
 		h.RUnlock()
-		// ignore error
-		return nil
+		return err
 	}
 	h.RUnlock()
 


### PR DESCRIPTION
Export registry error in method publish.

Show error while service name not found or registry occur some exceptions.