### PR TITLE
when the stream errors cleanup the connection

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -218,6 +218,12 @@ func (g *grpcClient) stream(ctx context.Context, node *registry.Node, req client
 
 	st, err := cc.NewStream(newCtx, desc, methodToGRPC(req.Service(), req.Endpoint()), grpcCallOptions...)
 	if err != nil {
+		// we need to cleanup as we dialled and created a context
+		// cancel the context
+		cancel()
+		// close the connection
+		cc.Close()
+		// now return the error
 		return nil, errors.InternalServerError("go.micro.client", fmt.Sprintf("Error creating stream: %v", err))
 	}
 


### PR DESCRIPTION
Bug fix for proxy connection leak. We don't cleanup the dialled conn when an error occurs during cc.NewStream, this can occur where we've actually dialled something that doesn't exist. gRPC Dial is non-blocking so this is a quirk.