### PR TITLE
 Initialize selector before we make an auth.Generate call

### DIFF
--- a/util/auth/auth.go
+++ b/util/auth/auth.go
@@ -28,7 +28,7 @@ func Generate(id string, name string, a auth.Auth) error {
 		if err != nil {
 			return err
 		}
-		logger.Infof("Auth [%v] Authenticated as %v issued by %v", a, name, acc.Issuer)
+		logger.Debugf("Auth [%v] Authenticated as %v issued by %v", a, name, acc.Issuer)
 
 		accID = acc.ID
 		accSecret = acc.Secret


### PR DESCRIPTION
Web, proxy and api was failing because the `selector.Select` in `auth.Generate` still had the `mdns` registry because the selector initialization (where we change from default `mdns` to `etcd`) happened after that call.

This fixes that.

Relevant stack trace printed by debug: https://gist.github.com/crufter/c408b6355d28b0a90ae101beb5b5e7f2#file-gistfile1-txt-L33