### PR TITLE
Rename PR job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
 
   prtest:
-    name: Test repo
+    name: PR sanity check
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Having 2 jobs with the same name means you can't select one to be required