### PR TITLE
Provide a callback to an RPC service

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -46,6 +46,8 @@ type Options struct {
 	// Other options for implementations of the interface
 	// can be stored in a context
 	Context context.Context
+
+	RPCErrorCB func(Server, error)
 }
 
 func newOptions(opt ...Option) Options {

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -804,6 +804,11 @@ func (s *rpcServer) Start() error {
 			// check the error and backoff
 			default:
 				if err != nil {
+					if s.opts.RPCErrorCB != nil {
+						s.opts.RPCErrorCB(s, err)
+						continue
+					}
+
 					log.Logf("Accept error: %v", err)
 					time.Sleep(time.Second)
 					continue


### PR DESCRIPTION
This callback allows to fix an infinite loop if NATS broker goes out.
Other handling routines could be also provided by a user of an RPC service.