### PR TITLE
Fixed nsq one queue run multiple times handlers, issue #1209

### DIFF
--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -526,6 +526,11 @@ func (router *router) ProcessMessage(ctx context.Context, msg Message) (err erro
 
 	// we may have multiple subscribers for the topic
 	for _, sub := range subs {
+		// Nsq one subscriber had multiple queue, one queue bind to one connection, skip repeat subscriber.
+		if sub.opts.Queue != msg.Header()["Queue"] {
+			continue
+		}
+
 		// we may have multiple handlers per subscriber
 		for i := 0; i < len(sub.handlers); i++ {
 			// get the handler


### PR DESCRIPTION
If nsq broker subscribe with three queues, message will run 3*3=9 times handlers.

So add queue check before handler.

https://github.com/micro/go-micro/issues/1209

I add pr to go-plugins also.
https://github.com/micro/go-plugins/pull/513
