### PR TITLE
codec - Allow to Write() nil body

### DIFF
--- a/codec/bytes/bytes.go
+++ b/codec/bytes/bytes.go
@@ -44,6 +44,8 @@ func (c *Codec) ReadBody(b interface{}) error {
 func (c *Codec) Write(m *codec.Message, b interface{}) error {
 	var v []byte
 	switch vb := b.(type) {
+	case nil:
+		return nil
 	case *Frame:
 		v = vb.Data
 	case *[]byte:

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1,0 +1,54 @@
+package codec_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/micro/go-micro/v2/codec"
+	"github.com/micro/go-micro/v2/codec/bytes"
+	"github.com/micro/go-micro/v2/codec/grpc"
+	"github.com/micro/go-micro/v2/codec/json"
+	"github.com/micro/go-micro/v2/codec/jsonrpc"
+	"github.com/micro/go-micro/v2/codec/proto"
+	"github.com/micro/go-micro/v2/codec/protorpc"
+	"github.com/micro/go-micro/v2/codec/text"
+)
+
+type testRWC struct{}
+
+func (rwc *testRWC) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (rwc *testRWC) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (rwc *testRWC) Close() error {
+	return nil
+}
+
+func getCodecs(c io.ReadWriteCloser) map[string]codec.Codec {
+
+	return map[string]codec.Codec{
+		"bytes":    bytes.NewCodec(c),
+		"grpc":     grpc.NewCodec(c),
+		"json":     json.NewCodec(c),
+		"jsonrpc":  jsonrpc.NewCodec(c),
+		"proto":    proto.NewCodec(c),
+		"protorpc": protorpc.NewCodec(c),
+		"text":     text.NewCodec(c),
+	}
+}
+
+func Test_WriteEmptyBody(t *testing.T) {
+	for name, c := range getCodecs(&testRWC{}) {
+		err := c.Write(&codec.Message{
+			Type:   codec.Error,
+			Header: map[string]string{},
+		}, nil)
+		if err != nil {
+			t.Fatalf("codec %s - expected no error when writing empty/nil body", name)
+		}
+	}
+}

--- a/codec/proto/proto.go
+++ b/codec/proto/proto.go
@@ -33,6 +33,10 @@ func (c *Codec) ReadBody(b interface{}) error {
 }
 
 func (c *Codec) Write(m *codec.Message, b interface{}) error {
+	if b == nil {
+		// Nothing to write
+		return nil
+	}
 	p, ok := b.(proto.Message)
 	if !ok {
 		return codec.ErrInvalidMessage

--- a/codec/text/text.go
+++ b/codec/text/text.go
@@ -46,6 +46,8 @@ func (c *Codec) ReadBody(b interface{}) error {
 func (c *Codec) Write(m *codec.Message, b interface{}) error {
 	var v []byte
 	switch ve := b.(type) {
+	case nil:
+		return nil
 	case *Frame:
 		v = ve.Data
 	case *[]byte:


### PR DESCRIPTION
I added `nil` checks to the codecs that did not have them, and added a test to check that all codecs accept a `nil` body.

Note that I am using v2.9.1 this PR is targets the `release-2.9` branch

closes #1902 
