### PR TITLE
auth: add token issuer option

### DIFF
--- a/auth/options.go
+++ b/auth/options.go
@@ -196,6 +196,8 @@ type TokenOptions struct {
 	RefreshToken string
 	// Expiry is the time the token should live for
 	Expiry time.Duration
+	// Issuer of the account
+	Issuer string
 }
 
 type TokenOption func(o *TokenOptions)
@@ -217,6 +219,12 @@ func WithCredentials(id, secret string) TokenOption {
 func WithToken(rt string) TokenOption {
 	return func(o *TokenOptions) {
 		o.RefreshToken = rt
+	}
+}
+
+func WithTokenIssuer(iss string) TokenOption {
+	return func(o *TokenOptions) {
+		o.Issuer = iss
 	}
 }
 

--- a/auth/service/service.go
+++ b/auth/service/service.go
@@ -193,6 +193,9 @@ func (s *svc) Inspect(token string) (*auth.Account, error) {
 // Token generation using an account ID and secret
 func (s *svc) Token(opts ...auth.TokenOption) (*auth.Token, error) {
 	options := auth.NewTokenOptions(opts...)
+	if len(options.Issuer) == 0 {
+		options.Issuer = s.options.Issuer
+	}
 
 	// we have the JWT private key and refresh accounts locally
 	if len(s.options.PrivateKey) > 0 {
@@ -224,7 +227,7 @@ func (s *svc) Token(opts ...auth.TokenOption) (*auth.Token, error) {
 		RefreshToken: options.RefreshToken,
 		TokenExpiry:  int64(options.Expiry.Seconds()),
 		Options: &pb.Options{
-			Namespace: s.Options().Issuer,
+			Namespace: options.Issuer,
 		},
 	}, s.callOpts()...)
 	if err != nil {


### PR DESCRIPTION
Since accounts are scoped to a namespace, we need to specify the issuer of the account when we try to login using credentials.