### PR TITLE
Fix: file-watcher bugs

### DIFF
--- a/config/source/file/file.go
+++ b/config/source/file/file.go
@@ -10,6 +10,7 @@ import (
 
 type file struct {
 	path string
+	data []byte
 	opts source.Options
 }
 

--- a/config/source/file/watcher.go
+++ b/config/source/file/watcher.go
@@ -39,26 +39,36 @@ func (w *watcher) Next() (*source.ChangeSet, error) {
 	default:
 	}
 
-	// try get the event
-	select {
-	case event, _ := <-w.fw.Events:
-		if event.Op == fsnotify.Rename {
-			// check existence of file, and add watch again
-			_, err := os.Stat(event.Name)
-			if err == nil || os.IsExist(err) {
-				w.fw.Add(event.Name)
+	for {
+		// try get the event
+		select {
+		case event, _ := <-w.fw.Events:
+			if event.Op == fsnotify.Rename {
+				// check existence of file, and add watch again
+				_, err := os.Stat(event.Name)
+				if err == nil || os.IsExist(err) {
+					w.fw.Add(event.Name)
+				}
 			}
-		}
 
-		c, err := w.f.Read()
-		if err != nil {
+			// ARCH: Darwin Kernel Version 18.7.0
+			// ioutil.WriteFile truncates it before writing, but the problem is that
+			// you will receive two events(fsnotify.Chmod and fsnotify.Write).
+			// We can solve this problem by ignoring fsnotify.Chmod event.
+			if event.Op&fsnotify.Write != fsnotify.Write {
+				continue
+			}
+
+			c, err := w.f.Read()
+			if err != nil {
+				return nil, err
+			}
+			return c, nil
+		case err := <-w.fw.Errors:
 			return nil, err
+		case <-w.exit:
+			return nil, source.ErrWatcherStopped
 		}
-		return c, nil
-	case err := <-w.fw.Errors:
-		return nil, err
-	case <-w.exit:
-		return nil, source.ErrWatcherStopped
 	}
 }
 

--- a/config/source/file/watcher_linux.go
+++ b/config/source/file/watcher_linux.go
@@ -4,6 +4,7 @@ package file
 
 import (
 	"os"
+	"reflect"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/micro/go-micro/v3/config/source"

--- a/config/source/file/watcher_linux.go
+++ b/config/source/file/watcher_linux.go
@@ -39,30 +39,38 @@ func (w *watcher) Next() (*source.ChangeSet, error) {
 	default:
 	}
 
-	// try get the event
-	select {
-	case event, _ := <-w.fw.Events:
-		if event.Op == fsnotify.Rename {
-			// check existence of file, and add watch again
-			_, err := os.Stat(event.Name)
-			if err == nil || os.IsExist(err) {
-				w.fw.Add(event.Name)
+	for {
+		// try get the event
+		select {
+		case event, _ := <-w.fw.Events:
+			if event.Op == fsnotify.Rename {
+				// check existence of file, and add watch again
+				_, err := os.Stat(event.Name)
+				if err == nil || os.IsExist(err) {
+					w.fw.Add(event.Name)
+				}
 			}
-		}
 
-		c, err := w.f.Read()
-		if err != nil {
+			c, err := w.f.Read()
+			if err != nil {
+				return nil, err
+			}
+
+			// ARCH: Linux centos-7.shared 3.10.0-693.5.2.el7.x86_64
+			// Sometimes, ioutil.WriteFile triggers multiple fsnotify.Write events, which may be a bug.
+
+			// Detect if the file has changed
+			if reflect.DeepEqual(c.Data, w.f.data) {
+				continue
+			}
+			w.f.data = c.Data
+
+			return c, nil
+		case err := <-w.fw.Errors:
 			return nil, err
+		case <-w.exit:
+			return nil, source.ErrWatcherStopped
 		}
-
-		// add path again for the event bug of fsnotify
-		w.fw.Add(w.f.path)
-
-		return c, nil
-	case err := <-w.fw.Errors:
-		return nil, err
-	case <-w.exit:
-		return nil, source.ErrWatcherStopped
 	}
 }
 


### PR DESCRIPTION
ioutil.WriteFile truncates it before writing, but the problem is that you will receive two events(fsnotify.Chmod and fsnotify.Write) in a non-linux OS.

Sometimes, ioutil.WriteFile triggers multiple fsnotify.Write events in Linux, which may be a bug.

I've done a lot of testing on Linux and non-Linux.
```
package file

import (
	"fmt"
	"io/ioutil"
	"os"
	"strings"
	"testing"
	"time"

	. "github.com/smartystreets/goconvey/convey"
	"github.com/micro/go-micro/v3/config/encoder/yaml"
)

func TestFileWatch(t *testing.T) {
	Convey("TestFileWatch", t, func(c C) {
		fileInit()

		sc := NewSource(WithPath("/tmp/test.yaml"))
		watcher, err := sc.Watch()
		So(err, ShouldBeNil)

		for i := 0; i < 5; i++ {

			timer := time.AfterFunc(time.Second*4, func() {
				So(false, ShouldBeTrue)
			})

			go func(c C) {
				content := fmt.Sprintf(`/test/gapi/redis: %d
/test/gapi/redis/codisA: codisA`, i)
				content = fmt.Sprintf("%s\n%s: %s", content, "/test/foo", strings.Repeat("#", 1024*1024))
				c.So(ioutil.WriteFile("/tmp/test.yaml", []byte(content), os.ModePerm), ShouldBeNil)
			}(c)

			cs, err := watcher.Next()
			timer.Stop()
			So(err, ShouldBeNil)

			data := make(map[string]interface{})
			encoder := yaml.NewEncoder()
			err = encoder.Decode(cs.Data, &data)
			So(err, ShouldBeNil)
			So(data["/test/redis"], ShouldEqual, i)
			So(data["/test/redis/codisA"], ShouldEqual, "codisA")
			So(data["/test/redis/codisB"], ShouldBeNil)
		}

		fileRecovery()
	})
}

func fileInit() {
	content := `/test/redis: 1234
/test/redis/codisA: codisA
/test/redis/codisB: codisB
`
	err := ioutil.WriteFile("/tmp/test.yaml", []byte(content), os.ModePerm)
	So(err, ShouldBeNil)
}

func fileRecovery() {
	fileInit()
}
```