### PR TITLE
transport/grpc: replace deprecated grpc.WithTimeout()

### DIFF
--- a/transport/grpc/grpc.go
+++ b/transport/grpc/grpc.go
@@ -94,9 +94,7 @@ func (t *grpcTransport) Dial(addr string, opts ...transport.DialOption) (transpo
 		opt(&dopts)
 	}
 
-	options := []grpc.DialOption{
-		grpc.WithTimeout(dopts.Timeout),
-	}
+	options := []grpc.DialOption{}
 
 	if t.opts.Secure || t.opts.TLSConfig != nil {
 		config := t.opts.TLSConfig
@@ -112,7 +110,9 @@ func (t *grpcTransport) Dial(addr string, opts ...transport.DialOption) (transpo
 	}
 
 	// dial the server
-	conn, err := grpc.Dial(addr, options...)
+	ctx, cancel := context.WithTimeout(context.Background(), dopts.Timeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, addr, options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
godoc asserts that `grpc.WithTimeout()` is deprecated. 
> deprecated: use DialContext instead of Dial and context.WithTimeout instead.                                                               

This uses `DialContext()` and `context.WithTimeout()` instead.