### PR TITLE
Remove missing gRPC example from README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,6 @@ This is a repository for go-micro examples. Feel free to contribute.
 - [options](options) - Setting options in the go-micro framework
 - [plugins](plugins) - How to use plugins
 - [pubsub](pubsub) - Example of using pubsub at the client/server level
-- [grpc](grpc) - Examples of how to use grpc
 - [redirect](redirect) - An example of how to http redirect using an API service
 - [roundrobin](roundrobin) - A stateful client wrapper for true round robin of requests
 - [secure](secure) - Demonstrates use of transport secure option for self signed certs


### PR DESCRIPTION
gRPC example link was redirecting to a 404 page. I don't see a gRPC folder either inside `examples`. I have seen that some other examples were removed too in previous commits, so I guess this is a consequence of some refactoring.
