### PR TITLE
Check ipv4 or ipv6 address is valid before assigning

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -353,10 +353,10 @@ func (m *mdnsRegistry) GetService(service string, opts ...GetOption) ([]*Service
 				}
 				addr := ""
 				// prefer ipv4 addrs
-				if e.AddrV4 != nil {
+				if len(e.AddrV4) > 0 {
 					addr = e.AddrV4.String()
 					// else use ipv6
-				} else if e.AddrV6 != nil {
+				} else if len(e.AddrV6) > 0 {
 					addr = "[" + e.AddrV6.String() + "]"
 				} else {
 					if logger.V(logger.InfoLevel, logger.DefaultLogger) {

--- a/util/mdns/client.go
+++ b/util/mdns/client.go
@@ -34,7 +34,7 @@ type ServiceEntry struct {
 
 // complete is used to check if we have all the info we need
 func (s *ServiceEntry) complete() bool {
-	return (s.AddrV4 != nil || s.AddrV6 != nil || s.Addr != nil) && s.Port != 0 && s.hasTXT
+	return (len(s.AddrV4) > 0 || len(s.AddrV6) > 0 || len(s.Addr) > 0) && s.Port != 0 && s.hasTXT
 }
 
 // QueryParam is used to customize how a Lookup is performed


### PR DESCRIPTION
There have been sporadic reports of strange errors when calling services where the error is something like `connection error: dial tcp: lookup <nil>: no such host`. 

The only way (that I can see) for the host to come back as `<nil>` is when calling `String()` on a zero length `net.IP` object. 

```
String returns the string form of the IP address ip. It returns one of 4 forms:

- "<nil>", if ip has length 0
- dotted decimal ("192.0.2.1"), if ip is an IPv4 or IP4-mapped IPv6 address
- IPv6 ("2001:db8::1"), if ip is a valid IPv6 address
- the hexadecimal form of ip, without punctuation, if no other cases apply
```

See https://golang.org/pkg/net/#IP.String

See reports https://github.com/micro/micro/issues/392 and https://github.com/micro/development/issues/165

The fix is to just change the check. No unit tests as the code is pretty intertwined and not easily testable without a major refactor. This is the lowest impact fix available.