### PR TITLE
Cockroach Store bugfix

### DIFF
--- a/config/cmd/cmd.go
+++ b/config/cmd/cmd.go
@@ -616,7 +616,7 @@ func (c *cmd) Before(ctx *cli.Context) error {
 	}
 
 	if len(ctx.String("store_namespace")) > 0 {
-		if err := (*c.opts.Store).Init(store.Namespace(ctx.String("store_address"))); err != nil {
+		if err := (*c.opts.Store).Init(store.Namespace(ctx.String("store_namespace"))); err != nil {
 			logger.Fatalf("Error configuring store: %v", err)
 		}
 	}

--- a/store/cockroach/cockroach.go
+++ b/store/cockroach/cockroach.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/lib/pq"
-	"github.com/micro/go-micro/v2/logger"
 	"github.com/micro/go-micro/v2/store"
 	"github.com/pkg/errors"
 )
@@ -371,10 +370,8 @@ func NewStore(opts ...store.Option) store.Store {
 	// set the options
 	s.options = options
 
-	// configure the store
-	if err := s.configure(); err != nil {
-		logger.Fatal(err)
-	}
+	// best-effort configure the store
+	s.configure()
 
 	// return store
 	return s


### PR DESCRIPTION
NewStore should never fatal. Init() is where the store is actually configured by go-micro.