### PR TITLE
util/wrapper: fix 401 error when requesting the default namespace

### DIFF
--- a/util/wrapper/wrapper.go
+++ b/util/wrapper/wrapper.go
@@ -224,7 +224,7 @@ func AuthHandler(fn func() auth.Auth) server.HandlerWrapper {
 
 			// Check the issuer matches the services namespace. TODO: Stop allowing go.micro to access
 			// any namespace and instead check for the server issuer.
-			if account != nil && account.Issuer != ns && account.Issuer != "go.micro" {
+			if account != nil && account.Issuer != ns && account.Issuer != "micro" {
 				return errors.Forbidden(req.Service(), "Account was not issued by %v", ns)
 			}
 


### PR DESCRIPTION
Update go-micro to micro as the default auth issuer.