### PR TITLE
config/source/service: change default namespace to micro

### DIFF
--- a/config/source/service/service.go
+++ b/config/source/service/service.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	DefaultName      = "go.micro.config"
-	DefaultNamespace = "global"
+	DefaultNamespace = "micro"
 	DefaultPath      = ""
 )
 


### PR DESCRIPTION
Now we're scoping config to the service's namespace, rename the default config namespace to the default namespace we use everywhere else: "micro". Since this is overwritten by the service's namespace during setup, the value should never be needed, see https://github.com/micro/go-micro/blob/f99b436ec2fbfcd21b20b53c83a1b4cac3319a07/config/cmd/cmd.go#L836.