### PR TITLE
Design: model interface ideas

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -1,0 +1,57 @@
+// Package model is a data modelling interface
+package model
+
+import (
+	"github.com/micro/go-micro/v2/codec"
+	"github.com/micro/go-micro/v2/store"
+)
+
+// Model represents a data model interface for data access
+type Model interface {
+	// Initialise options
+	Init(...Option) error
+	// Retrieve the options
+	Options() Options
+	// Register a data type
+	Register(v interface{}) error
+	// Create an entity
+	Create(v interface{}, opts ...CreateOption) error
+	// Read an entity
+	Read(v interface{}, opts ...ReadOption) error
+	// Update an enity
+	Update(v interface{}, opts ...UpdateOption) error
+	// Delete an entity
+	Delete(v interface{}, opts ...DeleteOption) error
+	// The implementation e.g crud
+	String() string
+}
+
+// Options to the model
+type Options struct {
+	// The store for data storage
+	Store store.Store
+	// The codec for marshalling
+	Codec codec.Marshaler
+}
+
+type Option func(o *Options) error
+
+// CreateOptions for writing entities
+type CreateOptions struct{}
+
+type CreateOption func(o *CreateOptions) error
+
+// ReadOptions for reading entities
+type ReadOptions struct{}
+
+type ReadOption func(o *ReadOptions) error
+
+// UpdateOptions for updating entities
+type UpdateOptions struct{}
+
+type UpdateOption func(o *UpdateOptions) error
+
+// DeleteOptions for deleting entities
+type DeleteOptions struct{}
+
+type DeleteOption func(o *DeleteOptions) error

--- a/model/model.go
+++ b/model/model.go
@@ -13,7 +13,7 @@ type Model interface {
 	// Retrieve the options
 	Options() Options
 	// New entity returns a new entity
-	NewEntity(id string, value interface{})
+	NewEntity(id string, value interface{}) Entity
 	// Register a data type
 	Register(v interface{}) error
 	// Create an entity

--- a/model/model.go
+++ b/model/model.go
@@ -12,18 +12,27 @@ type Model interface {
 	Init(...Option) error
 	// Retrieve the options
 	Options() Options
+	// New entity returns a new entity
+	NewEntity(id string, value interface{})
 	// Register a data type
 	Register(v interface{}) error
 	// Create an entity
-	Create(v interface{}, opts ...CreateOption) error
-	// Read an entity
+	Create(Entity, ...CreateOption) error
+	// Read an into the value provided
 	Read(v interface{}, opts ...ReadOption) error
 	// Update an enity
-	Update(v interface{}, opts ...UpdateOption) error
+	Update(Entity, ...UpdateOption) error
 	// Delete an entity
-	Delete(v interface{}, opts ...DeleteOption) error
+	Delete(Entity, ...DeleteOption) error
 	// The implementation e.g crud
 	String() string
+}
+
+type Entity interface {
+	// Id of the entity
+	ID() string
+	// Associated value
+	Value() interface{}
 }
 
 // Options to the model


### PR DESCRIPTION
## Overview

This is a design idea for a "model" interface which serves as a data model for accessing and storing data. It layers on store/sync/codec as client/server do on top of registry/broker/transport/codec.

## Design

We're using the entity relationship model to represent our model interface https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model. The idea is to create a simple high level CRUD for storage much like the client does for RPC calls. The entity represents access to a specific domain.

The Model interface is inline with the Client and Server interfaces and further encapsulated by the Service {Client, Server, Model} to encompass the overall requirements for a service.

Model encapsulates:
- Store - for the data storage
- Sync - for locking and synchronization
- Codec - for serialisation / marshaling

## Proto

We code generate service to service calls to reduce the boilerplate usage of the client/server. Considering the verbosity of CRUD development and repitition we want to encapsulate this concern in a similar way. The protoc-gen-micro command should code generate usage of the Model to create out of the box CRUD interfaces for storage.

```
// in the proto
service User {}
```

generates

```
// Generate a new user mode
NewUserModel(model.Model) UserModel

// Generates a register method
RegisterUserModel(model.Model)
```

Additionally the UserModel will include access and storage methods much like an ORM.