### PR TITLE
fix: rand race condition

### DIFF
--- a/util/jitter/jitter.go
+++ b/util/jitter/jitter.go
@@ -3,15 +3,20 @@ package jitter
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 )
 
 var (
-	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+	r  = rand.New(rand.NewSource(time.Now().UnixNano()))
+	mu sync.Mutex
 )
 
 // Do returns a random time to jitter with max cap specified
 func Do(d time.Duration) time.Duration {
-	v := r.Float64() * float64(d.Nanoseconds())
+	mu.Lock()
+	v := r.Float64()
+	mu.Unlock()
+	v *= float64(d.Nanoseconds())
 	return time.Duration(v)
 }


### PR DESCRIPTION
rand is not safe for concurrent use by multiple goroutines.