### PR TITLE
add Name to auth.Account as a user friendly alias

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -49,7 +49,7 @@ type Auth interface {
 
 // Account provided by an auth provider
 type Account struct {
-	// ID of the account e.g. email
+	// ID of the account e.g. UUID. Should not change
 	ID string `json:"id"`
 	// Type of the account, e.g. service
 	Type string `json:"type"`
@@ -61,6 +61,8 @@ type Account struct {
 	Scopes []string `json:"scopes"`
 	// Secret for the account, e.g. the password
 	Secret string `json:"secret"`
+	// Name of the account. User friendly name that might change e.g. a username or email
+	Name string `json:"name"`
 }
 
 // Token can be short or long lived

--- a/auth/jwt/jwt.go
+++ b/auth/jwt/jwt.go
@@ -54,13 +54,17 @@ func (j *jwtAuth) Generate(id string, opts ...auth.GenerateOption) (*auth.Accoun
 	if len(options.Issuer) == 0 {
 		options.Issuer = j.Options().Issuer
 	}
-
+	name := options.Name
+	if name == "" {
+		name = id
+	}
 	account := &auth.Account{
 		ID:       id,
 		Type:     options.Type,
 		Scopes:   options.Scopes,
 		Metadata: options.Metadata,
 		Issuer:   options.Issuer,
+		Name:     name,
 	}
 
 	// generate a JWT secret which can be provided to the Token() method

--- a/auth/noop/noop.go
+++ b/auth/noop/noop.go
@@ -40,13 +40,17 @@ func (n *noop) Options() auth.Options {
 // Generate a new account
 func (n *noop) Generate(id string, opts ...auth.GenerateOption) (*auth.Account, error) {
 	options := auth.NewGenerateOptions(opts...)
-
+	name := options.Name
+	if name == "" {
+		name = id
+	}
 	return &auth.Account{
 		ID:       id,
 		Secret:   options.Secret,
 		Metadata: options.Metadata,
 		Scopes:   options.Scopes,
 		Issuer:   n.Options().Issuer,
+		Name:     name,
 	}, nil
 }
 

--- a/auth/options.go
+++ b/auth/options.go
@@ -110,6 +110,8 @@ type GenerateOptions struct {
 	Secret string
 	// Issuer of the account, e.g. micro
 	Issuer string
+	// Name of the acouunt e.g. an email or username
+	Name string
 }
 
 type GenerateOption func(o *GenerateOptions)
@@ -153,6 +155,13 @@ func WithScopes(s ...string) GenerateOption {
 func WithIssuer(i string) GenerateOption {
 	return func(o *GenerateOptions) {
 		o.Issuer = i
+	}
+}
+
+// WithName for the generated account
+func WithName(n string) GenerateOption {
+	return func(o *GenerateOptions) {
+		o.Name = m
 	}
 }
 

--- a/auth/options.go
+++ b/auth/options.go
@@ -161,7 +161,7 @@ func WithIssuer(i string) GenerateOption {
 // WithName for the generated account
 func WithName(n string) GenerateOption {
 	return func(o *GenerateOptions) {
-		o.Name = m
+		o.Name = n
 	}
 }
 

--- a/util/token/jwt/jwt_test.go
+++ b/util/token/jwt/jwt_test.go
@@ -44,8 +44,9 @@ func TestInspect(t *testing.T) {
 		md := map[string]string{"foo": "bar"}
 		scopes := []string{"admin"}
 		subject := "test"
+		name := "testname"
 
-		acc := &auth.Account{ID: subject, Scopes: scopes, Metadata: md}
+		acc := &auth.Account{ID: subject, Scopes: scopes, Metadata: md, Name: name}
 		tok, err := j.Generate(acc)
 		if err != nil {
 			t.Fatalf("Generate returned %v error, expected nil", err)
@@ -64,6 +65,9 @@ func TestInspect(t *testing.T) {
 		if len(tok2.Metadata) != len(md) {
 			t.Errorf("Inspect returned %v as the token metadata, expected %v", tok2.Metadata, md)
 		}
+		if tok2.Name != name {
+			t.Errorf("Inspect returned %v as the token name, expected %v", tok2.Name, name)
+		}
 	})
 
 	t.Run("Expired token", func(t *testing.T) {
@@ -81,6 +85,21 @@ func TestInspect(t *testing.T) {
 		_, err := j.Inspect("Invalid token")
 		if err != token.ErrInvalidToken {
 			t.Fatalf("Inspect returned %v error, expected %v", err, token.ErrInvalidToken)
+		}
+	})
+
+	t.Run("Default name", func(t *testing.T) {
+		tok, err := j.Generate(&auth.Account{ID: "test"})
+		if err != nil {
+			t.Fatalf("Generate returned %v error, expected nil", err)
+		}
+
+		tok2, err := j.Inspect(tok.Token)
+		if err != nil {
+			t.Fatalf("Inspect returned %v error, expected nil", err)
+		}
+		if tok2.Name != "test" {
+			t.Fatalf("Inspect returned %v as the token name, expected test", tok2.Name)
 		}
 	})
 


### PR DESCRIPTION
Means that we can have ID as a UUID that never changes for the account and Name can be used as a user friendly alias which you could change. e.g. User would like to change their email or username. 