### PR TITLE
runtime: add WithVolume options and k8s support

### DIFF
--- a/runtime/kubernetes/service.go
+++ b/runtime/kubernetes/service.go
@@ -119,6 +119,20 @@ func newService(s *runtime.Service, c runtime.CreateOptions) *service {
 		kdeploy.Spec.Template.PodSpec.Containers[0].Resources = &client.ResourceRequirements{Limits: resLimits}
 	}
 
+	// mount volumes
+	var volumes []client.Volume
+	var mounts []client.VolumeMount
+	for name, path := range c.Volumes {
+		volumes = append(volumes, client.Volume{
+			Name:                  name,
+			PersistentVolumeClaim: &client.PersistentVolumeClaimVolumeSource{ClaimName: name},
+		})
+
+		mounts = append(mounts, client.VolumeMount{Name: name, MountPath: path})
+	}
+	kdeploy.Spec.Template.PodSpec.Volumes = volumes
+	kdeploy.Spec.Template.PodSpec.Containers[0].VolumeMounts = mounts
+
 	return &service{
 		Service:  s,
 		kservice: kservice,

--- a/runtime/kubernetes/service.go
+++ b/runtime/kubernetes/service.go
@@ -125,7 +125,7 @@ func newService(s *runtime.Service, c runtime.CreateOptions) *service {
 	for name, path := range c.Volumes {
 		volumes = append(volumes, client.Volume{
 			Name:                  name,
-			PersistentVolumeClaim: &client.PersistentVolumeClaimVolumeSource{ClaimName: name},
+			PersistentVolumeClaim: client.PersistentVolumeClaimVolumeSource{ClaimName: name},
 		})
 
 		mounts = append(mounts, client.VolumeMount{Name: name, MountPath: path})

--- a/runtime/options.go
+++ b/runtime/options.go
@@ -86,6 +86,8 @@ type CreateOptions struct {
 	Secrets map[string]string
 	// Resources to allocate the service
 	Resources *Resources
+	// Volumes to mount
+	Volumes map[string]string
 }
 
 // ReadOptions queries runtime services
@@ -175,6 +177,17 @@ func WithEnv(env []string) CreateOption {
 func WithOutput(out io.Writer) CreateOption {
 	return func(o *CreateOptions) {
 		o.Output = out
+	}
+}
+
+// WithVolume adds a volume to be mounted
+func WithVolume(name, path string) CreateOption {
+	return func(o *CreateOptions) {
+		if o.Volumes == nil {
+			o.Volumes = map[string]string{name: path}
+		} else {
+			o.Volumes[name] = path
+		}
 	}
 }
 

--- a/util/kubernetes/client/templates.go
+++ b/util/kubernetes/client/templates.go
@@ -139,8 +139,23 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
-      {{- end }}
-      {{- end }}
+          volumeMounts:
+          {{- with .VolumeMounts }}
+          {{- range . }}
+            name: {{ .Name }}
+            mountPath: {{ .MountPath }}
+          {{- end }}
+          {{- end }}
+    volumes:
+    {{- with .Spec.Template.PodSpec.Volumes }}
+    {{- range . }}
+      name: {{ .Name }}
+      persistentVolumeClaim:
+        {{- with .PersistentVolumeClaim }}
+        claimName: {{ .ClaimName }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
 `
 
 var serviceTmpl = `

--- a/util/kubernetes/client/templates.go
+++ b/util/kubernetes/client/templates.go
@@ -142,18 +142,18 @@ spec:
           volumeMounts:
           {{- with .VolumeMounts }}
           {{- range . }}
-          - name: {{ .Name }}
-            mountPath: {{ .MountPath }}
+            - name: {{ .Name }}
+              mountPath: {{ .MountPath }}
           {{- end }}
           {{- end }}
-    volumes:
-    {{- with .Spec.Template.PodSpec.Volumes }}
-    {{- range . }}
-    - name: {{ .Name }}
-      persistentVolumeClaim:
-        claimName: {{ .PersistentVolumeClaim.ClaimName }}
-    {{- end }}
-    {{- end }}
+      volumes:
+      {{- with .Spec.Template.PodSpec.Volumes }}
+      {{- range . }}
+        - name: {{ .Name }}
+          persistentVolumeClaim:
+            claimName: {{ .PersistentVolumeClaim.ClaimName }}
+      {{- end }}
+      {{- end }}
 `
 
 var serviceTmpl = `

--- a/util/kubernetes/client/templates.go
+++ b/util/kubernetes/client/templates.go
@@ -146,6 +146,8 @@ spec:
               mountPath: {{ .MountPath }}
           {{- end }}
           {{- end }}
+      {{- end }}
+      {{- end }} 
       volumes:
       {{- with .Spec.Template.PodSpec.Volumes }}
       {{- range . }}

--- a/util/kubernetes/client/templates.go
+++ b/util/kubernetes/client/templates.go
@@ -142,18 +142,16 @@ spec:
           volumeMounts:
           {{- with .VolumeMounts }}
           {{- range . }}
-            name: {{ .Name }}
+          - name: {{ .Name }}
             mountPath: {{ .MountPath }}
           {{- end }}
           {{- end }}
     volumes:
     {{- with .Spec.Template.PodSpec.Volumes }}
     {{- range . }}
-      name: {{ .Name }}
+    - name: {{ .Name }}
       persistentVolumeClaim:
-        {{- with .PersistentVolumeClaim }}
-        claimName: {{ .ClaimName }}
-        {{- end }}
+        claimName: {{ .PersistentVolumeClaim.ClaimName }}
     {{- end }}
     {{- end }}
 `

--- a/util/kubernetes/client/types.go
+++ b/util/kubernetes/client/types.go
@@ -43,6 +43,7 @@ type Container struct {
 	Ports          []ContainerPort       `json:"ports,omitempty"`
 	ReadinessProbe *Probe                `json:"readinessProbe,omitempty"`
 	Resources      *ResourceRequirements `json:"resources,omitempty"`
+	VolumeMounts   []VolumeMount         `json:"volumeMounts,omitempty"`
 }
 
 // DeploymentSpec defines micro deployment spec
@@ -110,6 +111,7 @@ type Metadata struct {
 type PodSpec struct {
 	Containers         []Container `json:"containers"`
 	ServiceAccountName string      `json:"serviceAccountName"`
+	Volumes            []Volume    `json:"volumes"`
 }
 
 // PodList
@@ -247,4 +249,21 @@ type ResourceLimits struct {
 	Memory           string `json:"memory,omitempty"`
 	CPU              string `json:"cpu,omitempty"`
 	EphemeralStorage string `json:"ephemeral-storage,omitempty"`
+}
+
+// Volume describes a volume which can be mounted to a pod
+type Volume struct {
+	Name                  string                            `json:"name"`
+	PersistentVolumeClaim PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
+}
+
+// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace
+type PersistentVolumeClaimVolumeSource struct {
+	ClaimName string `json:"claimName"`
+}
+
+// VolumeMount describes a mounting of a Volume within a container.
+type VolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
 }


### PR DESCRIPTION
Allow deployments created in k8s to mount persistent volumes.