### PR TITLE
config/reader.Values add Set for specific path merge

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -172,6 +172,17 @@ func (c *config) Get(path ...string) reader.Value {
 	return newValue()
 }
 
+func (c *config) Set(val interface{}, path ...string) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.vals != nil {
+		c.vals.Set(val, path...)
+	}
+
+	return
+}
+
 func (c *config) Bytes() []byte {
 	c.RLock()
 	defer c.RUnlock()

--- a/config/default.go
+++ b/config/default.go
@@ -183,6 +183,17 @@ func (c *config) Set(val interface{}, path ...string) {
 	return
 }
 
+func (c *config) Del(path ...string) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.vals != nil {
+		c.vals.Del(path...)
+	}
+
+	return
+}
+
 func (c *config) Bytes() []byte {
 	c.RLock()
 	defer c.RUnlock()

--- a/config/reader/reader.go
+++ b/config/reader/reader.go
@@ -18,6 +18,7 @@ type Reader interface {
 type Values interface {
 	Bytes() []byte
 	Get(path ...string) Value
+	Set(val interface{}, path ...string)
 	Map() map[string]interface{}
 	Scan(v interface{}) error
 }

--- a/config/reader/reader.go
+++ b/config/reader/reader.go
@@ -19,6 +19,7 @@ type Values interface {
 	Bytes() []byte
 	Get(path ...string) Value
 	Set(val interface{}, path ...string)
+	Del(path ...string)
 	Map() map[string]interface{}
 	Scan(v interface{}) error
 }


### PR DESCRIPTION
jsonReader still has this method. it can help us conveniently merge data with a specific path.

eg.
```
{"a":{"b":{"c":{"d":{"name":"im d"}}}}}
```
we can merge `{d:{"name":"i am not  d"}}` into it via `Set({d:{"name":"i am not  d"}}, "a", "b", "c")