### PR TITLE
fix locking of socket pool

### DIFF
--- a/util/socket/pool.go
+++ b/util/socket/pool.go
@@ -19,12 +19,18 @@ func (p *Pool) Get(id string) (*Socket, bool) {
 	}
 	p.RUnlock()
 
-	// create new socket
-	socket = New(id)
 	// save socket
 	p.Lock()
+	defer p.Unlock()
+	// double checked locking
+	socket, ok = p.pool[id]
+	if ok {
+		return socket, ok
+	}
+	// create new socket
+	socket = New(id)
 	p.pool[id] = socket
-	p.Unlock()
+
 	// return socket
 	return socket, false
 }


### PR DESCRIPTION
Current implementation doesn't behave as expected. Could have

Thread 1 : call `Get()`
Thread 2: call `Get()`
Thread 1: ReadLock. Sees `p.pool[id]` is empty. ReadUnlock
Thread 2: ReadLock. Sees `p.pool[id]` is empty. ReadUnlock
Thread 1: Lock. Assigns to `p.pool[id]`. Unlock
Thread 2: Lock. Assigns to `p.pool[id]`. Unlock

Adding double checked locking removes the possibility of overwriting.