### PR TITLE
server: remove unused invalidRequest

### DIFF
--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -25,10 +25,6 @@ import (
 
 var (
 	lastStreamResponseError = errors.New("EOS")
-	// A value sent as a placeholder for the server's response value when the server
-	// receives an invalid request. It is never decoded by the client since the Response
-	// contains an error when it is used.
-	invalidRequest = struct{}{}
 
 	// Precompute the reflect type for error. Can't use error directly
 	// because Typeof takes an empty interface value. This is annoying.


### PR DESCRIPTION
This removes an unused variable from `server`.