### PR TITLE
Fix Auth Headers

### DIFF
--- a/api/server/cors/cors.go
+++ b/api/server/cors/cors.go
@@ -38,6 +38,7 @@ func SetHeaders(w http.ResponseWriter, r *http.Request) {
 		set(w, "Access-Control-Allow-Origin", "*")
 	}
 
+	set(w, "Access-Control-Allow-Credentials", "true")
 	set(w, "Access-Control-Allow-Methods", "POST, PATCH, GET, OPTIONS, PUT, DELETE")
 	set(w, "Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -123,7 +123,7 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	if md, ok := metadata.FromContext(ctx); ok {
 		header = make(map[string]string, len(md))
 		for k, v := range md {
-			header[k] = v
+			header[strings.ToLower(k)] = v
 		}
 	} else {
 		header = make(map[string]string)
@@ -133,9 +133,12 @@ func (g *grpcClient) call(ctx context.Context, node *registry.Node, req client.R
 	header["timeout"] = fmt.Sprintf("%d", opts.RequestTimeout)
 	// set the content type for the request
 	header["x-content-type"] = req.ContentType()
+
 	// set the authorization token if one is saved locally
-	if token, err := config.Get("token"); err == nil && len(token) > 0 {
-		header["authorization"] = BearerScheme + token
+	if len(header["authorization"]) == 0 {
+		if token, err := config.Get("token"); err == nil && len(token) > 0 {
+			header["authorization"] = BearerScheme + token
+		}
 	}
 
 	md := gmetadata.New(header)


### PR DESCRIPTION
• When a token is found in the cookies, set this in the authorization header
• Update grpc to only use config auth token if header not already set
• Update CORS to allow cookies to be sent in the request headers