### PR TITLE
util/kubernetes: fix TCPSocketAction bug

### DIFF
--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -540,6 +540,11 @@ func (k *kubernetes) Update(s *runtime.Service, opts ...runtime.UpdateOption) er
 
 	// update the relevant services
 	for _, service := range services {
+		if service.kdeploy == nil {
+			fmt.Printf("Service %v has no kdeploy", service.Name)
+			service.kdeploy = client.NewDeployment(service.Name, service.Version, "service", options.Namespace)
+		}
+
 		// nil check
 		if service.kdeploy.Metadata == nil || service.kdeploy.Metadata.Annotations == nil {
 			md := new(client.Metadata)

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -540,11 +540,6 @@ func (k *kubernetes) Update(s *runtime.Service, opts ...runtime.UpdateOption) er
 
 	// update the relevant services
 	for _, service := range services {
-		if service.kdeploy == nil {
-			fmt.Printf("Service %v has no kdeploy", service.Name)
-			service.kdeploy = client.NewDeployment(service.Name, service.Version, "service", options.Namespace)
-		}
-
 		// nil check
 		if service.kdeploy.Metadata == nil || service.kdeploy.Metadata.Annotations == nil {
 			md := new(client.Metadata)

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -322,8 +322,8 @@ func NewDeployment(name, version, typ, namespace string) *Deployment {
 						ContainerPort: 8080,
 					}},
 					ReadinessProbe: &Probe{
-						TCPSocket: TCPSocketAction{
-							Port: "8080",
+						TCPSocket: &TCPSocketAction{
+							Port: 8080,
 						},
 						PeriodSeconds:       10,
 						InitialDelaySeconds: 10,

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -323,7 +323,7 @@ func NewDeployment(name, version, typ, namespace string) *Deployment {
 					}},
 					ReadinessProbe: &Probe{
 						TCPSocket: TCPSocketAction{
-							Port: 8080,
+							Port: "8080",
 						},
 						PeriodSeconds:       10,
 						InitialDelaySeconds: 10,

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -323,7 +323,7 @@ func NewDeployment(name, version, typ, namespace string) *Deployment {
 					}},
 					ReadinessProbe: &Probe{
 						TCPSocket: TCPSocketAction{
-							Port: "8080",
+							Port: 8080,
 						},
 						PeriodSeconds:       10,
 						InitialDelaySeconds: 10,

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -274,10 +274,12 @@ func NewDeployment(name, version, typ, namespace string) *Deployment {
 		logger.Tracef("kubernetes default deployment: name: %s, version: %s", name, version)
 	}
 
-	Labels := map[string]string{
-		"name":    name,
-		"version": version,
-		"micro":   typ,
+	Labels := map[string]string{"name": name}
+	if len(typ) > 0 {
+		Labels["micro"] = typ
+	}
+	if len(version) > 0 {
+		Labels["version"] = version
 	}
 
 	depName := name

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -232,8 +232,8 @@ type Probe struct {
 
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {
-	Host string `json:"host,omitempty"`
-	Port int    `json:"port,omitempty"`
+	Host string      `json:"host,omitempty"`
+	Port interface{} `json:"port,omitempty"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -233,7 +233,7 @@ type Probe struct {
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {
 	Host string `json:"host,omitempty"`
-	Port int    `json:"port,omitempty"`
+	Port string `json:"port,omitempty"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -225,15 +225,15 @@ type ServiceAccount struct {
 
 // Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 type Probe struct {
-	TCPSocket           TCPSocketAction `json:"tcpSocket,omitempty"`
-	PeriodSeconds       int             `json:"periodSeconds"`
-	InitialDelaySeconds int             `json:"initialDelaySeconds"`
+	TCPSocket           *TCPSocketAction `json:"tcpSocket,omitempty"`
+	PeriodSeconds       int              `json:"periodSeconds"`
+	InitialDelaySeconds int              `json:"initialDelaySeconds"`
 }
 
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {
 	Host string `json:"host,omitempty"`
-	Port string `json:"port,omitempty"`
+	Port int    `json:"port,omitempty"`
 }
 
 // ResourceRequirements describes the compute resource requirements.

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -233,7 +233,7 @@ type Probe struct {
 // TCPSocketAction describes an action based on opening a socket
 type TCPSocketAction struct {
 	Host string `json:"host,omitempty"`
-	Port string `json:"port,omitempty"`
+	Port int    `json:"port,omitempty"`
 }
 
 // ResourceRequirements describes the compute resource requirements.


### PR DESCRIPTION
Fixes an issue with k8s API requiring int for port but returning a string. 