### PR TITLE
client/grpc: fix error panic

### DIFF
--- a/client/grpc/error.go
+++ b/client/grpc/error.go
@@ -24,7 +24,9 @@ func microError(err error) error {
 
 	// return first error from details
 	if details := s.Details(); len(details) > 0 {
-		return microError(details[0].(error))
+		if verr, ok := details[0].(error); ok {
+			return microError(verr)
+		}
 	}
 
 	// try to decode micro *errors.Error


### PR DESCRIPTION
Fixes:

```
panic: interface conversion: *errors.Error is not error: missing method Error

goroutine 136 [running]:
github.com/micro/go-micro/v2/client/grpc.microError(0x1f855c0, 0xc000559140, 0xc0003f1740, 0xc00018c5c0)
	/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200719184811-9b74bc52d6a3/client/grpc/error.go:27 +0x28b
github.com/micro/go-micro/v2/client/grpc.(*grpcClient).call.func2(0x1fb6cc0, 0xc0004e70e0, 0xc0001b6d80, 0xc0000a5e00, 0x1fbcc80, 0xc0003f1740, 0x1fc9f20, 0xc00015d280, 0x1c69fa0, 0xc0003f15c0, ...)
	/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200719184811-9b74bc52d6a3/client/grpc/grpc.go:136 +0x385
created by github.com/micro/go-micro/v2/client/grpc.(*grpcClient).call
	/go/pkg/mod/github.com/micro/go-micro/v2@v2.9.1-0.20200719184811-9b74bc52d6a3/client/grpc/grpc.go:128 +0xc7a
```