### PR TITLE
Add secrets interface to config/secrets

### DIFF
--- a/config/secrets/box/box.go
+++ b/config/secrets/box/box.go
@@ -1,0 +1,45 @@
+// Package box is an asymmetric implementation of config/secrets using nacl/box
+package box
+
+import "github.com/micro/go-micro/v2/config/secrets"
+
+type box struct {
+	options secrets.Options
+
+	publicKey  [32]byte
+	privateKey [32]byte
+}
+
+// NewCodec returns a nacl-box codec
+func NewCodec(opts ...secrets.Option) secrets.Codec {
+	b := &box{}
+	for _, o := range opts {
+		o(&b.options)
+	}
+	return b
+}
+
+// Init initialises a box
+func (b *box) Init(...secrets.Option) error {
+	return nil
+}
+
+// Options returns options
+func (b *box) Options() secrets.Options {
+	return b.options
+}
+
+// String returns nacl-box
+func (*box) String() string {
+	return "nacl-box"
+}
+
+// Encrypt encrypts
+func (b *box) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, error) {
+	return nil, nil
+}
+
+// Decrypt Decrypts
+func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte), error) {
+	return nil, nil
+}

--- a/config/secrets/box/box.go
+++ b/config/secrets/box/box.go
@@ -1,7 +1,13 @@
 // Package box is an asymmetric implementation of config/secrets using nacl/box
 package box
 
-import "github.com/micro/go-micro/v2/config/secrets"
+import (
+	"github.com/micro/go-micro/v2/config/secrets"
+	"github.com/pkg/errors"
+	naclbox "golang.org/x/crypto/nacl/box"
+
+	"crypto/rand"
+)
 
 type box struct {
 	options secrets.Options
@@ -20,7 +26,15 @@ func NewCodec(opts ...secrets.Option) secrets.Codec {
 }
 
 // Init initialises a box
-func (b *box) Init(...secrets.Option) error {
+func (b *box) Init(opts ...secrets.Option) error {
+	for _, o := range opts {
+		o(&b.options)
+	}
+	if len(b.options.PrivateKey) != 32 || len(b.options.PublicKey) != 32 {
+		return errors.New("A 32 byte public and private key must be provided")
+	}
+	copy(b.privateKey[:], b.options.PrivateKey)
+	copy(b.publicKey[:], b.options.PublicKey)
 	return nil
 }
 
@@ -34,12 +48,40 @@ func (*box) String() string {
 	return "nacl-box"
 }
 
-// Encrypt encrypts
+// Encrypt encrypts a message with the sender's private key and the receipient's public key
 func (b *box) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, error) {
-	return nil, nil
+	var options secrets.EncryptOptions
+	for _, o := range opts {
+		o(&options)
+	}
+	if len(options.RecipientPublicKey) != 32 {
+		return []byte{}, errors.New("Recepient's public key must be provided")
+	}
+	var recipientPublicKey [32]byte
+	copy(recipientPublicKey[:], options.RecipientPublicKey)
+	var nonce [24]byte
+	if _, err := rand.Reader.Read(nonce[:]); err != nil {
+		return []byte{}, errors.Wrap(err, "Couldn't obtain a random nonce from crypto/rand")
+	}
+	return naclbox.Seal(nonce[:], in, &nonce, &recipientPublicKey, &b.privateKey), nil
 }
 
-// Decrypt Decrypts
+// Decrypt Decrypts a message with the receiver's private key and the sender's public key
 func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, error) {
-	return nil, nil
+	var options secrets.DecryptOptions
+	for _, o := range opts {
+		o(&options)
+	}
+	if len(options.SenderPublicKey) != 32 {
+		return []byte{}, errors.New("Sender's public key bust be provided")
+	}
+	var nonce [24]byte
+	var senderPublicKey [32]byte
+	copy(nonce[:], in[:24])
+	copy(senderPublicKey[:], options.SenderPublicKey)
+	decrypted, ok := naclbox.Open(nil, in[24:], &nonce, &senderPublicKey, &b.privateKey)
+	if !ok {
+		return []byte{}, errors.New("Incoming message couldn't be verified / decrypted")
+	}
+	return decrypted, nil
 }

