### PR TITLE
api/handler/rpc: dont log error on normal websocket error code

### DIFF
--- a/api/handler/rpc/stream.go
+++ b/api/handler/rpc/stream.go
@@ -185,7 +185,11 @@ func writeLoop(rw io.ReadWriter, stream client.Stream) {
 			if err != nil {
 				if wserr, ok := err.(wsutil.ClosedError); ok {
 					switch wserr.Code {
+					case ws.StatusGoingAway:
+						// this happens when user leave the page
+						return
 					case ws.StatusNormalClosure, ws.StatusNoStatusRcvd:
+						// this happens when user close ws connection, or we don't get any status
 						return
 					}
 				}


### PR DESCRIPTION
don't log error on websocket 1001 error code, that happens when user go away

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>