### PR TITLE
Cache interface

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,17 @@
+// Package cache is a caching interface
+package cache
+
+type Cache interface {
+	// Initialise options
+	Init(...Option) error
+	// Get a value
+	Get(key string) (interface{}, error)
+	// Set a value
+	Set(key string, val interface{}) error
+	// Delete a value
+	Delete(key string) error
+	// Name of the implementation
+	String() string
+}
+
+type Option struct{}

--- a/cache/memory/memory.go
+++ b/cache/memory/memory.go
@@ -1,0 +1,56 @@
+// Package memory is an in memory cache
+package memory
+
+import (
+	"sync"
+
+	"github.com/micro/go-micro/v2/cache"
+	"github.com/micro/go-micro/v2/errors"
+)
+
+type memoryCache struct {
+	// TODO: use a decent caching library
+	sync.RWMutex
+	values map[string]interface{}
+}
+
+func (m *memoryCache) Init(opts ...cache.Option) error {
+	// TODO: implement
+	return nil
+}
+
+func (m *memoryCache) Get(key string) (interface{}, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	v, ok := m.values[key]
+	if !ok {
+		return nil, errors.NotFound("go.micro.cache", key+" not found")
+	}
+
+	return v, nil
+}
+
+func (m *memoryCache) Set(key string, val interface{}) error {
+	m.Lock()
+	m.values[key] = val
+	m.Unlock()
+	return nil
+}
+
+func (m *memoryCache) Delete(key string) error {
+	m.Lock()
+	delete(m.values, key)
+	m.Unlock()
+	return nil
+}
+
+func (m *memoryCache) String() string {
+	return "memory"
+}
+
+func NewCache(opts ...cache.Option) cache.Cache {
+	return &memoryCache{
+		values: make(map[string]interface{}),
+	}
+}


### PR DESCRIPTION
The cache interface is the first version of an interface specifically designed for caching. In future implementations may include memcache, redis, groupcache, bigcache and other things deemed for caching. We may run a cache service on the platform specifically for this purpose.

Our store interface is a persistent storage layer but it is designed for the backend of a database as opposed to fast caching. What it highlights is that every interface dictates a certain abstraction and design pattern. Cache demonstrates this as a next iteration. In the same way Model will likely be for SQL and Graph will be for graph querying. This is not exclusive to data storage. Micro being a distributed systems framework dictates abstractions / design patterns as interfaces.