--- a/config/secrets/box/box.go
+++ b/config/secrets/box/box.go
@@ -9,11 +9,13 @@ import (
 	"crypto/rand"
 )
 
+const keyLength = 32
+
 type box struct {
 	options secrets.Options
 
-	publicKey  [32]byte
-	privateKey [32]byte
+	publicKey  [keyLength]byte
+	privateKey [keyLength]byte
 }
 
 // NewCodec returns a nacl-box codec
@@ -30,8 +32,8 @@ func (b *box) Init(opts ...secrets.Option) error {
 	for _, o := range opts {
 		o(&b.options)
 	}
-	if len(b.options.PrivateKey) != 32 || len(b.options.PublicKey) != 32 {
-		return errors.New("A 32 byte public and private key must be provided")
+	if len(b.options.PrivateKey) != keyLength || len(b.options.PublicKey) != keyLength {
+		return errors.Errorf("a public key and a private key of length %d must both be provided", keyLength)
 	}
 	copy(b.privateKey[:], b.options.PrivateKey)
 	copy(b.publicKey[:], b.options.PublicKey)
@@ -54,14 +56,14 @@ func (b *box) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, error) 
 	for _, o := range opts {
 		o(&options)
 	}
-	if len(options.RecipientPublicKey) != 32 {
-		return []byte{}, errors.New("Recepient's public key must be provided")
+	if len(options.RecipientPublicKey) != keyLength {
+		return []byte{}, errors.New("recepient's public key must be provided")
 	}
-	var recipientPublicKey [32]byte
+	var recipientPublicKey [keyLength]byte
 	copy(recipientPublicKey[:], options.RecipientPublicKey)
 	var nonce [24]byte
 	if _, err := rand.Reader.Read(nonce[:]); err != nil {
-		return []byte{}, errors.Wrap(err, "Couldn't obtain a random nonce from crypto/rand")
+		return []byte{}, errors.Wrap(err, "couldn't obtain a random nonce from crypto/rand")
 	}
 	return naclbox.Seal(nonce[:], in, &nonce, &recipientPublicKey, &b.privateKey), nil
 }
@@ -72,8 +74,8 @@ func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, error) 
 	for _, o := range opts {
 		o(&options)
 	}
-	if len(options.SenderPublicKey) != 32 {
-		return []byte{}, errors.New("Sender's public key bust be provided")
+	if len(options.SenderPublicKey) != keyLength {
+		return []byte{}, errors.New("sender's public key bust be provided")
 	}
 	var nonce [24]byte
 	var senderPublicKey [32]byte
@@ -81,7 +83,7 @@ func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, error) 
 	copy(senderPublicKey[:], options.SenderPublicKey)
 	decrypted, ok := naclbox.Open(nil, in[24:], &nonce, &senderPublicKey, &b.privateKey)
 	if !ok {
-		return []byte{}, errors.New("Incoming message couldn't be verified / decrypted")
+		return []byte{}, errors.New("incoming message couldn't be verified / decrypted")
 	}
 	return decrypted, nil
 }

--- a/config/secrets/box/box.go
+++ b/config/secrets/box/box.go
@@ -40,6 +40,6 @@ func (b *box) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, error) 
 }
 
 // Decrypt Decrypts
-func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte), error) {
+func (b *box) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, error) {
 	return nil, nil
 }

