### PR TITLE
Set option and cli args to the service profile

### DIFF
--- a/config/cmd/options.go
+++ b/config/cmd/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/micro/go-micro/v2/broker"
 	"github.com/micro/go-micro/v2/client"
 	"github.com/micro/go-micro/v2/client/selector"
+	"github.com/micro/go-micro/v2/debug/profile"
 	"github.com/micro/go-micro/v2/debug/trace"
 	"github.com/micro/go-micro/v2/registry"
 	"github.com/micro/go-micro/v2/runtime"
@@ -32,6 +33,7 @@ type Options struct {
 	Store     *store.Store
 	Tracer    *trace.Tracer
 	Auth      *auth.Auth
+	Profile   *profile.Profile
 
 	Brokers    map[string]func(...broker.Option) broker.Broker
 	Clients    map[string]func(...client.Option) client.Client
@@ -43,6 +45,7 @@ type Options struct {
 	Stores     map[string]func(...store.Option) store.Store
 	Tracers    map[string]func(...trace.Option) trace.Tracer
 	Auths      map[string]func(...auth.Option) auth.Auth
+	Profiles   map[string]func(...profile.Option) profile.Profile
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -115,6 +118,12 @@ func Tracer(t *trace.Tracer) Option {
 func Auth(a *auth.Auth) Option {
 	return func(o *Options) {
 		o.Auth = a
+	}
+}
+
+func Profile(p *profile.Profile) Option {
+	return func(o *Options) {
+		o.Profile = p
 	}
 }
 

--- a/debug/profile/profile.go
+++ b/debug/profile/profile.go
@@ -10,6 +10,24 @@ type Profile interface {
 	String() string
 }
 
+var (
+	DefaultProfile Profile = new(noop)
+)
+
+type noop struct{}
+
+func (p *noop) Start() error {
+	return nil
+}
+
+func (p *noop) Stop() error {
+	return nil
+}
+
+func (p *noop) String() string {
+	return "noop"
+}
+
 type Options struct {
 	// Name to use for the profile
 	Name string

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/micro/go-micro/v2/client"
 	"github.com/micro/go-micro/v2/client/selector"
 	"github.com/micro/go-micro/v2/config/cmd"
+	"github.com/micro/go-micro/v2/debug/profile"
 	"github.com/micro/go-micro/v2/debug/trace"
 	"github.com/micro/go-micro/v2/registry"
 	"github.com/micro/go-micro/v2/server"
@@ -25,6 +26,7 @@ type Options struct {
 	Server    server.Server
 	Registry  registry.Registry
 	Transport transport.Transport
+	Profile   profile.Profile
 
 	// Before and After funcs
 	BeforeStart []func() error
@@ -96,6 +98,13 @@ func Context(ctx context.Context) Option {
 func HandleSignal(b bool) Option {
 	return func(o *Options) {
 		o.Signal = b
+	}
+}
+
+// Profile to be used for debug profile
+func Profile(p profile.Profile) Option {
+	return func(o *Options) {
+		o.Profile = p
 	}
 }
 


### PR DESCRIPTION
Profile disabled default.
There are multiple easy ways to enable profile same like other micro options.

### With cli args
```
./demo-srv --profile=http    # Enable HTTP profile 
./demo-srv --profile=pprof   # Enable local file profile 
```

### With option

```go
import (
	"github.com/micro/go-micro/v2"
	"github.com/micro/go-micro/v2/debug/profile/http"
)

service := micro.NewService(
	micro.Name("example.service.srv.demo"),
	micro.Profile(http.NewProfile()),    // Enable HTTP profile 
)
// ...
service.Run()
```

## With environment variables

```shell
MICRO_DEBUG_PROFILE=http \
    ./demo-srv
```
