### PR TITLE
[config] Update default config Loader to use optional Reader

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -41,12 +41,16 @@ func newConfig(opts ...Option) (Config, error) {
 
 func (c *config) Init(opts ...Option) error {
 	c.opts = Options{
-		Loader: memory.NewLoader(),
 		Reader: json.NewReader(),
 	}
 	c.exit = make(chan bool)
 	for _, o := range opts {
 		o(&c.opts)
+	}
+
+	// default loader uses the configured reader
+	if c.opts.Loader == nil {
+		c.opts.Loader = memory.NewLoader(memory.WithReader(c.opts.Reader))
 	}
 
 	err := c.opts.Loader.Load(c.opts.Source...)


### PR DESCRIPTION
This delays the construction of the default config Loader until after options are parsed. That way the default Loader uses a custom Reader if one is configured.

Closes https://github.com/micro/go-micro/issues/1716