--- a/config/secrets/box/box_test.go
+++ b/config/secrets/box/box_test.go
@@ -1,0 +1,63 @@
+package box
+
+import (
+	"crypto/rand"
+	"reflect"
+	"testing"
+
+	"github.com/micro/go-micro/v2/config/secrets"
+	naclbox "golang.org/x/crypto/nacl/box"
+)
+
+func TestBox(t *testing.T) {
+	alicePublicKey, alicePrivateKey, err := naclbox.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bobPublicKey, bobPrivateKey, err := naclbox.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice, bob := NewCodec(secrets.PublicKey(alicePublicKey[:]), secrets.PrivateKey(alicePrivateKey[:])), NewCodec()
+	if err := alice.Init(); err != nil {
+		t.Error(err)
+	}
+	if err := bob.Init(secrets.PublicKey(bobPublicKey[:]), secrets.PrivateKey(bobPrivateKey[:])); err != nil {
+		t.Error(err)
+	}
+	if alice.String() != "nacl-box" {
+		t.Error("String() doesn't return nacl-box")
+	}
+	aliceSecret := []byte("Why is a raven like a writing-desk?")
+	if _, err := alice.Encrypt(aliceSecret); err == nil {
+		t.Error("alice.Encrypt succeded without a public key")
+	}
+	enc, err := alice.Encrypt(aliceSecret, secrets.RecipientPublicKey(bob.Options().PublicKey))
+	if err != nil {
+		t.Error("alice.Encrypt failed")
+	}
+	if _, err := bob.Decrypt(enc); err == nil {
+		t.Error("bob.Decrypt succeded without a public key")
+	}
+	if dec, err := bob.Decrypt(enc, secrets.SenderPublicKey(alice.Options().PublicKey)); err == nil {
+		if !reflect.DeepEqual(dec, aliceSecret) {
+			t.Errorf("Bob's decrypted message didn't match Alice's encrypted message: %v != %v", aliceSecret, dec)
+		}
+	} else {
+		t.Errorf("bob.Decrypt failed (%s)", err)
+	}
+
+	bobSecret := []byte("I haven't the slightest idea")
+	enc, err = bob.Encrypt(bobSecret, secrets.RecipientPublicKey(alice.Options().PublicKey))
+	if err != nil {
+		t.Error(err)
+	}
+	dec, err := alice.Decrypt(enc, secrets.SenderPublicKey(bob.Options().PrivateKey))
+	if err == nil {
+		t.Error(err)
+	}
+	dec, err = alice.Decrypt(enc, secrets.SenderPublicKey(bob.Options().PublicKey))
+	if !reflect.DeepEqual(dec, bobSecret) {
+		t.Errorf("Alice's decrypted message didn't match Bob's encrypted message %v != %v", bobSecret, dec)
+	}
+}

--- a/config/secrets/secretbox/secretbox.go
+++ b/config/secrets/secretbox/secretbox.go
@@ -1,0 +1,71 @@
+// Package secretbox is a config/secrets implementation that uses nacl/secretbox
+// to do symmetric encryption / verification
+package secretbox
+
+import (
+	"github.com/micro/go-micro/v2/config/secrets"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/nacl/secretbox"
+
+	"crypto/rand"
+)
+
+type secretBox struct {
+	options secrets.Options
+
+	secretKey [32]byte
+}
+
+// NewCodec returns a secretbox codec
+func NewCodec(opts ...secrets.Option) secrets.Codec {
+	sb := &secretBox{}
+	for _, o := range opts {
+		o(&sb.options)
+	}
+	return sb
+}
+
+func (s *secretBox) Init(opts ...secrets.Option) error {
+	for _, o := range opts {
+		o(&s.options)
+	}
+	if len(s.options.SecretKey) == 0 {
+		return errors.New("No secret Key is defined")
+	}
+	if len(s.options.SecretKey) != 32 {
+		return errors.New("Secret Key must be 32 bytes long")
+	}
+	copy(s.secretKey[:], s.options.SecretKey)
+	return nil
+}
+
+func (s *secretBox) Options() secrets.Options {
+	return s.options
+}
+
+func (s *secretBox) String() string {
+	return "nacl-secretbox"
+}
+
+func (s *secretBox) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, error) {
+	// no opts are expected, so they are ignored
+
+	// there must be a unique nonce for each message
+	var nonce [24]byte
+	if _, err := rand.Reader.Read(nonce[:]); err != nil {
+		return []byte{}, errors.Wrap(err, "Couldn't obtain a random nonce from crypto/rand")
+	}
+	return secretbox.Seal(nonce[:], in, &nonce, &s.secretKey), nil
+}
+
+func (s *secretBox) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, error) {
+	// no options are expected, so they are ignored
+
+	var decryptNonce [24]byte
+	copy(decryptNonce[:], in[:24])
+	decrypted, ok := secretbox.Open(nil, in[24:], &decryptNonce, &s.secretKey)
+	if !ok {
+		return []byte{}, errors.New("Decryption failed (is the key set correctly?)")
+	}
+	return decrypted, nil
+}

