### PR TITLE
api/handler: use http.MaxBytesReader and buffer pool

### DIFF
--- a/api/handler/api/api.go
+++ b/api/handler/api/api.go
@@ -24,7 +24,13 @@ const (
 
 // API handler is the default handler which takes api.Request and returns api.Response
 func (a *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	request, err := requestToProto(r)
+	bsize := handler.DefaultMaxRecvSize
+	if a.opts.MaxRecvSize > 0 {
+		bsize = a.opts.MaxRecvSize
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, bsize)
+	request, err := a.requestToProto(r)
 	if err != nil {
 		er := errors.InternalServerError("go.micro.api", err.Error())
 		w.Header().Set("Content-Type", "application/json")

--- a/api/handler/api/api.go
+++ b/api/handler/api/api.go
@@ -30,7 +30,7 @@ func (a *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, bsize)
-	request, err := a.requestToProto(r)
+	request, err := requestToProto(r)
 	if err != nil {
 		er := errors.InternalServerError("go.micro.api", err.Error())
 		w.Header().Set("Content-Type", "application/json")

--- a/api/handler/api/util.go
+++ b/api/handler/api/util.go
@@ -13,7 +13,7 @@ import (
 	"github.com/micro/go-micro/v2/registry"
 )
 
-func requestToProto(r *http.Request) (*api.Request, error) {
+func (a *apiHandler) requestToProto(r *http.Request) (*api.Request, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, fmt.Errorf("Error parsing form: %v", err)
 	}
@@ -39,8 +39,10 @@ func requestToProto(r *http.Request) (*api.Request, error) {
 		case "application/x-www-form-urlencoded":
 			// expect form vals in Post data
 		default:
-
-			data, _ := ioutil.ReadAll(r.Body)
+			data, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
 			req.Body = string(data)
 		}
 	}

--- a/api/handler/broker/broker.go
+++ b/api/handler/broker/broker.go
@@ -155,6 +155,13 @@ func (c *conn) writeLoop() {
 }
 
 func (b *brokerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	bsize := handler.DefaultMaxRecvSize
+	if b.opts.MaxRecvSize > 0 {
+		bsize = b.opts.MaxRecvSize
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, bsize)
+
 	br := b.opts.Service.Client().Options().Broker
 
 	// Setup the broker

--- a/api/handler/options.go
+++ b/api/handler/options.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	DefaultMaxRecvSize int64 = 1024 * 1024 * 10 // 4Mb
+	DefaultMaxRecvSize int64 = 1024 * 1024 * 10 // 10Mb
 )
 
 type Options struct {

--- a/api/handler/options.go
+++ b/api/handler/options.go
@@ -5,10 +5,15 @@ import (
 	"github.com/micro/go-micro/v2/api/router"
 )
 
+var (
+	DefaultMaxRecvSize int64 = 1024 * 1024 * 10 // 4Mb
+)
+
 type Options struct {
-	Namespace string
-	Router    router.Router
-	Service   micro.Service
+	MaxRecvSize int64
+	Namespace   string
+	Router      router.Router
+	Service     micro.Service
 }
 
 type Option func(o *Options)
@@ -28,6 +33,10 @@ func NewOptions(opts ...Option) Options {
 	// set namespace if blank
 	if len(options.Namespace) == 0 {
 		WithNamespace("go.micro.api")(&options)
+	}
+
+	if options.MaxRecvSize == 0 {
+		options.MaxRecvSize = DefaultMaxRecvSize
 	}
 
 	return options
@@ -51,5 +60,12 @@ func WithRouter(r router.Router) Option {
 func WithService(s micro.Service) Option {
 	return func(o *Options) {
 		o.Service = s
+	}
+}
+
+// WithmaxRecvSize specifies max body size
+func WithMaxRecvSize(size int64) Option {
+	return func(o *Options) {
+		o.MaxRecvSize = size
 	}
 }

--- a/api/handler/registry/registry.go
+++ b/api/handler/registry/registry.go
@@ -187,6 +187,13 @@ func watch(rw registry.Watcher, w http.ResponseWriter, r *http.Request) {
 }
 
 func (rh *registryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	bsize := handler.DefaultMaxRecvSize
+	if rh.opts.MaxRecvSize > 0 {
+		bsize = rh.opts.MaxRecvSize
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, bsize)
+
 	switch r.Method {
 	case "GET":
 		rh.get(w, r)

--- a/api/handler/rpc/rpc.go
+++ b/api/handler/rpc/rpc.go
@@ -69,6 +69,13 @@ func strategy(services []*registry.Service) selector.Strategy {
 }
 
 func (h *rpcHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	bsize := handler.DefaultMaxRecvSize
+	if h.opts.MaxRecvSize > 0 {
+		bsize = h.opts.MaxRecvSize
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, bsize)
+
 	defer r.Body.Close()
 	var service *api.Service
 


### PR DESCRIPTION
protect api handlers from OOM cases

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>