### PR TITLE
store/file: add WithDir option

### DIFF
--- a/store/file/options.go
+++ b/store/file/options.go
@@ -1,0 +1,16 @@
+package file
+
+import (
+	"context"
+
+	"github.com/micro/go-micro/v3/store"
+)
+
+type dirKey struct{}
+
+// WithDir sets the directory to store the files in
+func WithDir(dir string) store.Option {
+	return func(o *store.Options) {
+		o.Context = context.WithValue(o.Context, dirKey{}, dir)
+	}
+}


### PR DESCRIPTION
The file store is currently hardcoded to use the temp dir. This PR adds an option so the directory can be changed. It's going to be used by the k8s profile to connect the file store to the persistent volume. 