--- a/config/secrets/secretbox/secretbox.go
+++ b/config/secrets/secretbox/secretbox.go
@@ -10,10 +10,12 @@ import (
 	"crypto/rand"
 )
 
+const keyLength = 32
+
 type secretBox struct {
 	options secrets.Options
 
-	secretKey [32]byte
+	secretKey [keyLength]byte
 }
 
 // NewCodec returns a secretbox codec
@@ -30,10 +32,10 @@ func (s *secretBox) Init(opts ...secrets.Option) error {
 		o(&s.options)
 	}
 	if len(s.options.SecretKey) == 0 {
-		return errors.New("No secret Key is defined")
+		return errors.New("no secret key is defined")
 	}
-	if len(s.options.SecretKey) != 32 {
-		return errors.New("Secret Key must be 32 bytes long")
+	if len(s.options.SecretKey) != keyLength {
+		return errors.Errorf("secret key must be %d bytes long", keyLength)
 	}
 	copy(s.secretKey[:], s.options.SecretKey)
 	return nil
@@ -53,7 +55,7 @@ func (s *secretBox) Encrypt(in []byte, opts ...secrets.EncryptOption) ([]byte, e
 	// there must be a unique nonce for each message
 	var nonce [24]byte
 	if _, err := rand.Reader.Read(nonce[:]); err != nil {
-		return []byte{}, errors.Wrap(err, "Couldn't obtain a random nonce from crypto/rand")
+		return []byte{}, errors.Wrap(err, "couldn't obtain a random nonce from crypto/rand")
 	}
 	return secretbox.Seal(nonce[:], in, &nonce, &s.secretKey), nil
 }
@@ -65,7 +67,7 @@ func (s *secretBox) Decrypt(in []byte, opts ...secrets.DecryptOption) ([]byte, e
 	copy(decryptNonce[:], in[:24])
 	decrypted, ok := secretbox.Open(nil, in[24:], &decryptNonce, &s.secretKey)
 	if !ok {
-		return []byte{}, errors.New("Decryption failed (is the key set correctly?)")
+		return []byte{}, errors.New("decryption failed (is the key set correctly?)")
 	}
 	return decrypted, nil
 }

--- a/config/secrets/secretbox/secretbox_test.go
+++ b/config/secrets/secretbox/secretbox_test.go
@@ -1,0 +1,56 @@
+package secretbox
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	"github.com/micro/go-micro/v2/config/secrets"
+)
+
+func TestSecretBox(t *testing.T) {
+	secretKey, err := base64.StdEncoding.DecodeString("4jbVgq8FsAV7vy+n8WqEZrl7BUtNqh3fYT5RXzXOPFY=")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewCodec()
+
+	if err := s.Init(); err == nil {
+		t.Error("Secretbox accepted an empty secret key")
+	}
+	if err := s.Init(secrets.SecretKey([]byte("invalid"))); err == nil {
+		t.Error("Secretbox accepted a secret key that is invalid")
+	}
+
+	if err := s.Init(secrets.SecretKey(secretKey)); err != nil {
+		t.Fatal(err)
+	}
+
+	o := s.Options()
+	if !reflect.DeepEqual(o.SecretKey, secretKey) {
+		t.Error("Init() didn't set secret key correctly")
+	}
+	if s.String() != "nacl-secretbox" {
+		t.Error(s.String() + " should be nacl-secretbox")
+	}
+
+	// Try 10 times to get different nonces
+	for i := 0; i < 10; i++ {
+		message := []byte(`Can you hear me, Major Tom?`)
+
+		encrypted, err := s.Encrypt(message)
+		if err != nil {
+			t.Errorf("Failed to encrypt message (%s)", err)
+		}
+
+		decrypted, err := s.Decrypt(encrypted)
+		if err != nil {
+			t.Errorf("Failed to decrypt encrypted message (%s)", err)
+		}
+
+		if !reflect.DeepEqual(message, decrypted) {
+			t.Errorf("Decrypted Message dod not match encrypted message")
+		}
+	}
+}

