### PR TITLE
Add network proxying

### DIFF
--- a/util/net/net.go
+++ b/util/net/net.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -76,4 +77,41 @@ func Listen(addr string, fn func(string) (net.Listener, error)) (net.Listener, e
 
 	// why are we here?
 	return nil, fmt.Errorf("unable to bind to %s", addr)
+}
+
+// Proxy returns the proxy and the address if it exits
+func Proxy(service string, address []string) (string, []string, bool) {
+	var hasProxy bool
+
+        // get proxy
+        if prx := os.Getenv("MICRO_PROXY"); len(prx) > 0 {
+                // default name
+                if prx == "service" {
+                        prx = "go.micro.proxy"
+                }
+                service = prx
+		hasProxy = true
+        }
+
+        // get proxy address
+        if prx := os.Getenv("MICRO_PROXY_ADDRESS"); len(prx) > 0 {
+		address = []string{prx}
+		hasProxy = true
+        }
+
+        if prx := os.Getenv("MICRO_NETWORK"); len(prx) > 0 {
+                // default name
+                if prx == "service" {
+                        prx = "go.micro.network"
+                }
+                service = prx
+		hasProxy = true
+        }
+
+        if prx := os.Getenv("MICRO_NEWORK_ADDRESS"); len(prx) > 0 {
+                address = []string{prx}
+		hasProxy = true
+        }
+
+	return service, address, hasProxy
 }

--- a/util/net/net.go
+++ b/util/net/net.go
@@ -83,35 +83,35 @@ func Listen(addr string, fn func(string) (net.Listener, error)) (net.Listener, e
 func Proxy(service string, address []string) (string, []string, bool) {
 	var hasProxy bool
 
-        // get proxy
-        if prx := os.Getenv("MICRO_PROXY"); len(prx) > 0 {
-                // default name
-                if prx == "service" {
-                        prx = "go.micro.proxy"
-                }
-                service = prx
+	// get proxy
+	if prx := os.Getenv("MICRO_PROXY"); len(prx) > 0 {
+		// default name
+		if prx == "service" {
+			prx = "go.micro.proxy"
+		}
+		service = prx
 		hasProxy = true
-        }
+	}
 
-        // get proxy address
-        if prx := os.Getenv("MICRO_PROXY_ADDRESS"); len(prx) > 0 {
+	// get proxy address
+	if prx := os.Getenv("MICRO_PROXY_ADDRESS"); len(prx) > 0 {
 		address = []string{prx}
 		hasProxy = true
-        }
+	}
 
-        if prx := os.Getenv("MICRO_NETWORK"); len(prx) > 0 {
-                // default name
-                if prx == "service" {
-                        prx = "go.micro.network"
-                }
-                service = prx
+	if prx := os.Getenv("MICRO_NETWORK"); len(prx) > 0 {
+		// default name
+		if prx == "service" {
+			prx = "go.micro.network"
+		}
+		service = prx
 		hasProxy = true
-        }
+	}
 
-        if prx := os.Getenv("MICRO_NEWORK_ADDRESS"); len(prx) > 0 {
-                address = []string{prx}
+	if prx := os.Getenv("MICRO_NEWORK_ADDRESS"); len(prx) > 0 {
+		address = []string{prx}
 		hasProxy = true
-        }
+	}
 
 	return service, address, hasProxy
 }


### PR DESCRIPTION
Enables proxying through the network. I think the model for operating through the network actually looks much different than this, potentially at a lower level but this is the first step. We're moving from routing all things through the proxy, to routing through the network and then using proxy on the edge.