### PR TITLE
router/registry: fix fallback failing if service has been seen already

### DIFF
--- a/router/table_test.go
+++ b/router/table_test.go
@@ -289,3 +289,44 @@ func TestQuery(t *testing.T) {
 		t.Errorf("incorrect number of routes returned. Expected: %d, found: %d", 1, len(routes))
 	}
 }
+
+func TestFallback(t *testing.T) {
+
+	r := &router{
+		subscribers: make(map[string]chan *Advert),
+		options:     DefaultOptions(),
+	}
+	route := Route{
+		Service: "go.micro.service.foo",
+		Router:  r.options.Id,
+		Link:    DefaultLink,
+		Metric:  DefaultLocalMetric,
+	}
+	r.table = newTable(func(s string) error {
+		r.table.Create(route)
+		return nil
+	})
+	r.start()
+
+	rts, err := r.Lookup(QueryService("go.micro.service.foo"))
+	if err != nil {
+		t.Errorf("error looking up service %s", err)
+	}
+	if len(rts) != 1 {
+		t.Errorf("incorrect number of routes returned %d", len(rts))
+	}
+
+	// deleting from the table but the next query should invoke the fallback that we passed during new table creation
+	if err := r.table.Delete(route); err != nil {
+		t.Errorf("error deleting route %s", err)
+	}
+
+	rts, err = r.Lookup(QueryService("go.micro.service.foo"))
+	if err != nil {
+		t.Errorf("error looking up service %s", err)
+	}
+	if len(rts) != 1 {
+		t.Errorf("incorrect number of routes returned %d", len(rts))
+	}
+
+}


### PR DESCRIPTION
If a service has already been registered and then deleted subsequent fallbacks will fail. Also fixes an intermittent bug we saw in tests for micro