--- a/config/secrets/secrets.go
+++ b/config/secrets/secrets.go
@@ -8,8 +8,8 @@ type Codec interface {
 	Init(...Option) error
 	Options() Options
 	String() string
-	Decrypt([]byte) []byte
-	Encrypt([]byte) []byte
+	Decrypt([]byte, ...DecryptOption) ([]byte, error)
+	Encrypt([]byte, ...EncryptOption) ([]byte, error)
 }
 
 // Options is a codec's options

--- a/config/secrets/secrets.go
+++ b/config/secrets/secrets.go
@@ -28,21 +28,24 @@ type Option func(*Options)
 // SecretKey sets the symmetric secret key
 func SecretKey(key []byte) Option {
 	return func(o *Options) {
-		o.SecretKey = key
+		o.SecretKey = make([]byte, len(key))
+		copy(o.SecretKey, key)
 	}
 }
 
 // PublicKey sets the asymmetric Public Key of this codec
 func PublicKey(key []byte) Option {
 	return func(o *Options) {
-		o.PublicKey = key
+		o.PublicKey = make([]byte, len(key))
+		copy(o.PublicKey, key)
 	}
 }
 
 // PrivateKey sets the asymmetric Private Key of this codec
 func PrivateKey(key []byte) Option {
 	return func(o *Options) {
-		o.PrivateKey = key
+		o.PrivateKey = make([]byte, len(key))
+		copy(o.PrivateKey, key)
 	}
 }
 
@@ -57,7 +60,8 @@ type DecryptOption func(*DecryptOptions)
 // SenderPublicKey is the Public Key of the Codec that encrypted this message
 func SenderPublicKey(key []byte) DecryptOption {
 	return func(d *DecryptOptions) {
-		d.SenderPublicKey = key
+		d.SenderPublicKey = make([]byte, len(key))
+		copy(d.SenderPublicKey, key)
 	}
 }
 
@@ -72,6 +76,7 @@ type EncryptOption func(*EncryptOptions)
 // RecipientPublicKey is the Public Key of the Codec that will decrypt this message
 func RecipientPublicKey(key []byte) EncryptOption {
 	return func(e *EncryptOptions) {
-		e.RecipientPublicKey = key
+		e.RecipientPublicKey = make([]byte, len(key))
+		copy(e.RecipientPublicKey, key)
 	}
 }

