### PR TITLE
api/router/registry: use resolved domain

### DIFF
--- a/api/router/registry/registry.go
+++ b/api/router/registry/registry.go
@@ -434,7 +434,7 @@ func (r *registryRouter) Route(req *http.Request) (*api.Service, error) {
 	name := rp.Name
 
 	// get service
-	services, err := r.rc.GetService(name)
+	services, err := r.rc.GetService(name, registry.GetDomain(rp.Domain))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes an issue where the api resolver would determine the domain to be "foo", but the router didn't use this domain when looking up the service.