### PR TITLE
Registry router fixes

### DIFF
--- a/client/lookup.go
+++ b/client/lookup.go
@@ -19,12 +19,12 @@ func LookupRoute(ctx context.Context, req Request, opts CallOptions) ([]string, 
 	}
 
 	// construct the router query
-	query := []router.QueryOption{}
+	query := []router.LookupOption{}
 
 	// if a custom network was requested, pass this to the router. By default the router will use it's
 	// own network, which is set during initialisation.
 	if len(opts.Network) > 0 {
-		query = append(query, router.QueryNetwork(opts.Network))
+		query = append(query, router.LookupNetwork(opts.Network))
 	}
 
 	// lookup the routes which can be used to execute the request

--- a/client/lookup.go
+++ b/client/lookup.go
@@ -19,7 +19,7 @@ func LookupRoute(ctx context.Context, req Request, opts CallOptions) ([]string, 
 	}
 
 	// construct the router query
-	query := []router.QueryOption{router.QueryService(req.Service())}
+	query := []router.QueryOption{}
 
 	// if a custom network was requested, pass this to the router. By default the router will use it's
 	// own network, which is set during initialisation.
@@ -28,7 +28,7 @@ func LookupRoute(ctx context.Context, req Request, opts CallOptions) ([]string, 
 	}
 
 	// lookup the routes which can be used to execute the request
-	routes, err := opts.Router.Lookup(query...)
+	routes, err := opts.Router.Lookup(req.Service(), query...)
 	if err == router.ErrRouteNotFound {
 		return nil, errors.InternalServerError("go.micro.client", "service %s: %s", req.Service(), err.Error())
 	} else if err != nil {

--- a/client/options.go
+++ b/client/options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/micro/go-micro/v3/router"
 	regRouter "github.com/micro/go-micro/v3/router/registry"
 	"github.com/micro/go-micro/v3/selector"
-	"github.com/micro/go-micro/v3/selector/random"
+	"github.com/micro/go-micro/v3/selector/roundrobin"
 	"github.com/micro/go-micro/v3/transport"
 	thttp "github.com/micro/go-micro/v3/transport/http"
 )
@@ -125,7 +125,7 @@ func NewOptions(options ...Option) Options {
 		PoolTTL:   DefaultPoolTTL,
 		Broker:    http.NewBroker(),
 		Router:    regRouter.NewRouter(),
-		Selector:  random.NewSelector(),
+		Selector:  roundrobin.NewSelector(),
 		Transport: thttp.NewTransport(),
 	}
 

--- a/network/mucp/mucp.go
+++ b/network/mucp/mucp.go
@@ -961,8 +961,8 @@ func (n *mucpNetwork) processNetChan(listener tunnel.Listener) {
 						route.Metric = d
 					}
 