--- a/config/secrets/secrets.go
+++ b/config/secrets/secrets.go
@@ -1,0 +1,77 @@
+// Package secrets is an interface for encrypting and decrypting secrets
+package secrets
+
+import "context"
+
+// Codec encrypts or decrypts arbitrary data. The data should be as small as possible
+type Codec interface {
+	Init(...Option) error
+	Options() Options
+	String() string
+	Decrypt([]byte) []byte
+	Encrypt([]byte) []byte
+}
+
+// Options is a codec's options
+// SecretKey or both PublicKey and PrivateKey should be set depending on the
+// underlying implementation
+type Options struct {
+	SecretKey  []byte
+	PrivateKey []byte
+	PublicKey  []byte
+	Context    context.Context
+}
+
+// Option sets options
+type Option func(*Options)
+
+// SecretKey sets the symmetric secret key
+func SecretKey(key []byte) Option {
+	return func(o *Options) {
+		o.SecretKey = key
+	}
+}
+
+// PublicKey sets the asymmetric Public Key of this codec
+func PublicKey(key []byte) Option {
+	return func(o *Options) {
+		o.PublicKey = key
+	}
+}
+
+// PrivateKey sets the asymmetric Private Key of this codec
+func PrivateKey(key []byte) Option {
+	return func(o *Options) {
+		o.PrivateKey = key
+	}
+}
+
+// DecryptOptions can be passed to Codec.Decrypt
+type DecryptOptions struct {
+	SenderPublicKey []byte
+}
+
+// DecryptOption sets DecryptOptions
+type DecryptOption func(*DecryptOptions)
+
+// SenderPublicKey is the Public Key of the Codec that encrypted this message
+func SenderPublicKey(key []byte) DecryptOption {
+	return func(d *DecryptOptions) {
+		d.SenderPublicKey = key
+	}
+}
+
+// EncryptOptions can be passed to Codec.Encrypt
+type EncryptOptions struct {
+	RecipientPublicKey []byte
+}
+
+// EncryptOption Sets EncryptOptions
+type EncryptOption func(*EncryptOptions)
+
+// RecipientPublicKey is the Public Key of the Codec that will decrypt this message
+func RecipientPublicKey(key []byte) EncryptOption {
+	return func(e *EncryptOptions) {
+		e.RecipientPublicKey = key
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,7 @@ github.com/mholt/certmagic v0.9.3 h1:RmzuNJ5mpFplDbyS41z+gGgE/py24IX6m0nHZ0yNTQU
 github.com/mholt/certmagic v0.9.3/go.mod h1:nu8jbsbtwK4205EDH/ZUMTKsfYpJA1Q7MKXHfgTihNw=
 github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
+github.com/micro/go-micro v1.18.0 h1:gP70EZVHpJuUIT0YWth192JmlIci+qMOEByHm83XE9E=
 github.com/micro/mdns v0.3.0 h1:bYycYe+98AXR3s8Nq5qvt6C573uFTDPIYzJemWON0QE=
 github.com/micro/mdns v0.3.0/go.mod h1:KJ0dW7KmicXU2BV++qkLlmHYcVv7/hHnbtguSWt9Aoc=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -461,6 +462,7 @@ golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go.sum
+++ b/go.sum
@@ -284,7 +284,6 @@ github.com/mholt/certmagic v0.9.3 h1:RmzuNJ5mpFplDbyS41z+gGgE/py24IX6m0nHZ0yNTQU
 github.com/mholt/certmagic v0.9.3/go.mod h1:nu8jbsbtwK4205EDH/ZUMTKsfYpJA1Q7MKXHfgTihNw=
 github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
-github.com/micro/go-micro v1.18.0 h1:gP70EZVHpJuUIT0YWth192JmlIci+qMOEByHm83XE9E=
 github.com/micro/mdns v0.3.0 h1:bYycYe+98AXR3s8Nq5qvt6C573uFTDPIYzJemWON0QE=
 github.com/micro/mdns v0.3.0/go.mod h1:KJ0dW7KmicXU2BV++qkLlmHYcVv7/hHnbtguSWt9Aoc=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -462,7 +461,6 @@ golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
This adds an interface for using asymmetric (public key cryptography) and symmetric encryption to encipher small messages. I've also included an implementation of each using http://nacl.cr.yp.to/