### PR TITLE
registry/mdns: fix nil pointer bug

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -120,10 +120,10 @@ func decode(record []string) (*mdnsTxt, error) {
 
 	br := bytes.NewReader(hr)
 	zr, err := zlib.NewReader(br)
-	defer zr.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer zr.Close()
 
 	rbuf, err := ioutil.ReadAll(zr)
 	if err != nil {


### PR DESCRIPTION
Fixes:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15061a3]

goroutine 21 [running]:
github.com/micro/go-micro/v2/registry.decode(0xc00031e040, 0x1, 0x1, 0x0, 0x0, 0x0)
	/Users/micro/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200710152546-09ec20fdeddd/registry/mdns_registry.go:123 +0x173
github.com/micro/go-micro/v2/registry.(*mdnsWatcher).Next(0xc000114620, 0x17d4340, 0x1899ec0, 0xc000114620)
	/Users/micro/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200710152546-09ec20fdeddd/registry/mdns_registry.go:685 +0x10e
github.com/micro/go-micro/v2/router.(*router).watchRegistry(0xc0000fd2b0, 0x1899ec0, 0xc000114620, 0x0, 0x0)
	/Users/micro/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200710152546-09ec20fdeddd/router/default.go:229 +0xf5
github.com/micro/go-micro/v2/router.(*router).start.func1(0xc0000fd2b0, 0xc00014e500)
	/Users/micro/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200710152546-09ec20fdeddd/router/default.go:526 +0x8f
created by github.com/micro/go-micro/v2/router.(*router).start
	/Users/micro/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200710152546-09ec20fdeddd/router/default.go:504 +0x229
```