### PR TITLE
broker: drop unused registryKey variable

### DIFF
--- a/broker/options.go
+++ b/broker/options.go
@@ -46,10 +46,6 @@ type PublishOption func(*PublishOptions)
 
 type SubscribeOption func(*SubscribeOptions)
 
-var (
-	registryKey = "github.com/micro/go-micro/registry"
-)
-
 func NewSubscribeOptions(opts ...SubscribeOption) SubscribeOptions {
 	opt := SubscribeOptions{
 		AutoAck: true,


### PR DESCRIPTION
This removes the unused `registryKey` variable from the `broker` package.