### PR TITLE
feat(dockerfile): adding dumb-init to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /user && \
     echo 'nobody:x:65534:' > /user/group
 
 ENV GO111MODULE=on
-RUN apk --no-cache add make git gcc libtool musl-dev ca-certificates && \
+RUN apk --no-cache add make git gcc libtool musl-dev ca-certificates dumb-init && \
     rm -rf /var/cache/apk/* /tmp/*
 
 WORKDIR /


### PR DESCRIPTION
This helps us adopt recommended `dumb-init` when building go-micro based microservices.

```
COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
```

https://github.com/xmlking/micro-starter-kit/blob/develop/Dockerfile#L44