### PR TITLE
fix HTTP 401 Unauthorized, {"message": "401: Unauthorized", "code": 0}

### DIFF
--- a/agent/input/discord/discord.go
+++ b/agent/input/discord/discord.go
@@ -87,7 +87,7 @@ func (d *discordInput) Start() error {
 	}
 
 	var err error
-	d.session, err = discordgo.New(d.token)
+	d.session, err = discordgo.New("Bot " + d.token)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix file=bot.go:426 level=error service=bot error starting bot HTTP 401 Unauthorized, {"message": "401: Unauthorized", "code": 0}
see https://github.com/bwmarrin/discordgo#usage