### PR TITLE
Add model interface

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -1,0 +1,51 @@
+// Package model is an interface for data modelling
+package model
+
+import (
+	"github.com/micro/go-micro/v2/store"
+	"github.com/micro/go-micro/v2/sync"
+)
+
+// Model provides an interface for data modelling
+type Model interface {
+	// Initialise options
+	Init(...Option) error
+	// NewEntity creates a new entity to store or access
+	NewEntity(name string, value interface{}) Entity
+	// Create a value
+	Create(Entity) error
+	// Read values
+	Read(...ReadOption) ([]Entity, error)
+	// Update the value
+	Update(Entity) error
+	// Delete an entity
+	Delete(...DeleteOption) error
+	// Implementation of the model
+	String() string
+}
+
+type Entity interface {
+	// Unique id of the entity
+	Id() string
+	// The value associated with the entity
+	Value() interface{}
+	// Attributes of the enity
+	Attributes() map[string]interface{}
+}
+
+type Options struct {
+	// for locking
+	Sync sync.Sync
+	// for storage
+	Store store.Store
+}
+
+type Option func(o *Options)
+
+type ReadOptions struct{}
+
+type ReadOption func(o *ReadOptions)
+
+type DeleteOptions struct{}
+
+type DeleteOption func(o *DeleteOptions)


### PR DESCRIPTION
First step towards a model interface. I'm taking the approach which I took with the client and server which is to define an interface, commit and let it bake for a while as I start to think about its evolution. Its clear to me that certain new packages and interfaces which I will define are more difficult to do in an upfront design doc, often they're not right and its easier to iterate in practice. 

Model represents domain and data modelling for data storage. It sits as a layer on top of sync/store. It may in future be implemented as gorm or some other ORM based solution but just like the client/server we start with an implementation written by ourselves from scratch. The goal here is to have a client/server/model be core abstractions of a service which can then be code generated based on a proto service e.g User generates code to register handlers, to make service calls and now will add boilerplate for CRUD so it does not have to be written by hand.