### PR TITLE
router/registry: add fallback if routes aren't found in the cache

### DIFF
--- a/router/default.go
+++ b/router/default.go
@@ -51,9 +51,9 @@ func newRouter(opts ...Option) Router {
 		subscribers: make(map[string]chan *Advert),
 	}
 
-	// create the new table, passing the router in. The router can be used as a fallback if
+	// create the new table, passing the fetchRoute method in as a fallback if
 	// the table doesn't contain the result for a query.
-	r.table = newTable(r)
+	r.table = newTable(r.fetchRoutes)
 
 	// start the router and return
 	r.start()

--- a/router/default.go
+++ b/router/default.go
@@ -48,9 +48,12 @@ func newRouter(opts ...Option) Router {
 	// construct the router
 	r := &router{
 		options:     options,
-		table:       newTable(),
 		subscribers: make(map[string]chan *Advert),
 	}
+
+	// create the new table, passing the router in. The router can be used as a fallback if
+	// the table doesn't contain the result for a query.
+	r.table = newTable(r)
 
 	// start the router and return
 	r.start()
@@ -170,6 +173,29 @@ func (r *router) manageRegistryRoutes(reg registry.Registry, action string) erro
 			if err := r.manageRoutes(srv, action, domain); err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+// fetchRoutes retrieves all the routes for a given service and creates them in the routing table
+func (r *router) fetchRoutes(service string) error {
+	services, err := r.options.Registry.GetService(service, registry.GetDomain(registry.WildcardDomain))
+	if err != nil {
+		return fmt.Errorf("failed getting services: %v", err)
+	}
+
+	for _, srv := range services {
+		var domain string
+		if srv.Metadata != nil && len(srv.Metadata["domain"]) > 0 {
+			domain = srv.Metadata["domain"]
+		} else {
+			domain = registry.WildcardDomain
+		}
+
+		if err := r.manageRoutes(srv, "create", domain); err != nil {
+			return err
 		}
 	}
 

--- a/router/table.go
+++ b/router/table.go
@@ -258,9 +258,11 @@ func (t *table) Query(q ...QueryOption) ([]Route, error) {
 		}
 
 		// load the cache and try again
+		t.RUnlock()
 		if err := t.router.fetchRoutes(opts.Service); err != nil {
 			return nil, err
 		}
+		t.RLock()
 		if _, ok := t.routes[opts.Service]; ok {
 			return findRoutes(t.routes[opts.Service], opts.Address, opts.Gateway, opts.Network, opts.Router, opts.Strategy), nil
 

--- a/router/table_test.go
+++ b/router/table_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func testSetup() (*table, Route) {
-	table := newTable(&router{options: DefaultOptions()})
+	router := newRouter().(*router)
+	table := router.table
 
 	route := Route{
 		Service: "dest.svc",

--- a/router/table_test.go
+++ b/router/table_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func testSetup() (*table, Route) {
-	table := newTable()
+	table := newTable(&router{options: DefaultOptions()})
 
 	route := Route{
 		Service: "dest.svc",


### PR DESCRIPTION
This PR fixes the flakey tests in micro.