### PR TITLE
util/wrapper: fix noop auth nil account bug

### DIFF
--- a/util/wrapper/wrapper.go
+++ b/util/wrapper/wrapper.go
@@ -189,18 +189,19 @@ func AuthHandler(fn func() auth.Auth) server.HandlerWrapper {
 				return h(ctx, req, rsp)
 			}
 
-			// Extract the token if present. Note: if noop is being used
-			// then the token can be blank without erroring
-			var account *auth.Account
+			// Extract the token if the header is present. We will inspect the token regardless of if it's
+			// present or not since noop auth will return a blank account upon Inspecting a blank token.
+			var token string
 			if header, ok := metadata.Get(ctx, "Authorization"); ok {
 				// Ensure the correct scheme is being used
 				if !strings.HasPrefix(header, auth.BearerScheme) {
 					return errors.Unauthorized(req.Service(), "invalid authorization header. expected Bearer schema")
 				}
-
-				// Strip the prefix and inspect the resulting token
-				account, _ = a.Inspect(strings.TrimPrefix(header, auth.BearerScheme))
+				token = strings.TrimPrefix(header, auth.BearerScheme)
 			}
+
+			// Strip the prefix and inspect the resulting token
+			account, _ := a.Inspect(token)
 
 			// Extract the namespace header
 			ns, ok := metadata.Get(ctx, "Micro-Namespace")

--- a/util/wrapper/wrapper.go
+++ b/util/wrapper/wrapper.go
@@ -197,10 +197,12 @@ func AuthHandler(fn func() auth.Auth) server.HandlerWrapper {
 				if !strings.HasPrefix(header, auth.BearerScheme) {
 					return errors.Unauthorized(req.Service(), "invalid authorization header. expected Bearer schema")
 				}
+
+				// Strip the bearer scheme prefix
 				token = strings.TrimPrefix(header, auth.BearerScheme)
 			}
 
-			// Strip the prefix and inspect the resulting token
+			// Inspect the token and decode an account
 			account, _ := a.Inspect(token)
 
 			// Extract the namespace header

--- a/util/wrapper/wrapper_test.go
+++ b/util/wrapper/wrapper_test.go
@@ -121,22 +121,6 @@ func TestAuthHandler(t *testing.T) {
 		}
 	})
 
-	// If the Authorization header is blank, no error should be returned and verify not called
-	t.Run("BlankAuthorizationHeader", func(t *testing.T) {
-		a := testAuth{}
-		handler := AuthHandler(func() auth.Auth {
-			return &a
-		})
-
-		err := handler(h)(context.TODO(), serviceReq, nil)
-		if err != nil {
-			t.Errorf("Expected nil error but got %v", err)
-		}
-		if a.inspectCount != 0 {
-			t.Errorf("Did not expect inspect to be called")
-		}
-	})
-
 	// If the Authorization header is invalid, an error should be returned and verify not called
 	t.Run("InvalidAuthorizationHeader", func(t *testing.T) {
 		a := testAuth{}
@@ -173,7 +157,7 @@ func TestAuthHandler(t *testing.T) {
 
 	// If the issuer header was not set on the request, the wrapper should set it to the auths
 	// own issuer
-	t.Run("BlankissuerHeader", func(t *testing.T) {
+	t.Run("BlankIssuerHeader", func(t *testing.T) {
 		a := testAuth{issuer: "myissuer"}
 		handler := AuthHandler(func() auth.Auth {
 			return &a
@@ -193,7 +177,7 @@ func TestAuthHandler(t *testing.T) {
 			t.Errorf("Expected issuer to be set to %v but was %v", a.issuer, ns)
 		}
 	})
-	t.Run("ValidissuerHeader", func(t *testing.T) {
+	t.Run("ValidIssuerHeader", func(t *testing.T) {
 		a := testAuth{issuer: "myissuer"}
 		handler := AuthHandler(func() auth.Auth {
 			return &a


### PR DESCRIPTION
noop auth (the default implementation) returns an account from Inspect regardless of the token provided, however the auth wrapper was only making the Inspect call if the Authorization header was present. 