### PR TITLE
tunnel: remove unused test loop

### DIFF
--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -113,27 +113,25 @@ func testAccept(t *testing.T, tun Tunnel, wait chan bool, wg *sync.WaitGroup) {
 	}
 
 	// get a message
-	for {
-		// accept the message
-		m := new(transport.Message)
-		if err := c.Recv(m); err != nil {
-			t.Fatal(err)
-		}
-
-		if v := m.Header["test"]; v != "send" {
-			t.Fatalf("Accept side expected test:send header. Received: %s", v)
-		}
-
-		// now respond
-		m.Header["test"] = "accept"
-		if err := c.Send(m); err != nil {
-			t.Fatal(err)
-		}
-
-		wait <- true
-
-		return
+	// accept the message
+	m := new(transport.Message)
+	if err := c.Recv(m); err != nil {
+		t.Fatal(err)
 	}
+
+	if v := m.Header["test"]; v != "send" {
+		t.Fatalf("Accept side expected test:send header. Received: %s", v)
+	}
+
+	// now respond
+	m.Header["test"] = "accept"
+	if err := c.Send(m); err != nil {
+		t.Fatal(err)
+	}
+
+	wait <- true
+
+	return
 }
 
 // testSend will create a new link to an address and then a tunnel on top


### PR DESCRIPTION
This diff looks bigger than it is.

This removes a `for` loop in `testAccept()` that did nothing. So long as `t.Fatal()` wasn't triggered, it would get to the end, send a `true` down the `wait` channel, and then `return`.