### PR TITLE
util/wrapper: only use service namespace when authorising requests

### DIFF
--- a/service.go
+++ b/service.go
@@ -44,16 +44,11 @@ func newService(opts ...Option) Service {
 	options.Client = wrapper.CacheClient(cacheFn, options.Client)
 	options.Client = wrapper.AuthClient(authFn, options.Client)
 
-	// pass the services auth namespace to the auth handler so it
-	// uses this to verify requests, preventing the reliance on the
-	// unsecure Micro-Namespace header.
-	handlerNS := wrapper.AuthHandlerNamespace(options.Auth.Options().Issuer)
-
 	// wrap the server to provide handler stats
 	options.Server.Init(
 		server.WrapHandler(wrapper.HandlerStats(stats.DefaultStats)),
 		server.WrapHandler(wrapper.TraceHandler(trace.DefaultTracer)),
-		server.WrapHandler(wrapper.AuthHandler(authFn, handlerNS)),
+		server.WrapHandler(wrapper.AuthHandler(authFn)),
 	)
 
 	// set opts


### PR DESCRIPTION
Previously, the proxy used this wrapper when authenticating request, however this is being removed so there is no longer the need to use a dynamic namespace. We only have an exception for "micro" since it supports multi-tenancy. This wrapper will soon be moved to micro and refactored further for v3.