### PR TITLE
[FEATURE] add call options proxy, overrides MICRO_PROXY environment

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -80,7 +80,14 @@ func (g *grpcClient) next(request client.Request, opts client.CallOptions) (sele
 	service := request.Service()
 
 	// get proxy
-	if prx := os.Getenv("MICRO_PROXY"); len(prx) > 0 {
+	prx := ""
+	if len(opts.Proxy) > 0 {
+		// call options first
+		prx = opts.Proxy
+	} else if prxEnv := os.Getenv("MICRO_PROXY"); len(prxEnv) > 0 {
+		prx = prxEnv
+	}
+	if len(prx) > 0 {
 		// default name
 		if prx == "service" {
 			prx = "go.micro.proxy"

--- a/client/options.go
+++ b/client/options.go
@@ -56,6 +56,9 @@ type CallOptions struct {
 	// Request/Response timeout
 	RequestTimeout time.Duration
 
+	// Proxy, if len>0 it's overrides MICRO_PROXY environment
+	Proxy string
+
 	// Middleware for low level call func
 	CallWrappers []CallWrapper
 
@@ -215,6 +218,13 @@ func RequestTimeout(d time.Duration) Option {
 	}
 }
 
+// Service proxy, overrides MICRO_PROXY environment
+func Proxy(prx string) Option {
+	return func(o *Options) {
+		o.CallOptions.Proxy = prx
+	}
+}
+
 // Transport dial timeout
 func DialTimeout(d time.Duration) Option {
 	return func(o *Options) {
@@ -280,6 +290,13 @@ func WithRetries(i int) CallOption {
 func WithRequestTimeout(d time.Duration) CallOption {
 	return func(o *CallOptions) {
 		o.RequestTimeout = d
+	}
+}
+
+// WithProxy is a CallOption, overrides MICRO_PROXY environment
+func WithProxy(prx string) CallOption {
+	return func(o *CallOptions) {
+		o.Proxy = prx
 	}
 }
 

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -466,7 +466,7 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 	retries := callOpts.Retries
 
 	// disable retries when using a proxy
-	if len(callOpts.Proxy) > 0 && r.hasProxy() {
+	if len(callOpts.Proxy) > 0 || r.hasProxy() {
 		retries = 0
 	}
 
@@ -557,7 +557,7 @@ func (r *rpcClient) Stream(ctx context.Context, request Request, opts ...CallOpt
 	retries := callOpts.Retries
 
 	// disable retries when using a proxy
-	if len(callOpts.Proxy) > 0 && r.hasProxy() {
+	if len(callOpts.Proxy) > 0 || r.hasProxy() {
 		retries = 0
 	}
 

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -340,7 +340,14 @@ func (r *rpcClient) next(request Request, opts CallOptions) (selector.Next, erro
 	service := request.Service()
 
 	// get proxy
-	if prx := os.Getenv("MICRO_PROXY"); len(prx) > 0 {
+	prx := ""
+	if len(opts.Proxy) > 0 {
+		// call options first
+		prx = opts.Proxy
+	} else if prxEnv := os.Getenv("MICRO_PROXY"); len(prxEnv) > 0 {
+		prx = prxEnv
+	}
+	if len(prx) > 0 {
 		// default name
 		if prx == "service" {
 			prx = "go.micro.proxy"
@@ -459,7 +466,7 @@ func (r *rpcClient) Call(ctx context.Context, request Request, response interfac
 	retries := callOpts.Retries
 
 	// disable retries when using a proxy
-	if r.hasProxy() {
+	if len(callOpts.Proxy) > 0 && r.hasProxy() {
 		retries = 0
 	}
 
@@ -550,7 +557,7 @@ func (r *rpcClient) Stream(ctx context.Context, request Request, opts ...CallOpt
 	retries := callOpts.Retries
 
 	// disable retries when using a proxy
-	if r.hasProxy() {
+	if len(callOpts.Proxy) > 0 && r.hasProxy() {
 		retries = 0
 	}
 


### PR DESCRIPTION
Use the proxy dynamically through CallOptions.
My implementation is `CallOptions.Proxy` overrides `MICRO_PROXY` environment
https://github.com/micro/go-micro/issues/1389