### PR TITLE
Don't close the k8s log stream

### DIFF
--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -384,7 +384,6 @@ func (k *kubeStream) Stop() error {
 		return nil
 	default:
 		close(k.stop)
-		close(k.stream)
 	}
 	return nil
 }

--- a/runtime/kubernetes/logs.go
+++ b/runtime/kubernetes/logs.go
@@ -53,7 +53,11 @@ func (k *klog) podLogStream(podName string, stream *kubeStream) error {
 				record := runtime.LogRecord{
 					Message: s.Text(),
 				}
-				stream.stream <- record
+				select {
+				case stream.stream <- record:
+				case <-stream.stop:
+					return stream.Error()
+				}
 			} else {
 				// TODO: is there a blocking call
 				// rather than a sleep loop?


### PR DESCRIPTION
Closing log stream causes it to panic so better to select on stop and return and not close the stream since the sender is not the closer. Channels not closed as still garbage collected.