### PR TITLE
Fixing the metric tagging issue here

### DIFF
--- a/metrics/wrapper/metrics_wrapper.go
+++ b/metrics/wrapper/metrics_wrapper.go
@@ -40,7 +40,7 @@ func (w *Wrapper) HandlerFunc(handlerFunction server.HandlerFunc) server.Handler
 		if err != nil {
 			tags["result"] = "failure"
 		} else {
-			tags["result"] = "failure"
+			tags["result"] = "success"
 		}
 
 		// Instrument the result (if the DefaultClient has been configured):


### PR DESCRIPTION
I've used this wrapper in the new build service, and noticed that the same copy/paste issue exists here too (no surprise).