### PR TITLE
runtime/kubernetes: remove unused constants

### DIFF
--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -14,12 +14,6 @@ import (
 // action to take on runtime service
 type action int
 
-const (
-	start action = iota
-	update
-	stop
-)
-
 type kubernetes struct {
 	sync.RWMutex
 	// options configure runtime


### PR DESCRIPTION
This removes three apparently unused constant variables (`start`, `stop`, and 'update`) from `runtime/kubernetes`.