### PR TITLE
broker/nats: Prune Unused Functions

### DIFF
--- a/broker/nats/context.go
+++ b/broker/nats/context.go
@@ -6,29 +6,9 @@ import (
 	"github.com/micro/go-micro/v2/broker"
 )
 
-// setSubscribeOption returns a function to setup a context with given value
-func setSubscribeOption(k, v interface{}) broker.SubscribeOption {
-	return func(o *broker.SubscribeOptions) {
-		if o.Context == nil {
-			o.Context = context.Background()
-		}
-		o.Context = context.WithValue(o.Context, k, v)
-	}
-}
-
 // setBrokerOption returns a function to setup a context with given value
 func setBrokerOption(k, v interface{}) broker.Option {
 	return func(o *broker.Options) {
-		if o.Context == nil {
-			o.Context = context.Background()
-		}
-		o.Context = context.WithValue(o.Context, k, v)
-	}
-}
-
-// setPublishOption returns a function to setup a context with given value
-func setPublishOption(k, v interface{}) broker.PublishOption {
-	return func(o *broker.PublishOptions) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}


### PR DESCRIPTION
This removes the unused functions `setSubscribeOption()' and 'setPublishOption()' from `broker/nats`.