### PR TITLE
api/handler/rpc: pass request context to stream

### DIFF
--- a/util/ctx/ctx.go
+++ b/util/ctx/ctx.go
@@ -3,16 +3,24 @@ package ctx
 import (
 	"context"
 	"net/http"
+	"net/textproto"
 	"strings"
 
 	"github.com/micro/go-micro/v2/metadata"
 )
 
 func FromRequest(r *http.Request) context.Context {
-	ctx := context.Background()
-	md := make(metadata.Metadata)
-	for k, v := range r.Header {
-		md[k] = strings.Join(v, ",")
+	ctx := r.Context()
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		md = make(metadata.Metadata)
 	}
+	for k, v := range r.Header {
+		md[textproto.CanonicalMIMEHeaderKey(k)] = strings.Join(v, ",")
+	}
+	// pass http host
+	md["Host"] = r.Host
+	// pass http method
+	md["Method"] = r.Method
 	return metadata.NewContext(ctx, md)
 }


### PR DESCRIPTION
pass incoming http context to rpc endpoints to pass tracing headers and other relevant stuff

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>
