### PR TITLE
runtime/kubernetes: fix update bug

### DIFF
--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -533,7 +533,7 @@ func (k *kubernetes) Update(s *runtime.Service, opts ...runtime.UpdateOption) er
 	}
 
 	// get the existing service
-	services, err := k.getService(labels)
+	services, err := k.getService(labels, client.GetNamespace(options.Namespace))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Kubernetes update wasn't querying services in the correct namespace, hence it found none to update