### PR TITLE
fix etcd keys for services

### DIFF
--- a/registry/etcd/etcd_test.go
+++ b/registry/etcd/etcd_test.go
@@ -10,44 +10,59 @@ func TestEtcdHasName(t *testing.T) {
 		key    string
 		prefix string
 		name   string
+		domain string
 		expect bool
 	}{
 		{
 			"/micro/registry/micro/registry",
 			"/micro/registry",
 			"registry",
+			"micro",
 			true,
 		},
 		{
-			"/micro/registry/micro/store",
+			"/micro/registry/micro",
 			"/micro/registry",
-			"registry",
+			"store",
+			"micro",
 			false,
 		},
 		{
 			"/prefix/baz/*/registry",
 			"/prefix/baz",
 			"registry",
+			"*",
 			true,
 		},
 		{
-			"/prefix/baz/micro/registry",
+			"/prefix/baz",
 			"/prefix/baz",
 			"store",
+			"micro",
 			false,
 		},
 		{
-			"/prefix/baz/micro/registry",
+			"/prefix/baz/foobar/registry",
 			"/prefix/baz",
 			"registry",
+			"foobar",
 			true,
 		},
 	}
 
 	for _, c := range testCases {
-		v := hasName(c.key, c.prefix, c.name)
-		if v != c.expect {
-			t.Fatalf("Expected %t for %v got: %t", c.expect, c, v)
+		domain, service, ok := getName(c.key, c.prefix)
+		if ok != c.expect {
+			t.Fatalf("Expected %t for %v got: %t", c.expect, c, ok)
+		}
+		if !ok {
+			continue
+		}
+		if service != c.name {
+			t.Fatalf("Expected service %s got %s", c.name, service)
+		}
+		if domain != c.domain {
+			t.Fatalf("Expected domain %s got %s", c.domain, domain)
 		}
 	}
 }

--- a/registry/mdns/mdns.go
+++ b/registry/mdns/mdns.go
@@ -202,7 +202,8 @@ func createServiceMDNSEntry(name, domain string) (*mdnsEntry, error) {
 	return &mdnsEntry{id: "*", node: srv}, nil
 }
 
-func (m *mdnsRegistry) getMdnsEntries(domain, serviceName string) ([]*mdnsEntry, error) {
+func (m *mdnsRegistry) createMDNSEntries(domain, serviceName string) ([]*mdnsEntry, error) {
+	// if it already exists don't reegister it again
 	entries, ok := m.domains[domain][serviceName]
 	if ok {
 		return entries, nil
@@ -320,7 +321,7 @@ func (m *mdnsRegistry) Register(service *registry.Service, opts ...registry.Regi
 		m.domains[options.Domain] = make(services)
 	}
 
-	entries, err := m.getMdnsEntries(options.Domain, service.Name)
+	entries, err := m.createMDNSEntries(options.Domain, service.Name)
 	if err != nil {
 		m.Unlock()
 		return err


### PR DESCRIPTION
Because we register services in a domain, when we return them the key used to split the nodes must be name + version + domain