### PR TITLE
Support custom private blocks

### DIFF
--- a/util/addr/addr.go
+++ b/util/addr/addr.go
@@ -17,6 +17,15 @@ func init() {
 	}
 }
 
+// AppendPrivateBlocks append private network blocks
+func AppendPrivateBlocks(bs ...string) {
+	for _, b := range bs {
+		if _, block, err := net.ParseCIDR(b); err == nil {
+			privateBlocks = append(privateBlocks, block)
+		}
+	}
+}
+
 func isPrivateIP(ipAddr string) bool {
 	ip := net.ParseIP(ipAddr)
 	for _, priv := range privateBlocks {

--- a/util/addr/addr_test.go
+++ b/util/addr/addr_test.go
@@ -56,3 +56,24 @@ func TestExtractor(t *testing.T) {
 	}
 
 }
+
+func TestAppendPrivateBlocks(t *testing.T) {
+	tests := []struct {
+		addr   string
+		expect bool
+	}{
+		{addr: "9.134.71.34", expect: true},
+		{addr: "8.10.110.34", expect: false}, // not in private blocks
+	}
+
+	AppendPrivateBlocks("9.134.0.0/16")
+
+	for _, test := range tests {
+		t.Run(test.addr, func(t *testing.T) {
+			res := isPrivateIP(test.addr)
+			if res != test.expect {
+				t.Fatalf("expected %t got %t", test.expect, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The registry announce invalid address while run in private network that not in default private blocks.  https://github.com/micro/go-micro/blob/master/util/addr/addr.go#L13

There's a way to append default private network blocks.

Tests

```
=== RUN   TestAppendPrivateBlocks
=== RUN   TestAppendPrivateBlocks/9.134.71.34
=== RUN   TestAppendPrivateBlocks/8.10.110.34
--- PASS: TestAppendPrivateBlocks (0.00s)
    --- PASS: TestAppendPrivateBlocks/9.134.71.34 (0.00s)
    --- PASS: TestAppendPrivateBlocks/8.10.110.34 (0.00s)
PASS
```