### PR TITLE
router/registry: fix nil eventChan bug

### DIFF
--- a/router/default.go
+++ b/router/default.go
@@ -705,8 +705,10 @@ func (r *router) Close() error {
 	}
 
 	// close and remove event chan
-	close(r.eventChan)
-	r.eventChan = nil
+	if r.eventChan != nil {
+		close(r.eventChan)
+		r.eventChan = nil
+	}
 
 	r.running = false
 	return nil

--- a/router/default.go
+++ b/router/default.go
@@ -285,7 +285,6 @@ func (r *router) watchTable(w Watcher) error {
 
 		select {
 		case <-r.exit:
-			close(r.eventChan)
 			return nil
 		case r.eventChan <- event:
 			// process event
@@ -705,10 +704,11 @@ func (r *router) Close() error {
 		r.sub.Unlock()
 	}
 
-	// remove event chan
+	// close and remove event chan
+	close(r.eventChan)
 	r.eventChan = nil
-	r.running = false
 
+	r.running = false
 	return nil
 }
 


### PR DESCRIPTION
Fixes:
```
2020-07-01 11:04:30  file=server/rpc_server.go:770 level=info service=server Registry [mdns] Deregistering node: go.micro-1541ef96-6116-4693-a699-a29f9eb117b7
panic: close of nil channel

goroutine 113 [running]:
github.com/micro/go-micro/v2/router.(*router).watchTable(0xc0003096c0, 0x5785560, 0xc0000ff360, 0x0, 0x0)
	/Users/micro/go/src/github.com/micro/go-micro/router/default.go:288 +0x1ef
github.com/micro/go-micro/v2/router.(*router).advertiseEvents.func1(0xc0003096c0, 0xc00017f310)
	/Users/micro/go/src/github.com/micro/go-micro/router/default.go:361 +0x8f
created by github.com/micro/go-micro/v2/router.(*router).advertiseEvents
	/Users/micro/go/src/github.com/micro/go-micro/router/default.go:341 +0x1d0
```