### PR TITLE
Send only best routes via Sync. Only apply best routes.

### DIFF
--- a/network/default.go
+++ b/network/default.go
@@ -854,7 +854,7 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 					q := []router.QueryOption{
 						router.QueryStrategy(n.router.Options().Advertise),
 					}
-					routes, err := n.options.Router.Table().Query(q...)
+					routes, err := n.router.Table().Query(q...)
 					switch err {
 					case nil:
 						// encode the routes to protobuf
@@ -1051,7 +1051,7 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 					// unmarshal the routes received from remote peer
 					route := pbUtil.ProtoToRoute(pbRoute)
 					// continue if we are the originator of the route
-					if route.Router == n.options.Router.Options().Id {
+					if route.Router == n.router.Options().Id {
 						log.Debugf("Network node %s skipping route addition: route already present", n.id)
 						continue
 					}
@@ -1061,7 +1061,7 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 						router.QueryStrategy(n.router.Options().Advertise),
 					}
 
-					routes, err := n.options.Router.Table().Query(q...)
+					routes, err := n.router.Table().Query(q...)
 					if err != nil {
 						log.Debugf("Network node %s failed listing best routes for %s: %v", n.id, route.Service, err)
 						continue
@@ -1075,6 +1075,7 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 							log.Debugf("Network node %s failed to add route: %v", n.id, err)
 							continue
 						}
+						continue
 					}
 
 					// find the best route for the given service
@@ -1381,7 +1382,7 @@ func (n *network) manage() {
 				q := []router.QueryOption{
 					router.QueryStrategy(n.router.Options().Advertise),
 				}
-				routes, err := n.options.Router.Table().Query(q...)
+				routes, err := n.router.Table().Query(q...)
 				switch err {
 				case nil:
 					// encode the routes to protobuf

--- a/network/default.go
+++ b/network/default.go
@@ -1070,10 +1070,8 @@ func (n *network) processNetChan(listener tunnel.Listener) {
 					// we found no routes for the given service
 					// create the new route we have just received
 					if len(routes) == 0 {
-						// add routes to the routing table
 						if err := n.router.Table().Create(route); err != nil && err != router.ErrDuplicateRoute {
 							log.Debugf("Network node %s failed to add route: %v", n.id, err)
-							continue
 						}
 						continue
 					}


### PR DESCRIPTION
We now send only the best routes over `Sync`.
When applying routes received in the `Sync` message we:
* prefer our own routes if the metric for a service we receive is the same as our best route for the same service
* we only add new routes if the received route metric is better than the metric of our best route
