### PR TITLE
router: update interface

### DIFF
--- a/client/selector/router/router.go
+++ b/client/selector/router/router.go
@@ -184,7 +184,7 @@ func (r *routerSelector) Reset(service string) {
 
 func (r *routerSelector) Close() error {
 	// stop the router advertisements
-	return r.r.Stop()
+	return r.r.Close()
 }
 
 func (r *routerSelector) String() string {

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1
 	google.golang.org/grpc v1.26.0
-	google.golang.org/protobuf v1.22.0
+	google.golang.org/protobuf v1.22.0 // indirect
 	gopkg.in/telegram-bot-api.v4 v4.6.4
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,7 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/network/default.go
+++ b/network/default.go
@@ -1746,11 +1746,6 @@ func (n *network) Connect() error {
 	// create closed channel
 	n.closed = make(chan bool)
 
-	// start the router
-	if err := n.options.Router.Start(); err != nil {
-		return err
-	}
-
 	// start advertising routes
 	advertChan, err := n.options.Router.Advertise()
 	if err != nil {
@@ -1785,8 +1780,8 @@ func (n *network) close() error {
 		return err
 	}
 
-	// stop the router
-	if err := n.router.Stop(); err != nil {
+	// close the router
+	if err := n.router.Close(); err != nil {
 		return err
 	}
 

--- a/router/default_test.go
+++ b/router/default_test.go
@@ -15,19 +15,15 @@ func routerTestSetup() Router {
 	return newRouter(Registry(r))
 }
 
-func TestRouterStartStop(t *testing.T) {
+func TestRouterClose(t *testing.T) {
 	r := routerTestSetup()
-
-	if err := r.Start(); err != nil {
-		t.Errorf("failed to start router: %v", err)
-	}
 
 	_, err := r.Advertise()
 	if err != nil {
 		t.Errorf("failed to start advertising: %v", err)
 	}
 
-	if err := r.Stop(); err != nil {
+	if err := r.Close(); err != nil {
 		t.Errorf("failed to stop router: %v", err)
 	}
 	if len(os.Getenv("IN_TRAVIS_CI")) == 0 {
@@ -40,10 +36,6 @@ func TestRouterAdvertise(t *testing.T) {
 
 	// lower the advertise interval
 	AdvertiseEventsTick = 500 * time.Millisecond
-
-	if err := r.Start(); err != nil {
-		t.Errorf("failed to start router: %v", err)
-	}
 
 	ch, err := r.Advertise()
 	if err != nil {
@@ -134,7 +126,7 @@ func TestRouterAdvertise(t *testing.T) {
 
 	wg.Wait()
 
-	if err := r.Stop(); err != nil {
+	if err := r.Close(); err != nil {
 		t.Errorf("failed to stop router: %v", err)
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -11,7 +11,7 @@ var (
 	// DefaultName is default router service name
 	DefaultName = "go.micro.router"
 	// DefaultNetwork is default micro network
-	DefaultNetwork = "go.micro"
+	DefaultNetwork = "micro"
 	// DefaultRouter is default network router
 	DefaultRouter = NewRouter()
 )

--- a/router/router.go
+++ b/router/router.go
@@ -32,10 +32,8 @@ type Router interface {
 	Lookup(...QueryOption) ([]Route, error)
 	// Watch returns a watcher which tracks updates to the routing table
 	Watch(opts ...WatchOption) (Watcher, error)
-	// Start starts the router
-	Start() error
-	// Stop stops the router
-	Stop() error
+	// Close the router
+	Close() error
 	// Returns the router implementation
 	String() string
 }

--- a/router/service/service.go
+++ b/router/service/service.go
@@ -85,13 +85,6 @@ func (s *svc) Table() router.Table {
 	return s.table
 }
 
-// Start starts the service
-func (s *svc) Start() error {
-	s.Lock()
-	defer s.Unlock()
-	return nil
-}
-
 func (s *svc) advertiseEvents(advertChan chan *router.Advert, stream pb.Router_AdvertiseService) error {
 	go func() {
 		<-s.exit
@@ -202,8 +195,8 @@ func (s *svc) Process(advert *router.Advert) error {
 	return nil
 }
 
-// Remote router cannot be stopped
-func (s *svc) Stop() error {
+// Remote router cannot be closed
+func (s *svc) Close() error {
 	s.Lock()
 	defer s.Unlock()
 


### PR DESCRIPTION
Update the router interface, removing the need for Start() and renaming Stop() to Close(). This brings it more inline with other go-micro interfaces. This is also needed go-micro services will soon be using the router internally (not just via the proxy).

Also, updating the default network from "go.micro" to "micro", inline with the default registry domain.

This is a breaking change, however as discussed with Asim, the router is only currently being used by micro, so I'll open a secondary PR to update this shortly.