### PR TITLE
Use the same logic for advertising routes in Router and Network

### DIFF
--- a/router/default_test.go
+++ b/router/default_test.go
@@ -18,7 +18,6 @@ func routerTestSetup() Router {
 func TestRouterStartStop(t *testing.T) {
 	r := routerTestSetup()
 
-	log.Debugf("TestRouterStartStop STARTING")
 	if err := r.Start(); err != nil {
 		t.Errorf("failed to start router: %v", err)
 	}


### PR DESCRIPTION
`router.Query()` allows to query the routes in the table with `router.Strategy`.
It uses the same logic as was implemented in `flushRouteEvents` but the code was never updated in the router to replace the existing code (same logic). This way we are consistent across both router and network packages.