### PR TITLE
Fix client RPC stream close mutex

### DIFF
--- a/client/rpc_stream.go
+++ b/client/rpc_stream.go
@@ -130,15 +130,15 @@ func (r *rpcStream) Error() error {
 }
 
 func (r *rpcStream) Close() error {
-	r.RLock()
+	r.Lock()
 
 	select {
 	case <-r.closed:
-		r.RUnlock()
+		r.Unlock()
 		return nil
 	default:
 		close(r.closed)
-		r.RUnlock()
+		r.Unlock()
 
 		// send the end of stream message
 		if r.sendEOS {


### PR DESCRIPTION
@TriAnMan and I figured out that I messed up a little with my previous PR (#884):

With the `RLock()` it is possible to have multiple go routine enter the locked code and then close the channel, causing panics:
```
panic: close of closed channel
goroutine 57 [running]:
github.com/jexia-com/our-app/vendor/github.com/micro/go-micro/client.(*rpcStream).Close(0xc0010eea20, 0x1fad940, 0xc001fa90e0)
	/go/src/github.com/jexia-com/our-app/vendor/github.com/micro/go-micro/client/rpc_stream.go:140 +0xac
```

This is fixed with the `Lock()` as it only allows one (writer) go routine to enter, it then can close the channel, so a/the next go routine will bail out.

Unfortunately, it does not seem (easily) possible to read the channel and only grab `Lock()` when channel needs closing. On the other hand, blocking the application to use the stream at this point does not seem matter much as it is breaking down...