### PR TITLE
Build all micro/examples for `release-X.X.X` branches

### DIFF
--- a/.github/workflows/micro-examples.yml
+++ b/.github/workflows/micro-examples.yml
@@ -1,0 +1,31 @@
+name: Build all github.com/micro/examples
+on:
+  push: 
+    branches:
+      - 'release-**'
+  pull_request: 
+    branches:
+      - 'release-**'
+
+jobs:
+
+  build:
+    name: Build repos
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code examples
+      uses: actions/checkout@v2
+      with:
+        repository: 'micro/examples'
+        path: 'examples'
+
+    - name: Build all
+      run: .github/workflows/scripts/build-all-examples.sh $GITHUB_SHA
+    

--- a/.github/workflows/micro-examples.yml
+++ b/.github/workflows/micro-examples.yml
@@ -3,9 +3,6 @@ on:
   push: 
     branches:
       - 'release-**'
-  pull_request: 
-    branches:
-      - 'master'
 
 jobs:
 

--- a/.github/workflows/micro-examples.yml
+++ b/.github/workflows/micro-examples.yml
@@ -20,6 +20,11 @@ jobs:
         go-version: 1.13
       id: go
 
+    - name: Check out this code
+      uses: actions/checkout@v2
+      with:
+        path: 'go-micro'
+
     - name: Check out code examples
       uses: actions/checkout@v2
       with:
@@ -27,5 +32,6 @@ jobs:
         path: 'examples'
 
     - name: Build all
-      run: .github/workflows/scripts/build-all-examples.sh $GITHUB_SHA
+      run: $GITHUB_WORKSPACE/go-micro/.github/workflows/scripts/build-all-examples.sh $GITHUB_SHA
+      working-directory: examples
     

--- a/.github/workflows/micro-examples.yml
+++ b/.github/workflows/micro-examples.yml
@@ -5,7 +5,7 @@ on:
       - 'release-**'
   pull_request: 
     branches:
-      - 'release-**'
+      - 'master'
 
 jobs:
 

--- a/.github/workflows/scripts/build-all-examples.sh
+++ b/.github/workflows/scripts/build-all-examples.sh
@@ -4,8 +4,6 @@
 function build_binary {
     echo building $1
     pushd $1
-    go mod init github.com/micro/examples
-    go mod edit -require=github.com/micro/go-micro/v2@$2
     go build
     local ret=$?
     if [ $ret -gt 0 ]; then 
@@ -34,5 +32,7 @@ function check_dir {
 
 failed=0
 this_hash=$1
+go mod init github.com/micro/examples
+go mod edit -require=github.com/micro/go-micro/v2@$1 
 check_dir . $1
 exit $failed

--- a/.github/workflows/scripts/build-all-examples.sh
+++ b/.github/workflows/scripts/build-all-examples.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# set -x
+
+function build_binary {
+    echo building $1
+    pushd $1
+    go mod init example
+    go mod edit -require=github.com/micro/go-micro/v2@$2
+    go build
+    local ret=$?
+    if [ $ret -gt 0 ]; then 
+        failed=1
+    fi
+    popd
+}
+
+function is_main {
+    grep "package main" -l -dskip $1/*.go > /dev/null 2>&1
+}
+
+
+function check_dir {
+    is_main $1
+    local ret=$?
+    if [ $ret == 0 ]; then
+        build_binary $1 $2
+    fi
+    for filename in $1/*; do
+        if [ -d $filename ]; then
+            check_dir $filename $2
+        fi
+    done
+}
+
+failed=0
+this_hash=$1
+check_dir . $1
+exit $failed

--- a/.github/workflows/scripts/build-all-examples.sh
+++ b/.github/workflows/scripts/build-all-examples.sh
@@ -8,6 +8,7 @@ function build_binary {
     local ret=$?
     if [ $ret -gt 0 ]; then 
         failed=1
+        failed_arr+=($1)
     fi
     popd
 }
@@ -29,10 +30,14 @@ function check_dir {
         fi
     done
 }
-
+failed_arr=()
 failed=0
 this_hash=$1
 go mod init github.com/micro/examples
 go mod edit -require=github.com/micro/go-micro/v2@$1 
 check_dir . $1
+if [ $failed -gt 0 ]; then
+    echo Some builds failed
+    printf '%s\n' "${failed_arr[@]}"
+fi
 exit $failed

--- a/.github/workflows/scripts/build-all-examples.sh
+++ b/.github/workflows/scripts/build-all-examples.sh
@@ -4,7 +4,7 @@
 function build_binary {
     echo building $1
     pushd $1
-    go mod init example
+    go mod init github.com/micro/examples
     go mod edit -require=github.com/micro/go-micro/v2@$2
     go build
     local ret=$?


### PR DESCRIPTION
As part of new release process, when we cut new release candidate branch `release-X.X.X` we should build this branch against all examples in `micro/examples`. 

If it doesn't build for a minor or patch release then we've made a breaking change to an API somewhere so we need to investigate. If it doesn't build for a major release then we should check the results carefully to ensure the breaks are expected API changes or something. 