### PR TITLE
Registration Retry / Interval

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/micro/go-micro/v2/registry"
 	"github.com/micro/go-micro/v2/transport"
 	"github.com/micro/go-micro/v2/util/addr"
+	"github.com/micro/go-micro/v2/util/backoff"
 	mnet "github.com/micro/go-micro/v2/util/net"
 	"github.com/micro/go-micro/v2/util/socket"
 )
@@ -514,18 +515,39 @@ func (s *rpcServer) Subscribe(sb Subscriber) error {
 }
 
 func (s *rpcServer) Register() error {
-
 	s.RLock()
 	rsvc := s.rsvc
 	config := s.Options()
 	s.RUnlock()
 
-	if rsvc != nil {
+	regFunc := func(service *registry.Service) error {
+		// create registry options
 		rOpts := []registry.RegisterOption{registry.RegisterTTL(config.RegisterTTL)}
-		if err := config.Registry.Register(rsvc, rOpts...); err != nil {
-			return err
+
+		var regErr error
+
+		for i := 0; i < 3; i++ {
+			// attempt to register
+			if err := config.Registry.Register(service, rOpts...); err != nil {
+				// set the error
+				regErr = err
+				// backoff then retry
+				time.Sleep(backoff.Do(i + 1))
+				continue
+			}
+			// success so nil error
+			regErr = nil
+			break
 		}
 
+		return regErr
+	}
+
+	// have we registered before?
+	if rsvc != nil {
+		if err := regFunc(rsvc); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -635,10 +657,8 @@ func (s *rpcServer) Register() error {
 		}
 	}
 
-	// create registry options
-	rOpts := []registry.RegisterOption{registry.RegisterTTL(config.RegisterTTL)}
-
-	if err := config.Registry.Register(service, rOpts...); err != nil {
+	// register the service
+	if err := regFunc(service); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -145,7 +145,7 @@ var (
 	DefaultRouter                  = newRpcRouter()
 	DefaultRegisterCheck           = func(context.Context) error { return nil }
 	DefaultRegisterInterval        = time.Second * 30
-	DefaultRegisterTTL             = time.Minute
+	DefaultRegisterTTL             = time.Second * 90
 
 	// NewServer creates a new server
 	NewServer func(...Option) Server = newRpcServer

--- a/server/server.go
+++ b/server/server.go
@@ -125,7 +125,7 @@ type Handler interface {
 }
 
 // Subscriber interface represents a subscription to a given topic using
-// a specific subscriber function or object with endpoints. It mirrors 
+// a specific subscriber function or object with endpoints. It mirrors
 // the handler in its behaviour.
 type Subscriber interface {
 	Topic() string

--- a/web/service.go
+++ b/web/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/micro/go-micro/v2/registry"
 	maddr "github.com/micro/go-micro/v2/util/addr"
 	authutil "github.com/micro/go-micro/v2/util/auth"
+	"github.com/micro/go-micro/v2/util/backoff"
 	mhttp "github.com/micro/go-micro/v2/util/http"
 	mnet "github.com/micro/go-micro/v2/util/net"
 	signalutil "github.com/micro/go-micro/v2/util/signal"
@@ -138,7 +139,24 @@ func (s *service) register() error {
 		return err
 	}
 
-	return r.Register(s.srv, registry.RegisterTTL(s.opts.RegisterTTL))
+	var regErr error
+
+	// try three times if necessary
+	for i := 0; i < 3; i++ {
+		// attempt to register
+		if err := r.Register(s.srv, registry.RegisterTTL(s.opts.RegisterTTL)); err != nil {
+			// set the error
+			regErr = err
+			// backoff then retry
+			time.Sleep(backoff.Do(i + 1))
+			continue
+		}
+		// success so nil error
+		regErr = nil
+		break
+	}
+
+	return regErr
 }
 
 func (s *service) deregister() error {

--- a/web/web.go
+++ b/web/web.go
@@ -31,7 +31,7 @@ var (
 	DefaultAddress = ":0"
 
 	// for registration
-	DefaultRegisterTTL      = time.Minute
+	DefaultRegisterTTL      = time.Second * 90
 	DefaultRegisterInterval = time.Second * 30
 
 	// static directory


### PR DESCRIPTION
Because the re-register interval is 30 seconds and ttl is 60 seconds, in the event of a single failed attempt to register, services will actually be de-registered at the 60 second ttl mark, potentially as a race condition. A service could be expired but also register causing events to be emitted unnecessarily.

In this PR we do two things. Firstly the ttl is increased to 90 seconds. Secondly we retry registration 3 times with backoff built in. This potentially gives us the chance to retry where there is a transient error and also attempt again in 30 seconds with less issues.