### PR TITLE
Enabling default runtime to run multiple versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ are pluggable and allows Go Micro to be runtime agnostic. You can plugin any und
 ## Getting Started
 
 See the [docs](https://micro.mu/docs/framework.html) for detailed information on the architecture, installation and use of go-micro.
+

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -78,7 +78,7 @@ func (s *service) shouldStart() bool {
 }
 
 func (s *service) key() string {
-	return fmt.Sprint("%v:%v", s.Name, s.Version)
+	return fmt.Sprintf("%v:%v", s.Name, s.Version)
 }
 
 func (s *service) ShouldStart() bool {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -78,7 +78,7 @@ func (s *service) shouldStart() bool {
 }
 
 func (s *service) key() string {
-	return fmt.Sprint("%v:%v", s)
+	return fmt.Sprint("%v:%v", s.Name, s.Version)
 }
 
 func (s *service) ShouldStart() bool {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -74,6 +75,10 @@ func (s *service) shouldStart() bool {
 		return false
 	}
 	return s.retries <= s.maxRetries
+}
+
+func (s *service) key() string {
+	return fmt.Sprint("%v:%v", s)
 }
 
 func (s *service) ShouldStart() bool {


### PR DESCRIPTION
Putting this back to WIP to do more testing.

`micro update something@newversion` failed before this patch with `service already running` error due to an other version already running.

Did `micro run` and `micro update` to test it.