### PR TITLE
Tidying up the new Metrics implementations

### DIFF
--- a/metrics/logging/reporter.go
+++ b/metrics/logging/reporter.go
@@ -27,19 +27,19 @@ func New(opts ...metrics.Option) *Reporter {
 
 // Count implements the metrics.Reporter interface Count method:
 func (r *Reporter) Count(metricName string, value int64, tags metrics.Tags) error {
-	logger.Logf(defaultLoggingLevel, "Count metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Count metric: (%s: %d) %s", metricName, value, tags)
 	return nil
 }
 
 // Gauge implements the metrics.Reporter interface Gauge method:
 func (r *Reporter) Gauge(metricName string, value float64, tags metrics.Tags) error {
-	logger.Logf(defaultLoggingLevel, "Gauge metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Gauge metric: (%s: %f) %s", metricName, value, tags)
 	return nil
 }
 
 // Timing implements the metrics.Reporter interface Timing method:
 func (r *Reporter) Timing(metricName string, value time.Duration, tags metrics.Tags) error {
-	logger.Logf(defaultLoggingLevel, "Timing metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Timing metric: (%s: %s) %s", metricName, value.String(), tags)
 	return nil
 }
 

--- a/metrics/logging/reporter.go
+++ b/metrics/logging/reporter.go
@@ -3,43 +3,43 @@ package logging
 import (
 	"time"
 
-	log "github.com/micro/go-micro/v3/logger"
+	"github.com/micro/go-micro/v3/logger"
 	"github.com/micro/go-micro/v3/metrics"
+)
+
+const (
+	defaultLoggingLevel = logger.TraceLevel
 )
 
 // Reporter is an implementation of metrics.Reporter:
 type Reporter struct {
-	logger  log.Logger
 	options metrics.Options
 }
 
-// New returns a configured noop reporter:
+// New returns a configured logging reporter:
 func New(opts ...metrics.Option) *Reporter {
-	options := metrics.NewOptions(opts...)
-	logger := log.NewLogger(log.WithFields(convertTags(options.DefaultTags)))
-	logger.Log(log.InfoLevel, "Metrics/Logging - metrics will be logged (at TRACE level)")
+	logger.Logf(logger.InfoLevel, "Metrics/Logging - metrics will be logged (at %s level)", defaultLoggingLevel.String())
 
 	return &Reporter{
-		logger:  logger,
 		options: metrics.NewOptions(opts...),
 	}
 }
 
 // Count implements the metrics.Reporter interface Count method:
 func (r *Reporter) Count(metricName string, value int64, tags metrics.Tags) error {
-	r.logger.Logf(log.TraceLevel, "Count metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Count metric: %s", tags)
 	return nil
 }
 
 // Gauge implements the metrics.Reporter interface Gauge method:
 func (r *Reporter) Gauge(metricName string, value float64, tags metrics.Tags) error {
-	r.logger.Logf(log.TraceLevel, "Gauge metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Gauge metric: %s", tags)
 	return nil
 }
 
 // Timing implements the metrics.Reporter interface Timing method:
 func (r *Reporter) Timing(metricName string, value time.Duration, tags metrics.Tags) error {
-	r.logger.Logf(log.TraceLevel, "Timing metric: %s", tags)
+	logger.Logf(defaultLoggingLevel, "Timing metric: %s", tags)
 	return nil
 }
 

--- a/metrics/logging/reporter_test.go
+++ b/metrics/logging/reporter_test.go
@@ -1,11 +1,9 @@
 package logging
 
 import (
-	"bytes"
 	"testing"
 	"time"
 
-	log "github.com/micro/go-micro/v3/logger"
 	"github.com/micro/go-micro/v3/metrics"
 
 	"github.com/stretchr/testify/assert"
@@ -19,10 +17,6 @@ func TestLoggingReporter(t *testing.T) {
 	assert.Equal(t, "prometheus-test", reporter.options.DefaultTags["service"])
 	assert.Equal(t, ":9000", reporter.options.Address)
 	assert.Equal(t, "/prometheus", reporter.options.Path)
-
-	// Make a log buffer and create a new logger to use it:
-	logBuffer := new(bytes.Buffer)
-	reporter.logger = log.NewLogger(log.WithLevel(log.TraceLevel), log.WithOutput(logBuffer), log.WithFields(convertTags(reporter.options.DefaultTags)))
 
 	// Check that our implementation is valid:
 	assert.Implements(t, new(metrics.Reporter), reporter)
@@ -45,7 +39,4 @@ func TestLoggingReporter(t *testing.T) {
 	assert.NoError(t, reporter.Gauge("test.gauge.1", 98, tags))
 	assert.NoError(t, reporter.Timing("test.timing.1", time.Second, tags))
 	assert.NoError(t, reporter.Timing("test.timing.2", time.Minute, tags))
-
-	// Test reading back the metrics from the logbuffer (doesn't seem to work because the output still goes to StdOut):
-	// assert.Contains(t, logBuffer.String(), "level=debug service=prometheus-test Count metric: map[tag1:false tag2:true]")
 }


### PR DESCRIPTION
* Adding some tests to the Prometheus reporter so we can prove that metrics are submitted with the appropriate tags, and are aggregated properly
* Removing the logger output routing from the logging reporter (as the Micro logger doesn't seem to actually use this)