### PR TITLE
router: pass node metadata to route instead of service metadata

### DIFF
--- a/router/default.go
+++ b/router/default.go
@@ -135,7 +135,7 @@ func (r *router) manageRoutes(service *registry.Service, action, network string)
 			Router:   r.options.Id,
 			Link:     DefaultLink,
 			Metric:   DefaultLocalMetric,
-			Metadata: service.Metadata,
+			Metadata: node.Metadata,
 		}
 
 		if err := r.manageRoute(route, action); err != nil {


### PR DESCRIPTION
Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>