-					q := []router.QueryOption{
-						router.QueryLink(route.Link),
+					q := []router.LookupOption{
+						router.LookupLink(route.Link),
 					}
 
 					routes, err := n.router.Lookup(route.Service, q...)
@@ -1078,14 +1078,14 @@ func (n *mucpNetwork) processNetChan(listener tunnel.Listener) {
 }
 
 // pruneRoutes prunes routes return by given query
-func (n *mucpNetwork) pruneRoutes(q ...router.QueryOption) error {
+func (n *mucpNetwork) pruneRoutes(q ...router.LookupOption) error {
 	routes, err := n.router.Table().List()
 	if err != nil && err != router.ErrRouteNotFound {
 		return err
 	}
 
 	// filter and delete the routes in question
-	for _, route := range router.Filter(routes, router.NewQuery(q...)) {
+	for _, route := range router.Filter(routes, router.NewLookup(q...)) {
 		n.router.Table().Delete(route)
 	}
 
@@ -1095,18 +1095,18 @@ func (n *mucpNetwork) pruneRoutes(q ...router.QueryOption) error {
 // pruneNodeRoutes prunes routes that were either originated by or routable via given node
 func (n *mucpNetwork) prunePeerRoutes(peer *node) error {
 	// lookup all routes originated by router
-	q := []router.QueryOption{
-		router.QueryRouter(peer.id),
-		router.QueryLink("*"),
+	q := []router.LookupOption{
+		router.LookupRouter(peer.id),
+		router.LookupLink("*"),
 	}
 	if err := n.pruneRoutes(q...); err != nil {
 		return err
 	}
 
 	// lookup all routes routable via gw
-	q = []router.QueryOption{
-		router.QueryGateway(peer.address),
-		router.QueryLink("*"),
+	q = []router.LookupOption{
+		router.LookupGateway(peer.address),
+		router.LookupLink("*"),
 	}
 	if err := n.pruneRoutes(q...); err != nil {
 		return err
@@ -1289,7 +1289,7 @@ func (n *mucpNetwork) manage() {
 				}
 
 				// otherwise delete all the routes originated by it
-				if err := n.pruneRoutes(router.QueryRouter(route.Router)); err != nil {
+				if err := n.pruneRoutes(router.LookupRouter(route.Router)); err != nil {
 					if logger.V(logger.DebugLevel, logger.DefaultLogger) {
 						logger.Debugf("Network failed deleting routes by %s: %v", route.Router, err)
 					}

--- a/proxy/grpc/grpc.go
+++ b/proxy/grpc/grpc.go
@@ -94,10 +94,7 @@ func (p *Proxy) ServeRequest(ctx context.Context, req server.Request, rsp server
 		logger.Tracef("Proxy received request for %s %s", service, endpoint)
 	}
 
-	// no retries with the proxy
-	opts := []client.CallOption{
-		client.WithRetries(0),
-	}
+	var opts []client.CallOption
 
 	// call a specific backend
 	if len(p.Endpoint) > 0 {

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -208,7 +208,7 @@ func (p *Proxy) getRoute(ctx context.Context, service string) ([]router.Route, e
 
 func (p *Proxy) cacheRoutes(service string) ([]router.Route, error) {
 	// lookup the routes in the router
-	results, err := p.Router.Lookup(router.QueryService(service), router.QueryNetwork("*"))
+	results, err := p.Router.Lookup(service, router.QueryNetwork("*"))
 	if err != nil {
 		// assumption that we're ok with stale routes
 		logger.Debugf("Failed to lookup route for %s: %v", service, err)

--- a/proxy/mucp/mucp.go
+++ b/proxy/mucp/mucp.go
@@ -208,7 +208,7 @@ func (p *Proxy) getRoute(ctx context.Context, service string) ([]router.Route, e
 
 func (p *Proxy) cacheRoutes(service string) ([]router.Route, error) {
 	// lookup the routes in the router
-	results, err := p.Router.Lookup(service, router.QueryNetwork("*"))
+	results, err := p.Router.Lookup(service, router.LookupNetwork("*"))
 	if err != nil {
 		// assumption that we're ok with stale routes
 		logger.Debugf("Failed to lookup route for %s: %v", service, err)

--- a/resolver/registry/registry.go
+++ b/resolver/registry/registry.go
@@ -2,9 +2,9 @@
 package registry
 
 import (
-	"github.com/micro/go-micro/v3/resolver"
 	"github.com/micro/go-micro/v3/registry"
 	"github.com/micro/go-micro/v3/registry/mdns"
+	"github.com/micro/go-micro/v3/resolver"
 )
 
 // Resolver is a registry network resolver

--- a/router/dns/dns.go
+++ b/router/dns/dns.go
@@ -43,9 +43,7 @@ func (d *dns) Close() error {
 	return nil
 }
 
-func (d *dns) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
-	options := router.NewQuery(opts...)
-
+func (d *dns) Lookup(service string, opts ...router.LookupOption) ([]router.Route, error) {
 	// check to see if we have the port provided in the service, e.g. go-micro-srv-foo:8000
 	host, port, err := net.SplitHostPort(service)
 	if err == nil {
@@ -61,7 +59,7 @@ func (d *dns) Lookup(service string, opts ...router.QueryOption) ([]router.Route
 		result := make([]router.Route, len(ips))
 		for i, ip := range ips {
 			result[i] = router.Route{
-				Service: options.Service,
+				Service: service,
 				Address: fmt.Sprintf("%s:%d", ip, uint16(p)),
 			}
 		}
@@ -79,7 +77,7 @@ func (d *dns) Lookup(service string, opts ...router.QueryOption) ([]router.Route
 	result := make([]router.Route, len(nodes))
 	for i, n := range nodes {
 		result[i] = router.Route{
-			Service: options.Service,
+			Service: service,
 			Address: fmt.Sprintf("%s:%d", n.Target, n.Port),
 			Network: d.options.Network,
 		}

--- a/router/dns/dns.go
+++ b/router/dns/dns.go
@@ -17,19 +17,17 @@ func NewRouter(opts ...router.Option) router.Router {
 	if len(options.Network) == 0 {
 		options.Network = "micro"
 	}
-	return &dns{options, &table{options}}
+	return &dns{options}
 }
 
 type dns struct {
 	options router.Options
-	table   *table
 }
 
 func (d *dns) Init(opts ...router.Option) error {
 	for _, o := range opts {
 		o(&d.options)
 	}
-	d.table.options = d.options
 	return nil
 }
 
@@ -38,50 +36,18 @@ func (d *dns) Options() router.Options {
 }
 
 func (d *dns) Table() router.Table {
-	return d.table
-}
-
-func (d *dns) Lookup(opts ...router.QueryOption) ([]router.Route, error) {
-	return d.table.Query(opts...)
-}
-
-func (d *dns) Watch(opts ...router.WatchOption) (router.Watcher, error) {
-	return nil, nil
+	return nil
 }
 
 func (d *dns) Close() error {
 	return nil
 }
 
-func (d *dns) String() string {
-	return "dns"
-}
-
-type table struct {
-	options router.Options
-}
-
-func (t *table) Create(router.Route) error {
-	return nil
-}
-
-func (t *table) Delete(router.Route) error {
-	return nil
-}
-
-func (t *table) Update(router.Route) error {
-	return nil
-}
-
-func (t *table) List() ([]router.Route, error) {
-	return nil, nil
-}
-
-func (t *table) Query(opts ...router.QueryOption) ([]router.Route, error) {
+func (d *dns) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
 	options := router.NewQuery(opts...)
 
 	// check to see if we have the port provided in the service, e.g. go-micro-srv-foo:8000
-	host, port, err := net.SplitHostPort(options.Service)
+	host, port, err := net.SplitHostPort(service)
 	if err == nil {
 		// lookup the service using A records
 		ips, err := net.LookupHost(host)
@@ -104,7 +70,7 @@ func (t *table) Query(opts ...router.QueryOption) ([]router.Route, error) {
 
 	// we didn't get the port so we'll lookup the service using SRV records. If we can't lookup the
 	// service using the SRV record, we return the error.
-	_, nodes, err := net.LookupSRV(options.Service, "tcp", t.options.Network)
+	_, nodes, err := net.LookupSRV(service, "tcp", d.options.Network)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +81,16 @@ func (t *table) Query(opts ...router.QueryOption) ([]router.Route, error) {
 		result[i] = router.Route{
 			Service: options.Service,
 			Address: fmt.Sprintf("%s:%d", n.Target, n.Port),
-			Network: t.options.Network,
+			Network: d.options.Network,
 		}
 	}
 	return result, nil
+}
+
+func (d *dns) Watch(opts ...router.WatchOption) (router.Watcher, error) {
+	return nil, nil
+}
+
+func (d *dns) String() string {
+	return "dns"
 }

--- a/router/mdns/mdns.go
+++ b/router/mdns/mdns.go
@@ -42,19 +42,19 @@ func (m *mdnsRouter) Table() router.Table {
 	return nil
 }
 
-func (m *mdnsRouter) Lookup(opts ...router.QueryOption) ([]router.Route, error) {
+func (m *mdnsRouter) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
 	options := router.NewQuery(opts...)
 
 	// check to see if we have the port provided in the service, e.g. go-micro-srv-foo:8000
-	service, port, err := net.SplitHostPort(options.Service)
+	srv, port, err := net.SplitHostPort(service)
 	if err != nil {
-		service = options.Service
+		srv = service
 	}
 
 	// query for the host
 	entries := make(chan *mdns.ServiceEntry)
 
-	p := mdns.DefaultParams(service)
+	p := mdns.DefaultParams(srv)
 	p.Timeout = time.Millisecond * 100
 	p.Entries = entries
 

--- a/router/mdns/mdns.go
+++ b/router/mdns/mdns.go
@@ -42,8 +42,8 @@ func (m *mdnsRouter) Table() router.Table {
 	return nil
 }
 
-func (m *mdnsRouter) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
-	options := router.NewQuery(opts...)
+func (m *mdnsRouter) Lookup(service string, opts ...router.LookupOption) ([]router.Route, error) {
+	options := router.NewLookup(opts...)
 
 	// check to see if we have the port provided in the service, e.g. go-micro-srv-foo:8000
 	srv, port, err := net.SplitHostPort(service)

--- a/router/options.go
+++ b/router/options.go
@@ -22,8 +22,8 @@ type Options struct {
 	Registry registry.Registry
 	// Context for additional options
 	Context context.Context
-	// Precache routes
-	Precache bool
+	// Cache routes
+	Cache bool
 }
 
 // Id sets Router Id
@@ -61,10 +61,10 @@ func Registry(r registry.Registry) Option {
 	}
 }
 
-// Precache the routes
-func Precache() Option {
+// Cache the routes
+func Cache() Option {
 	return func(o *Options) {
-		o.Precache = true
+		o.Cache = true
 	}
 }
 

--- a/router/query.go
+++ b/router/query.go
@@ -1,13 +1,11 @@
 package router
 
-// QueryOption sets routing table query options
-type QueryOption func(*QueryOptions)
+// LookupOption sets routing table query options
+type LookupOption func(*LookupOptions)
 
-// QueryOptions are routing table query options
+// LookupOptions are routing table query options
 // TODO replace with Filter(Route) bool
-type QueryOptions struct {
-	// Service is destination service name
-	Service string
+type LookupOptions struct {
 	// Address of the service
 	Address string
 	// Gateway is route gateway
@@ -20,53 +18,45 @@ type QueryOptions struct {
 	Link string
 }
 
-// QueryService sets service to query
-func QueryService(s string) QueryOption {
-	return func(o *QueryOptions) {
-		o.Service = s
-	}
-}
-
-// QueryAddress sets service to query
-func QueryAddress(a string) QueryOption {
-	return func(o *QueryOptions) {
+// LookupAddress sets service to query
+func LookupAddress(a string) LookupOption {
+	return func(o *LookupOptions) {
 		o.Address = a
 	}
 }
 
-// QueryGateway sets gateway address to query
-func QueryGateway(g string) QueryOption {
-	return func(o *QueryOptions) {
+// LookupGateway sets gateway address to query
+func LookupGateway(g string) LookupOption {
+	return func(o *LookupOptions) {
 		o.Gateway = g
 	}
 }
 
-// QueryNetwork sets network name to query
-func QueryNetwork(n string) QueryOption {
-	return func(o *QueryOptions) {
+// LookupNetwork sets network name to query
+func LookupNetwork(n string) LookupOption {
+	return func(o *LookupOptions) {
 		o.Network = n
 	}
 }
 
-// QueryRouter sets router id to query
-func QueryRouter(r string) QueryOption {
-	return func(o *QueryOptions) {
+// LookupRouter sets router id to query
+func LookupRouter(r string) LookupOption {
+	return func(o *LookupOptions) {
 		o.Router = r
 	}
 }
 
-// QueryLink sets the link to query
-func QueryLink(link string) QueryOption {
-	return func(o *QueryOptions) {
+// LookupLink sets the link to query
+func LookupLink(link string) LookupOption {
+	return func(o *LookupOptions) {
 		o.Link = link
 	}
 }
 
-// NewQuery creates new query and returns it
-func NewQuery(opts ...QueryOption) QueryOptions {
+// NewLookup creates new query and returns it
+func NewLookup(opts ...LookupOption) LookupOptions {
 	// default options
-	qopts := QueryOptions{
-		Service: "*",
+	qopts := LookupOptions{
 		Address: "*",
 		Gateway: "*",
 		Network: "*",
@@ -117,7 +107,7 @@ func isMatch(route Route, address, gateway, network, rtr, link string) bool {
 }
 
 // filterRoutes finds all the routes for given network and router and returns them
-func Filter(routes []Route, opts QueryOptions) []Route {
+func Filter(routes []Route, opts LookupOptions) []Route {
 	address := opts.Address
 	gateway := opts.Gateway
 	network := opts.Network

--- a/router/query.go
+++ b/router/query.go
@@ -80,3 +80,66 @@ func NewQuery(opts ...QueryOption) QueryOptions {
 
 	return qopts
 }
+
+// isMatch checks if the route matches given query options
+func isMatch(route Route, address, gateway, network, rtr, link string) bool {
+	// matches the values provided
+	match := func(a, b string) bool {
+		if a == "*" || b == "*" || a == b {
+			return true
+		}
+		return false
+	}
+
+	// a simple struct to hold our values
+	type compare struct {
+		a string
+		b string
+	}
+
+	// compare the following values
+	values := []compare{
+		{gateway, route.Gateway},
+		{network, route.Network},
+		{rtr, route.Router},
+		{address, route.Address},
+		{link, route.Link},
+	}
+
+	for _, v := range values {
+		// attempt to match each value
+		if !match(v.a, v.b) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// filterRoutes finds all the routes for given network and router and returns them
+func Filter(routes []Route, opts QueryOptions) []Route {
+	address := opts.Address
+	gateway := opts.Gateway
+	network := opts.Network
+	rtr := opts.Router
+	link := opts.Link
+
+	// routeMap stores the routes we're going to advertise
+	routeMap := make(map[string][]Route)
+
+	for _, route := range routes {
+		if isMatch(route, address, gateway, network, rtr, link) {
+			// add matchihg route to the routeMap
+			routeKey := route.Service + "@" + route.Network
+			routeMap[routeKey] = append(routeMap[routeKey], route)
+		}
+	}
+
+	var results []Route
+
+	for _, route := range routeMap {
+		results = append(results, route...)
+	}
+
+	return results
+}

--- a/router/registry/registry.go
+++ b/router/registry/registry.go
@@ -262,8 +262,8 @@ func (r *rtr) Close() error {
 }
 
 // lookup retrieves all the routes for a given service and creates them in the routing table
-func (r *rtr) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
-	q := router.NewQuery(opts...)
+func (r *rtr) Lookup(service string, opts ...router.LookupOption) ([]router.Route, error) {
+	q := router.NewLookup(opts...)
 
 	// if we find the routes filter and return them
 	routes, err := r.table.Query(service)

--- a/router/registry/registry.go
+++ b/router/registry/registry.go
@@ -47,7 +47,7 @@ func NewRouter(opts ...router.Option) router.Router {
 
 	// create the new table, passing the fetchRoute method in as a fallback if
 	// the table doesn't contain the result for a query.
-	r.table = newTable(r.lookup)
+	r.table = newTable()
 
 	// start the router
 	r.start()
@@ -241,8 +241,41 @@ func (r *rtr) loadRoutes(reg registry.Registry) error {
 	return nil
 }
 
+// Close the router
+func (r *rtr) Close() error {
+	r.Lock()
+	defer r.Unlock()
+
+	select {
+	case <-r.exit:
+		return nil
+	default:
+		if !r.running {
+			return nil
+		}
+		close(r.exit)
+
+	}
+
+	r.running = false
+	return nil
+}
+
 // lookup retrieves all the routes for a given service and creates them in the routing table
-func (r *rtr) lookup(service string) ([]router.Route, error) {
+func (r *rtr) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
+	q := router.NewQuery(opts...)
+
+	// if we find the routes filter and return them
+	routes, err := r.table.Query(service)
+	if err == nil {
+		routes = router.Filter(routes, q)
+		if len(routes) == 0 {
+			return nil, router.ErrRouteNotFound
+		}
+		return routes, nil
+	}
+
+	// lookup the route
 	logger.Tracef("Fetching route for %s domain: %v", service, registry.WildcardDomain)
 
 	services, err := r.options.Registry.GetService(service, registry.GetDomain(registry.WildcardDomain))
@@ -254,8 +287,6 @@ func (r *rtr) lookup(service string) ([]router.Route, error) {
 		return nil, fmt.Errorf("failed getting services: %v", err)
 	}
 
-	var routes []router.Route
-
 	for _, srv := range services {
 		domain := getDomain(srv)
 		// TODO: should we continue to send the event indicating we created a route?
@@ -263,6 +294,17 @@ func (r *rtr) lookup(service string) ([]router.Route, error) {
 		routes = append(routes, r.createRoutes(srv, domain)...)
 	}
 
+	// if we're supposed to cache then save the routes
+	if r.options.Cache {
+		for _, route := range routes {
+			r.table.Create(route)
+		}
+	}
+
+	routes = router.Filter(routes, q)
+	if len(routes) == 0 {
+		return nil, router.ErrRouteNotFound
+	}
 	return routes, nil
 }
 
@@ -434,34 +476,9 @@ func (r *rtr) start() error {
 	return nil
 }
 
-// Lookup routes in the routing table
-func (r *rtr) Lookup(q ...router.QueryOption) ([]router.Route, error) {
-	return r.Table().Query(q...)
-}
-
 // Watch routes
 func (r *rtr) Watch(opts ...router.WatchOption) (router.Watcher, error) {
 	return r.table.Watch(opts...)
-}
-
-// Close the router
-func (r *rtr) Close() error {
-	r.Lock()
-	defer r.Unlock()
-
-	select {
-	case <-r.exit:
-		return nil
-	default:
-		if !r.running {
-			return nil
-		}
-		close(r.exit)
-
-	}
-
-	r.running = false
-	return nil
 }
 
 // String prints debugging information about router

--- a/router/router.go
+++ b/router/router.go
@@ -23,7 +23,7 @@ type Router interface {
 	// The routing table
 	Table() Table
 	// Lookup queries routes in the routing table
-	Lookup(service string, opts ...QueryOption) ([]Route, error)
+	Lookup(service string, opts ...LookupOption) ([]Route, error)
 	// Watch returns a watcher which tracks updates to the routing table
 	Watch(opts ...WatchOption) (Watcher, error)
 	// Close the router

--- a/router/router.go
+++ b/router/router.go
@@ -23,7 +23,7 @@ type Router interface {
 	// The routing table
 	Table() Table
 	// Lookup queries routes in the routing table
-	Lookup(...QueryOption) ([]Route, error)
+	Lookup(service string, opts ...QueryOption) ([]Route, error)
 	// Watch returns a watcher which tracks updates to the routing table
 	Watch(opts ...WatchOption) (Watcher, error)
 	// Close the router
@@ -43,7 +43,7 @@ type Table interface {
 	// List all routes in the table
 	List() ([]Route, error)
 	// Query routes in the routing table
-	Query(...QueryOption) ([]Route, error)
+	Query(service string) ([]Route, error)
 }
 
 // Option used by the router

--- a/router/static/static.go
+++ b/router/static/static.go
@@ -10,12 +10,11 @@ func NewRouter(opts ...router.Option) router.Router {
 	for _, o := range opts {
 		o(&options)
 	}
-	return &static{options, new(table)}
+	return &static{options}
 }
 
 type static struct {
 	options router.Options
-	table   router.Table
 }
 
 func (s *static) Init(opts ...router.Option) error {
@@ -33,8 +32,18 @@ func (s *static) Table() router.Table {
 	return nil
 }
 
-func (s *static) Lookup(opts ...router.QueryOption) ([]router.Route, error) {
-	return s.table.Query(opts...)
+func (s *static) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
+	options := router.NewQuery(opts...)
+
+	return []router.Route{
+		router.Route{
+			Address: service,
+			Service: options.Address,
+			Gateway: options.Gateway,
+			Network: options.Network,
+			Router:  options.Router,
+		},
+	}, nil
 }
 
 func (s *static) Watch(opts ...router.WatchOption) (router.Watcher, error) {
@@ -47,36 +56,4 @@ func (s *static) Close() error {
 
 func (s *static) String() string {
 	return "static"
-}
-
-type table struct{}
-
-func (t *table) Create(router.Route) error {
-	return nil
-}
-
-func (t *table) Delete(router.Route) error {
-	return nil
-}
-
-func (t *table) Update(router.Route) error {
-	return nil
-}
-
-func (t *table) List() ([]router.Route, error) {
-	return nil, nil
-}
-
-func (t *table) Query(opts ...router.QueryOption) ([]router.Route, error) {
-	options := router.NewQuery(opts...)
-
-	return []router.Route{
-		router.Route{
-			Address: options.Service,
-			Service: options.Address,
-			Gateway: options.Gateway,
-			Network: options.Network,
-			Router:  options.Router,
-		},
-	}, nil
 }

--- a/router/static/static.go
+++ b/router/static/static.go
@@ -32,8 +32,8 @@ func (s *static) Table() router.Table {
 	return nil
 }
 
-func (s *static) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
-	options := router.NewQuery(opts...)
+func (s *static) Lookup(service string, opts ...router.LookupOption) ([]router.Route, error) {
+	options := router.NewLookup(opts...)
 
 	return []router.Route{
 		router.Route{

--- a/server/mucp/subscriber.go
+++ b/server/mucp/subscriber.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/micro/go-micro/v3/broker"
 	"github.com/micro/go-micro/v3/registry"
 	"github.com/micro/go-micro/v3/server"
-	"github.com/micro/go-micro/v3/broker"
 	"github.com/micro/go-micro/v3/transport"
 )
 
@@ -31,10 +31,10 @@ type subscriber struct {
 }
 
 func newMessage(msg transport.Message) *broker.Message {
-        return &broker.Message{
-                Header: msg.Header,
-                Body:   msg.Body,
-        }
+	return &broker.Message{
+		Header: msg.Header,
+		Body:   msg.Body,
+	}
 }
 
 func newSubscriber(topic string, sub interface{}, opts ...server.SubscriberOption) server.Subscriber {

--- a/util/http/roundtripper.go
+++ b/util/http/roundtripper.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/micro/go-micro/v3/router"
 	"github.com/micro/go-micro/v3/selector"
 )
 

--- a/util/http/roundtripper.go
+++ b/util/http/roundtripper.go
@@ -15,7 +15,7 @@ type roundTripper struct {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	routes, err := r.opts.Router.Lookup(router.QueryService(req.URL.Host))
+	routes, err := r.opts.Router.Lookup(req.URL.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/util/router/router.go
+++ b/util/router/router.go
@@ -10,7 +10,7 @@ type apiRouter struct {
 	router.Router
 }
 
-func (r *apiRouter) Lookup(...router.QueryOption) ([]router.Route, error) {
+func (r *apiRouter) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
 	return r.routes, nil
 }
 

--- a/util/router/router.go
+++ b/util/router/router.go
@@ -10,7 +10,7 @@ type apiRouter struct {
 	router.Router
 }
 
-func (r *apiRouter) Lookup(service string, opts ...router.QueryOption) ([]router.Route, error) {
+func (r *apiRouter) Lookup(service string, opts ...router.LookupOption) ([]router.Route, error) {
 	return r.routes, nil
 }
 


### PR DESCRIPTION
- Only cache routes when cache is specified
- Require service arg to Lookup
- Move filtering to a public func
- Strip out more tables from other implementations
- Enable retries in proxy
- Use roundrobin for retries