### PR TITLE
auth: rename Namespace to Issuer

### DIFF
--- a/auth/default.go
+++ b/auth/default.go
@@ -53,7 +53,7 @@ func (n *noop) Generate(id string, opts ...GenerateOption) (*Account, error) {
 		Secret:   options.Secret,
 		Metadata: options.Metadata,
 		Scopes:   options.Scopes,
-		Issuer:   n.Options().Namespace,
+		Issuer:   n.Options().Issuer,
 	}, nil
 }
 
@@ -79,7 +79,7 @@ func (n *noop) Verify(acc *Account, res *Resource, opts ...VerifyOption) error {
 
 // Inspect a token
 func (n *noop) Inspect(token string) (*Account, error) {
-	return &Account{ID: uuid.New().String(), Issuer: n.Options().Namespace}, nil
+	return &Account{ID: uuid.New().String(), Issuer: n.Options().Issuer}, nil
 }
 
 // Token generation using an account id and secret

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -56,7 +56,7 @@ func (j *jwt) Generate(id string, opts ...auth.GenerateOption) (*auth.Account, e
 		Type:     options.Type,
 		Scopes:   options.Scopes,
 		Metadata: options.Metadata,
-		Issuer:   j.Options().Namespace,
+		Issuer:   j.Options().Issuer,
 	}
 
 	// generate a JWT secret which can be provided to the Token() method

--- a/auth/options.go
+++ b/auth/options.go
@@ -22,8 +22,8 @@ func NewOptions(opts ...Option) Options {
 }
 
 type Options struct {
-	// Namespace the service belongs to
-	Namespace string
+	// Issuer of the service's account
+	Issuer string
 	// ID is the services auth ID
 	ID string
 	// Secret is used to authenticate the service
@@ -55,10 +55,10 @@ func Addrs(addrs ...string) Option {
 	}
 }
 
-// Namespace the service belongs to
-func Namespace(n string) Option {
+// Issuer of the services account
+func Issuer(i string) Option {
 	return func(o *Options) {
-		o.Namespace = n
+		o.Issuer = i
 	}
 }
 

--- a/config/cmd/cmd.go
+++ b/config/cmd/cmd.go
@@ -276,9 +276,9 @@ var (
 			Usage:   "Account secret used for client authentication",
 		},
 		&cli.StringFlag{
-			Name:    "auth_namespace",
-			EnvVars: []string{"MICRO_AUTH_NAMESPACE"},
-			Usage:   "Namespace for the services auth account",
+			Name:    "service_namespace",
+			EnvVars: []string{"MICRO_NAMESPACE"},
+			Usage:   "Namespace the service is operating in",
 			Value:   "go.micro",
 		},
 		&cli.StringFlag{
@@ -540,8 +540,8 @@ func (c *cmd) Before(ctx *cli.Context) error {
 	if len(ctx.String("auth_private_key")) > 0 {
 		authOpts = append(authOpts, auth.PrivateKey(ctx.String("auth_private_key")))
 	}
-	if len(ctx.String("auth_namespace")) > 0 {
-		authOpts = append(authOpts, auth.Namespace(ctx.String("auth_namespace")))
+	if len(ctx.String("service_namespace")) > 0 {
+		authOpts = append(authOpts, auth.Issuer(ctx.String("service_namespace")))
 	}
 	if name := ctx.String("auth_provider"); len(name) > 0 {
 		p, ok := DefaultAuthProviders[name]

--- a/util/wrapper/wrapper.go
+++ b/util/wrapper/wrapper.go
@@ -158,7 +158,7 @@ func (a *authWrapper) Call(ctx context.Context, req client.Request, rsp interfac
 
 	// set the namespace header if it has not been set (e.g. on a service to service request)
 	if _, ok := metadata.Get(ctx, "Micro-Namespace"); !ok {
-		ctx = metadata.Set(ctx, "Micro-Namespace", aa.Options().Namespace)
+		ctx = metadata.Set(ctx, "Micro-Namespace", aa.Options().Issuer)
 	}
 
 	// check to see if we have a valid access token
@@ -205,7 +205,7 @@ func AuthHandler(fn func() auth.Auth) server.HandlerWrapper {
 			// Extract the namespace header
 			ns, ok := metadata.Get(ctx, "Micro-Namespace")
 			if !ok {
-				ns = a.Options().Namespace
+				ns = a.Options().Issuer
 				ctx = metadata.Set(ctx, "Micro-Namespace", ns)
 			}
 

--- a/util/wrapper/wrapper_test.go
+++ b/util/wrapper/wrapper_test.go
@@ -61,7 +61,7 @@ func TestWrapper(t *testing.T) {
 type testAuth struct {
 	verifyCount    int
 	inspectCount   int
-	namespace      string
+	issuer         string
 	inspectAccount *auth.Account
 	verifyError    error
 
@@ -79,7 +79,7 @@ func (a *testAuth) Inspect(token string) (*auth.Account, error) {
 }
 
 func (a *testAuth) Options() auth.Options {
-	return auth.Options{Namespace: a.namespace}
+	return auth.Options{Issuer: a.issuer}
 }
 
 type testRequest struct {
@@ -171,10 +171,10 @@ func TestAuthHandler(t *testing.T) {
 		}
 	})
 
-	// If the namespace header was not set on the request, the wrapper should set it to the auths
-	// own namespace
-	t.Run("BlankNamespaceHeader", func(t *testing.T) {
-		a := testAuth{namespace: "mynamespace"}
+	// If the issuer header was not set on the request, the wrapper should set it to the auths
+	// own issuer
+	t.Run("BlankissuerHeader", func(t *testing.T) {
+		a := testAuth{issuer: "myissuer"}
 		handler := AuthHandler(func() auth.Auth {
 			return &a
 		})
@@ -189,17 +189,17 @@ func TestAuthHandler(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected nil error but got %v", err)
 		}
-		if ns, _ := metadata.Get(inCtx, "Micro-Namespace"); ns != a.namespace {
-			t.Errorf("Expected namespace to be set to %v but was %v", a.namespace, ns)
+		if ns, _ := metadata.Get(inCtx, "Micro-Namespace"); ns != a.issuer {
+			t.Errorf("Expected issuer to be set to %v but was %v", a.issuer, ns)
 		}
 	})
-	t.Run("ValidNamespaceHeader", func(t *testing.T) {
-		a := testAuth{namespace: "mynamespace"}
+	t.Run("ValidissuerHeader", func(t *testing.T) {
+		a := testAuth{issuer: "myissuer"}
 		handler := AuthHandler(func() auth.Auth {
 			return &a
 		})
 
-		inNs := "reqnamespace"
+		inNs := "reqissuer"
 		inCtx := metadata.Set(context.TODO(), "Micro-Namespace", inNs)
 		h := func(ctx context.Context, req server.Request, rsp interface{}) error {
 			inCtx = ctx
@@ -211,7 +211,7 @@ func TestAuthHandler(t *testing.T) {
 			t.Errorf("Expected nil error but got %v", err)
 		}
 		if ns, _ := metadata.Get(inCtx, "Micro-Namespace"); ns != inNs {
-			t.Errorf("Expected namespace to remain as %v but was set to %v", inNs, ns)
+			t.Errorf("Expected issuer to remain as %v but was set to %v", inNs, ns)
 		}
 	})
 
@@ -219,8 +219,8 @@ func TestAuthHandler(t *testing.T) {
 	// should be forbidden
 	t.Run("InvalidAccountIssuer", func(t *testing.T) {
 		a := testAuth{
-			namespace:      "validnamespace",
-			inspectAccount: &auth.Account{Issuer: "invalidnamespace"},
+			issuer:         "validissuer",
+			inspectAccount: &auth.Account{Issuer: "invalidissuer"},
 		}
 
 		handler := AuthHandler(func() auth.Auth {
@@ -235,8 +235,8 @@ func TestAuthHandler(t *testing.T) {
 	})
 	t.Run("ValidAccountIssuer", func(t *testing.T) {
 		a := testAuth{
-			namespace:      "validnamespace",
-			inspectAccount: &auth.Account{Issuer: "validnamespace"},
+			issuer:         "validissuer",
+			inspectAccount: &auth.Account{Issuer: "validissuer"},
 		}
 
 		handler := AuthHandler(func() auth.Auth {


### PR DESCRIPTION
Rename namespace to issuer within the context of auth to better fit with the domain specific language we're using across go-micro (e.g. registry=domain, router=network). 

Replaced the MICRO_AUTH_NAMESPACE env var with MICRO_NAMESPACE as this will be used in the future for a range of things beyond just auth. 