### PR TITLE
server/grpc: Prune Unused Code

### DIFF
--- a/server/grpc/codec.go
+++ b/server/grpc/codec.go
@@ -10,8 +10,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/micro/go-micro/v2/codec"
 	"github.com/micro/go-micro/v2/codec/bytes"
-	"github.com/micro/go-micro/v2/codec/jsonrpc"
-	"github.com/micro/go-micro/v2/codec/protorpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
@@ -34,14 +32,6 @@ var (
 		"application/grpc+json":    jsonCodec{},
 		"application/grpc+proto":   protoCodec{},
 		"application/grpc+bytes":   bytesCodec{},
-	}
-
-	defaultRPCCodecs = map[string]codec.NewCodec{
-		"application/json":         jsonrpc.NewCodec,
-		"application/json-rpc":     jsonrpc.NewCodec,
-		"application/protobuf":     protorpc.NewCodec,
-		"application/proto-rpc":    protorpc.NewCodec,
-		"application/octet-stream": protorpc.NewCodec,
 	}
 )
 

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/micro/go-micro/v2/broker"
-	"github.com/micro/go-micro/v2/codec"
 	"github.com/micro/go-micro/v2/errors"
 	meta "github.com/micro/go-micro/v2/metadata"
 	"github.com/micro/go-micro/v2/registry"
@@ -506,16 +505,6 @@ func (g *grpcServer) newGRPCCodec(contentType string) (encoding.Codec, error) {
 	}
 	if c, ok := defaultGRPCCodecs[contentType]; ok {
 		return c, nil
-	}
-	return nil, fmt.Errorf("Unsupported Content-Type: %s", contentType)
-}
-
-func (g *grpcServer) newCodec(contentType string) (codec.NewCodec, error) {
-	if cf, ok := g.opts.Codecs[contentType]; ok {
-		return cf, nil
-	}
-	if cf, ok := defaultRPCCodecs[contentType]; ok {
-		return cf, nil
 	}
 	return nil, fmt.Errorf("Unsupported Content-Type: %s", contentType)
 }


### PR DESCRIPTION
This removes the unused function `grpcServer.newCodec()` and its related map `defaultRPCCodecs`.