### PR TITLE
Add client header to rpcRequest header; issue #957

### DIFF
--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -211,6 +211,7 @@ func (s *service) call(ctx context.Context, router *router, sending *sync.Mutex,
 		method:      req.msg.Method,
 		endpoint:    req.msg.Endpoint,
 		body:        req.msg.Body,
+		header:      req.msg.Header,
 	}
 
 	// only set if not nil


### PR DESCRIPTION
Client send header to server, but server did not copy client header to rpcRequest.
