### PR TITLE
make rpcClient compatible with 32bit (arm) systems

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -21,10 +21,10 @@ import (
 )
 
 type rpcClient struct {
+	seq  uint64
 	once atomic.Value
 	opts Options
 	pool pool.Pool
-	seq  uint64
 }
 
 func newRpcClient(opt ...Option) Client {


### PR DESCRIPTION
When using the go-micro client on 32bit systems (like a ARMv7 SoC), the rpcClient panics due to an unaligned 64-bit atomic operation.

```golang
panic: unaligned 64-bit atomic operation
goroutine 672 [running]:
runtime/internal/atomic.panicUnaligned()
        /usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Xadd64(0x1f0c4d4, 0x1, 0x0, 0x1c100a8, 0x2)
        /usr/local/go/src/runtime/internal/atomic/asm_arm.s:233 +0x14
github.com/asim/go-micro/v3/client.(*rpcClient).call(0x1f0c410, 0xfb0abc, 0x1c6c500, 0x1e82270, 0xfb3560, 0x1e272c0, 0xc25450, 0x1e0e7c0, 0x0, 0x0, ...)
        /home/tobias/go/pkg/mod/github.com/asim/go-micro/v3@v3.5.1/client/rpc_client.go:117 +0x5a0
github.com/asim/go-micro/v3/client.(*rpcClient).Call.func1(0x0, 0x1e0, 0x1e0)
        /home/tobias/go/pkg/mod/github.com/asim/go-micro/v3@v3.5.1/client/rpc_client.go:425 +0x6bc
github.com/asim/go-micro/v3/client.(*rpcClient).Call.func2(0x1c6c580, 0x1e861e0, 0x0)
        /home/tobias/go/pkg/mod/github.com/asim/go-micro/v3@v3.5.1/client/rpc_client.go:443 +0x24
created by github.com/asim/go-micro/v3/client.(*rpcClient).Call
        /home/tobias/go/pkg/mod/github.com/asim/go-micro/v3@v3.5.1/client/rpc_client.go:442 +0x3d8
```

The problem is a known bug in the [sync/atomic package](https://golang.org/pkg/sync/atomic/#pkg-note-BUG). 

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. Only the first word in an allocated struct can be relied upon to be 64-bit aligned.

The fix is actually very easy. We only have to rearrange the order of the fields in struct `rpcClient` and put the `seq uint64` field in the first place. The sync/atomic package guarantees that the first word will be 64-bit aligned, even on 32bit platforms.