### PR TITLE
selector: use custom domain 

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -84,8 +84,14 @@ func (g *grpcClient) next(request client.Request, opts client.CallOptions) (sele
 		}, nil
 	}
 
+	// if the network was set, pass it to the selector
+	sopts := opts.SelectOptions
+	if len(opts.Network) > 0 {
+		sopts = append(sopts, selector.WithDomain(opts.Network))
+	}
+
 	// get next nodes from the selector
-	next, err := g.opts.Selector.Select(service, opts.SelectOptions...)
+	next, err := g.opts.Selector.Select(service, sopts...)
 	if err != nil {
 		if err == selector.ErrNotFound {
 			return nil, errors.InternalServerError("go.micro.client", "service %s: %s", service, err.Error())

--- a/client/options.go
+++ b/client/options.go
@@ -64,6 +64,8 @@ type CallOptions struct {
 	ServiceToken bool
 	// Duration to cache the response for
 	CacheExpiry time.Duration
+	// Network to lookup the route within
+	Network string
 
 	// Middleware for low level call func
 	CallWrappers []CallWrapper
@@ -335,6 +337,13 @@ func WithServiceToken() CallOption {
 func WithCache(c time.Duration) CallOption {
 	return func(o *CallOptions) {
 		o.CacheExpiry = c
+	}
+}
+
+// WithNetwork is a CallOption which sets the network attribute
+func WithNetwork(n string) CallOption {
+	return func(o *CallOptions) {
+		o.Network = n
 	}
 }
 

--- a/client/selector/options.go
+++ b/client/selector/options.go
@@ -21,6 +21,7 @@ type Options struct {
 type SelectOptions struct {
 	Filters  []Filter
 	Strategy Strategy
+	Domain   string
 
 	// Other options for implementations of the interface
 	// can be stored in a context
@@ -66,5 +67,12 @@ func WithFilter(fn ...Filter) SelectOption {
 func WithStrategy(fn Strategy) SelectOption {
 	return func(o *SelectOptions) {
 		o.Strategy = fn
+	}
+}
+
+// WithDomain sets the registry domain to use for the selection
+func WithDomain(d string) SelectOption {
+	return func(o *SelectOptions) {
+		o.Domain = d
 	}
 }

--- a/util/wrapper/wrapper.go
+++ b/util/wrapper/wrapper.go
@@ -222,10 +222,10 @@ func AuthHandler(fn func() auth.Auth) server.HandlerWrapper {
 				ctx = metadata.Set(ctx, "Micro-Namespace", ns)
 			}
 
-			// Check the issuer matches the services namespace. TODO: Stop allowing go.micro to access
+			// Check the issuer matches the services namespace. TODO: Stop allowing micro to access
 			// any namespace and instead check for the server issuer.
 			if account != nil && account.Issuer != ns && account.Issuer != "micro" {
-				return errors.Forbidden(req.Service(), "Account was not issued by %v", ns)
+				return errors.Forbidden(req.Service(), "Account was issued by %v, not %v", account.Issuer, ns)
 			}
 
 			// construct the resource


### PR DESCRIPTION
Enable micro web to pass a custom domain to the selector. Although the selector is going to be replaced shortly, the client options will still be used by the router to provide the same functionality.