### PR TITLE
Correct config name to resolve error on install

### DIFF
--- a/transport/quic/quic.go
+++ b/transport/quic/quic.go
@@ -118,7 +118,7 @@ func (q *quicTransport) Dial(addr string, opts ...transport.DialOption) (transpo
 		}
 	}
 	s, err := quic.DialAddr(addr, config, &quic.Config{
-		IdleTimeout: time.Minute * 2,
+		MaxIdleTimeout: time.Minute * 2,
 		KeepAlive:   true,
 	})
 	if err != nil {


### PR DESCRIPTION
When using `go get`, an error appears with quic that this config property does not exist. It's actually called "MaxIdleTimeout", so just a quick PR to fix it.

Attaching to #1082 (although the core content of the post is different, this error is described in it).