### PR TITLE
Support for tls on the server http plugin

### DIFF
--- a/plugins/server/http/http.go
+++ b/plugins/server/http/http.go
@@ -2,6 +2,7 @@
 package http
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -236,7 +237,17 @@ func (h *httpServer) Start() error {
 	hd := h.hd
 	h.Unlock()
 
-	ln, err := net.Listen("tcp", opts.Address)
+	var (
+		ln net.Listener
+		err error
+	)
+
+	if opts.TLSConfig != nil {
+		ln, err = tls.Listen("tcp", opts.Address, opts.TLSConfig)
+	} else {
+		ln, err = net.Listen("tcp", opts.Address)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -307,6 +318,9 @@ func (h *httpServer) Stop() error {
 }
 
 func (h *httpServer) String() string {
+	if h.opts.TLSConfig != nil {
+		return "https"
+	}
 	return "http"
 }
 


### PR DESCRIPTION
If the http server contains a `TLSConfig` option we will use `tls.Listen()`; will also render `http` or `https` depending on such option.