### PR TITLE
fix grpc json codec

### DIFF
--- a/server/grpc/codec.go
+++ b/server/grpc/codec.go
@@ -80,11 +80,6 @@ func (protoCodec) Name() string {
 }
 
 func (jsonCodec) Marshal(v interface{}) ([]byte, error) {
-	if pb, ok := v.(proto.Message); ok {
-		s, err := jsonpbMarshaler.MarshalToString(pb)
-		return []byte(s), err
-	}
-
 	return json.Marshal(v)
 }
 


### PR DESCRIPTION
`jsonpbMarshaler.MarshalToString` make enum type translate to string in response, and cause many problems in web side.