### PR TITLE
Fix util/log/log.Infof format didn't work

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -117,7 +117,7 @@ func Logf(format string, v ...interface{}) {
 	if len(prefix) > 0 {
 		format = prefix + " " + format
 	}
-	nlog.DefaultLogger.Log(levelToLevel(level), format, v)
+	nlog.DefaultLogger.Logf(levelToLevel(level), format, v)
 }
 
 // WithLevel logs with the level specified


### PR DESCRIPTION
This PR is fix a BUG of util/log/log.Infof(...) format didn't work.
util/log/log.og line 120 func Logf(...) called nlog.DefaultLogger.Log(...). It should be nlog.DefaultLogger.Logf(...)

`closes #2159`