### PR TITLE
README: missing Micro -> Nitro rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ based access control.
 level config from any source such as env vars, file, etcd. You can merge the sources and even define fallbacks.
 
 - **Data Storage** - A simple data store interface to read, write and delete records. It includes support for memory, file and 
-CockroachDB by default. State and persistence becomes a core requirement beyond prototyping and Micro looks to build that into the framework.
+CockroachDB by default. State and persistence becomes a core requirement beyond prototyping and Nitro looks to build that into the framework.
 
 - **Service Discovery** - Automatic service registration and name resolution. Service discovery is at the core of micro service 
 development. When service A needs to speak to service B it needs the location of that service. The default discovery mechanism is 


### PR DESCRIPTION
I think this is the only missing rename in the README.