### PR TITLE
fixing etcd stack in getToken

### DIFF
--- a/plugins/registry/etcd/etcd.go
+++ b/plugins/registry/etcd/etcd.go
@@ -56,6 +56,7 @@ func configure(e *etcdRegistry, opts ...registry.Option) error {
 	if e.options.Timeout == 0 {
 		e.options.Timeout = 5 * time.Second
 	}
+	config.DialTimeout = e.options.Timeout
 
 	if e.options.Secure || e.options.TLSConfig != nil {
 		tlsConfig := e.options.TLSConfig


### PR DESCRIPTION
when provide username and password, etcd will try to get auth token from server
if server is unavailble, etcd client will stack in
when dial timeout is set, it will return err instead of stack in

closes #2144
