### PR TITLE
secure the grpc client

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,7 +51,7 @@ func (g *grpcClient) secure(addr string) grpc.DialOption {
 
 	tlsConfig := &tls.Config{}
 	// default config
-	defaultCreds := grpc.WithTransportCredentials(credentials.NewTLS(config))
+	defaultCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 
 	// check if the address is prepended with https
 	if strings.HasPrefix(addr, "https://") {
@@ -57,9 +59,9 @@ func (g *grpcClient) secure(addr string) grpc.DialOption {
 	}
 
 	// if no port is specified or port is 443 default to tls
-	host, port, err := net.SplitHostPort(addr)
+	_, port, err := net.SplitHostPort(addr)
 	// assuming with no port its going to be secured
-	if port == 443 {
+	if port == "443" {
 		return defaultCreds
 	} else if err != nil && strings.Contains(err.Error(), "missing port in address") {
 		return defaultCreds

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -49,7 +49,7 @@ func (g *grpcClient) secure(addr string) grpc.DialOption {
 		}
 	}
 
-	// // default config
+	// default config
 	tlsConfig := &tls.Config{}
 	defaultCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -4,11 +4,12 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -50,9 +51,15 @@ func (g *grpcClient) secure(addr string) grpc.DialOption {
 		}
 	}
 
-	tlsConfig := &tls.Config{}
 	// default config
-	defaultCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
+	systemRoots, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatal("failed to load system root CA cert pool")
+	}
+	tlsConfig := credentials.NewTLS(&tls.Config{
+		RootCAs: systemRoots,
+	})
+	defaultCreds := grpc.WithTransportCredentials(tlsConfig)
 
 	// check if the address is prepended with https
 	if strings.HasPrefix(addr, "https://") {

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -4,9 +4,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"strings"
@@ -51,15 +49,9 @@ func (g *grpcClient) secure(addr string) grpc.DialOption {
 		}
 	}
 
-	// default config
-	systemRoots, err := x509.SystemCertPool()
-	if err != nil {
-		log.Fatal("failed to load system root CA cert pool")
-	}
-	tlsConfig := credentials.NewTLS(&tls.Config{
-		RootCAs: systemRoots,
-	})
-	defaultCreds := grpc.WithTransportCredentials(tlsConfig)
+	// // default config
+	tlsConfig := &tls.Config{}
+	defaultCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 
 	// check if the address is prepended with https
 	if strings.HasPrefix(addr, "https://") {


### PR DESCRIPTION
This change creates a secure grpc client where no port is present in the address or 443 is specified. It's assuming much like net/http that the machine has root certs that then go up the chain to find the authority. Basically anything with a valid tls cert will work.

Where no port is specified gRPC-go adds the default port of 443. Our client will now assume a similar behaviour. Because our environment and most others have dynamic ports or non 443 ports it will continue to fallback to insecure. 

For our proxy case. We're going to assume MICRO_PROXY_ADDRESS=proxy.micro.mu serving let's encrypt tls certs will work. Where this has been set to MICRO_PROXY_ADDRESS=micro-proxy:8081 this will fallback to insecure. Our proxy contains an external server and an internal server. So both will work. 

Note: I did not make the same change in the rpc client but that might also make sense.