### PR TITLE
proxy/mucp: use Micro-Namespace to filter networks

### DIFF
--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -128,7 +128,7 @@ func (p *Proxy) filterRoutes(ctx context.Context, routes []router.Route) []route
 		}
 
 		// only process routes with this network
-		if net, ok := md.Get("Micro-Network"); ok && len(net) > 0 {
+		if net, ok := md.Get("Micro-Namespace"); ok && len(net) > 0 {
 			if route.Network != router.DefaultNetwork && route.Network != net {
 				// skip routes that don't mwatch
 				continue


### PR DESCRIPTION
This fixes a bug where services can get routes from all networks when querying via the proxy. 