### PR TITLE
Move auth account creation to config/cmd

### DIFF
--- a/service.go
+++ b/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/micro/go-micro/v2/plugin"
 	"github.com/micro/go-micro/v2/server"
 	"github.com/micro/go-micro/v2/store"
-	authutil "github.com/micro/go-micro/v2/util/auth"
 	signalutil "github.com/micro/go-micro/v2/util/signal"
 	"github.com/micro/go-micro/v2/util/wrapper"
 )
@@ -176,11 +175,6 @@ func (s *service) Stop() error {
 }
 
 func (s *service) Run() error {
-	// generate an auth account
-	if err := authutil.Generate(s.Server().Options().Id, s.Name(), s.Options().Auth); err != nil {
-		return err
-	}
-
 	// register the debug handler
 	s.opts.Server.Handle(
 		s.opts.Server.NewHandler(


### PR DESCRIPTION
Right now auth accounts are generated on Run() which is suboptimal since setup may require auth (e.g. loading config etc). This PR moves the account generation to immediately after auth is configured.