### PR TITLE
kill all processes correctly for micro kill command

### DIFF
--- a/runtime/default.go
+++ b/runtime/default.go
@@ -536,7 +536,7 @@ func (r *runtime) Delete(s *Service, opts ...DeleteOption) error {
 	}
 	if s, ok := r.services[serviceKey(s)]; ok {
 		// check if running
-		if s.Running() {
+		if !s.Running() {
 			delete(r.services, s.key())
 			return nil
 		}


### PR DESCRIPTION
We weren't killing the process group correctly - see here for explanation of how to do it https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773