### PR TITLE
update plugins version & remove replace

### DIFF
--- a/plugins/broker/grpc/go.mod
+++ b/plugins/broker/grpc/go.mod
@@ -3,12 +3,10 @@ module github.com/asim/go-micro/plugins/broker/grpc/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/golang/protobuf v1.4.2
 	github.com/google/uuid v1.1.5
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	google.golang.org/grpc v1.26.0
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/broker/http/go.mod
+++ b/plugins/broker/http/go.mod
@@ -3,10 +3,8 @@ module github.com/asim/go-micro/plugins/broker/http/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/google/uuid v1.1.5
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/broker/segmentio/go.mod
+++ b/plugins/broker/segmentio/go.mod
@@ -3,13 +3,9 @@ module github.com/asim/go-micro/plugins/broker/segmentio/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/broker/kafka/v3 v3.0.0-00010101000000-000000000000
-	github.com/asim/go-micro/plugins/codec/segmentio/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/broker/kafka/v3 v3.0.0-20210130181356-ca3dfc4580fa
+	github.com/asim/go-micro/plugins/codec/segmentio/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/google/uuid v1.1.1
 	github.com/segmentio/kafka-go v0.3.7
 )
-
-replace github.com/asim/go-micro/plugins/broker/kafka/v3 => ../../broker/kafka
-
-replace github.com/asim/go-micro/plugins/codec/segmentio/v3 => ../../codec/segmentio

