### PR TITLE
Just watch services concerned

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -192,7 +192,7 @@ func (c *cache) get(domain, service string) ([]*registry.Service, error) {
 
 		// only kick it off if not running
 		if !running {
-			go c.run(domain)
+			go c.run(domain, service)
 		}
 	}
 
@@ -332,7 +332,7 @@ func (c *cache) update(domain string, res *registry.Result) {
 
 // run starts the cache watcher loop
 // it creates a new watcher if there's a problem
-func (c *cache) run(domain string) {
+func (c *cache) run(domain, service string) {
 	c.Lock()
 	c.running[domain] = true
 	c.Unlock()
@@ -358,7 +358,9 @@ func (c *cache) run(domain string) {
 		time.Sleep(time.Duration(j) * time.Millisecond)
 
 		// create new watcher
-		w, err := c.Registry.Watch(registry.WatchDomain(domain))
+		w, err := c.Registry.Watch(
+			registry.WatchDomain(domain),
+			registry.WatchService(service))
 		if err != nil {
 			if c.quit() {
 				return


### PR DESCRIPTION
1. Give a descriptive title to your PR.
registry cache only watch services concerned

2. Provide a description of your changes.
Registry cache only watch services concerned
don't care about other services
reduce waste of resources

If not as the default method, it can also be used as an cache option
