### PR TITLE
registry/mdns: fix nil host bug

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -563,9 +563,7 @@ func (m *mdnsWatcher) Next() (*Result, error) {
 			if len(m.wo.Service) > 0 && txt.Service != m.wo.Service {
 				continue
 			}
-
 			var action string
-
 			if e.TTL == 0 {
 				action = "delete"
 			} else {
@@ -584,9 +582,18 @@ func (m *mdnsWatcher) Next() (*Result, error) {
 				continue
 			}
 
+			var addr string
+			if len(e.AddrV4) > 0 {
+				addr = e.AddrV4.String()
+			} else if len(e.AddrV6) > 0 {
+				addr = "[" + e.AddrV6.String() + "]"
+			} else {
+				addr = e.Addr.String()
+			}
+
 			service.Nodes = append(service.Nodes, &Node{
 				Id:       strings.TrimSuffix(e.Name, suffix),
-				Address:  fmt.Sprintf("%s:%d", e.AddrV4.String(), e.Port),
+				Address:  fmt.Sprintf("%s:%d", addr, e.Port),
 				Metadata: txt.Metadata,
 			})
 


### PR DESCRIPTION
Fixes: `2020-06-15 14:52:56  file=api/api.go:313 level=fatal service=api {"id":"go.micro.client","code":500,"detail":"connection error: desc = \"transport: Error while dialing dial tcp: lookup \u003cnil\u003e: no such host\"","status":"Internal Server Error"}`