--- a/plugins/client/grpc/go.mod
+++ b/plugins/client/grpc/go.mod
@@ -3,11 +3,9 @@ module github.com/asim/go-micro/plugins/client/grpc/v3
 go 1.15
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/golang/protobuf v1.4.3
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	google.golang.org/grpc v1.26.0
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/client/http/go.mod
+++ b/plugins/client/http/go.mod
@@ -3,9 +3,7 @@ module github.com/asim/go-micro/plugins/client/http/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/golang/protobuf v1.4.2
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/network/proxy/grpc/go.mod
+++ b/plugins/network/proxy/grpc/go.mod
@@ -7,6 +7,4 @@ require (
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
 
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory
-
 replace github.com/asim/go-micro/plugins/client/grpc/v3 => ../../../client/grpc

--- a/plugins/network/proxy/http/go.mod
+++ b/plugins/network/proxy/http/go.mod
@@ -3,8 +3,6 @@ module github.com/asim/go-micro/plugins/network/proxy/http
 go 1.15
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/proxy/http/go.mod
+++ b/plugins/proxy/http/go.mod
@@ -3,8 +3,6 @@ module github.com/asim/go-micro/plugins/proxy/http/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/selector/label/go.mod
+++ b/plugins/selector/label/go.mod
@@ -3,8 +3,6 @@ module github.com/asim/go-micro/plugins/selector/label/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/server/grpc/go.mod
+++ b/plugins/server/grpc/go.mod
@@ -3,10 +3,10 @@ module github.com/asim/go-micro/plugins/server/grpc/v3
 go 1.15
 
 require (
-	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/plugins/client/grpc/v3 v3.0.0-00010101000000-000000000000
 	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
-	github.com/asim/go-micro/plugins/transport/grpc/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/transport/grpc/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/golang/protobuf v1.4.3
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
@@ -15,9 +15,5 @@ require (
 )
 
 replace github.com/asim/go-micro/plugins/client/grpc/v3 => ../../client/grpc
-
-replace github.com/asim/go-micro/plugins/transport/grpc/v3 => ../../transport/grpc
-
-replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../broker/memory
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/plugins/server/grpc/go.mod
+++ b/plugins/server/grpc/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
 	github.com/asim/go-micro/plugins/client/grpc/v3 v3.0.0-00010101000000-000000000000
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/plugins/transport/grpc/v3 v3.0.0-00010101000000-000000000000
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/golang/protobuf v1.4.3
@@ -19,7 +19,5 @@ replace github.com/asim/go-micro/plugins/client/grpc/v3 => ../../client/grpc
 replace github.com/asim/go-micro/plugins/transport/grpc/v3 => ../../transport/grpc
 
 replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../broker/memory
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/plugins/server/http/go.mod
+++ b/plugins/server/http/go.mod
@@ -3,8 +3,6 @@ module github.com/asim/go-micro/plugins/server/http/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../registry/memory

--- a/plugins/wrapper/breaker/gobreaker/go.mod
+++ b/plugins/wrapper/breaker/gobreaker/go.mod
@@ -3,9 +3,7 @@ module github.com/asim/go-micro/plugins/wrapper/breaker/gobreaker/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/sony/gobreaker v0.4.1
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/breaker/hystrix/go.mod
+++ b/plugins/wrapper/breaker/hystrix/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/monitoring/prometheus/go.mod
+++ b/plugins/wrapper/monitoring/prometheus/go.mod
@@ -3,12 +3,10 @@ module github.com/asim/go-micro/plugins/wrapper/monitoring/prometheus/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.4.0
 )
-
-replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../../broker/memory

--- a/plugins/wrapper/monitoring/prometheus/go.mod
+++ b/plugins/wrapper/monitoring/prometheus/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
@@ -12,5 +12,3 @@ require (
 )
 
 replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../../broker/memory
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/monitoring/victoriametrics/go.mod
+++ b/plugins/wrapper/monitoring/victoriametrics/go.mod
@@ -4,9 +4,7 @@ go 1.13
 
 require (
 	github.com/VictoriaMetrics/metrics v1.9.3
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/stretchr/testify v1.4.0
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/ratelimiter/ratelimit/go.mod
+++ b/plugins/wrapper/ratelimiter/ratelimit/go.mod
@@ -3,13 +3,9 @@ module github.com/asim/go-micro/plugins/wrapper/ratelimiter/ratelimit/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
-	github.com/asim/go-micro/plugins/transport/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/transport/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 )
-
-replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../../broker/memory
-
-replace github.com/asim/go-micro/plugins/transport/memory/v3 => ../../../transport/memory

--- a/plugins/wrapper/ratelimiter/ratelimit/go.mod
+++ b/plugins/wrapper/ratelimiter/ratelimit/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asim/go-micro/plugins/broker/memory/v3 v3.0.0-00010101000000-000000000000
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/plugins/transport/memory/v3 v3.0.0-00010101000000-000000000000
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
@@ -13,5 +13,3 @@ require (
 replace github.com/asim/go-micro/plugins/broker/memory/v3 => ../../../broker/memory
 
 replace github.com/asim/go-micro/plugins/transport/memory/v3 => ../../../transport/memory
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/trace/datadog/go.mod
+++ b/plugins/wrapper/trace/datadog/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/DataDog/datadog-go v3.3.1+incompatible // indirect
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
@@ -13,5 +13,3 @@ require (
 	google.golang.org/grpc v1.26.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.20.1
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory

--- a/plugins/wrapper/trace/opentracing/go.mod
+++ b/plugins/wrapper/trace/opentracing/go.mod
@@ -3,10 +3,8 @@ module github.com/asim/go-micro/plugins/wrapper/trace/opentracing/v3
 go 1.13
 
 require (
-	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-00010101000000-000000000000
+	github.com/asim/go-micro/plugins/registry/memory/v3 v3.0.0-20210202145831-070250155285
 	github.com/asim/go-micro/v3 v3.0.0-20210120135431-d94936f6c97c
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.4.0
 )
-
-replace github.com/asim/go-micro/plugins/registry/memory/v3 => ../../../registry/memory


### PR DESCRIPTION
## update plugins version & remove replace

I just update some plugins go.mod version and remove `replace` line in go.mod files.

`github.com/asim/go-micro/plugins/client/grpc/v3` plugin is not fix, i will fix it after this `pull request`.
