### PR TITLE
registry/mdns: fix deregister bug

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -359,6 +359,11 @@ func (m *mdnsRegistry) Deregister(service *Service, opts ...DeregisterOption) er
 		}
 	}
 
+	// we have no new entries, we can exist
+	if len(newEntries) == 0 {
+		return nil
+	}
+
 	// we have more than one entry remaining, we can exit
 	if len(newEntries) > 1 {
 		m.domains[options.Domain][service.Name] = newEntries

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -359,7 +359,7 @@ func (m *mdnsRegistry) Deregister(service *Service, opts ...DeregisterOption) er
 		}
 	}
 
-	// we have no new entries, we can exist
+	// we have no new entries, we can exit
 	if len(newEntries) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Fixes:

```
2020-07-01 10:32:39  file=grpc/grpc.go:373 level=error service=registry panic recovered: runtime error: index out of range [0] with length 0
2020-07-01 10:32:39  file=grpc/grpc.go:374 level=error service=registry goroutine 106 [running]:
runtime/debug.Stack(0xc00000eea0, 0xc000219902, 0xc0002199a0)
	/usr/local/Cellar/go/1.13.6/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/micro/go-micro/v2/server/grpc.(*grpcServer).processRequest.func1.1(0xc000801190)
	/Users/micro/go/src/github.com/micro/go-micro/server/grpc/grpc.go:374 +0x2cf
panic(0x53d2a20, 0xc0002f4f60)
	/usr/local/Cellar/go/1.13.6/libexec/src/runtime/panic.go:679 +0x1b2
github.com/micro/go-micro/v2/registry.(*mdnsRegistry).Deregister(0xc0000e99a0, 0xc000457f20, 0xc000518b70, 0x2, 0x2, 0x0, 0x0)
	/Users/micro/go/src/github.com/micro/go-micro/registry/mdns_registry.go:375 +0x8b1
github.com/micro/go-micro/v2/registry.(*mdnsRegistry).Deregister.func1(0xc0000e99a0, 0xc000457f20, 0xc0003ea1b0, 0x1, 0x1, 0xc000800be8)
	/Users/micro/go/src/github.com/micro/go-micro/registry/mdns_registry.go:329 +0x95
panic(0x53d2a20, 0xc0002f4f40)
```