### PR TITLE
util/kubernetes: prune unused code

### DIFF
--- a/util/kubernetes/api/api_test.go
+++ b/util/kubernetes/api/api_test.go
@@ -18,8 +18,6 @@ type testcase struct {
 	Assert func(req *http.Request) bool
 }
 
-type assertFn func(req *http.Request) bool
-
 var tests = []testcase{
 	testcase{
 		ReqFn: func(opts *Options) *Request {

--- a/util/kubernetes/api/response.go
+++ b/util/kubernetes/api/response.go
@@ -28,8 +28,6 @@ type Status struct {
 type Response struct {
 	res *http.Response
 	err error
-
-	body []byte
 }
 
 // Error returns an error

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -41,8 +41,6 @@ type DeploymentSpec struct {
 type DeploymentCondition struct {
 	LastUpdate string `json:lastUpdateTime`
 	Type       string `json:"type"`
-	reason     string `json:"reason,omitempty"`
-	message    string `json:"message,omitempty"`
 }
 
 // DeploymentStatus is returned when querying deployment


### PR DESCRIPTION
This removes some unused struct fields and types from `util/kubernetes`.