### PR TITLE
fixing grpc server invalid UTF-8 issue

### DIFF
--- a/plugins/server/grpc/grpc.go
+++ b/plugins/server/grpc/grpc.go
@@ -14,9 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/asim/go-micro/v3/cmd"
 	"github.com/asim/go-micro/v3/broker"
+	"github.com/asim/go-micro/v3/cmd"
 	"github.com/asim/go-micro/v3/errors"
 	"github.com/asim/go-micro/v3/logger"
 	meta "github.com/asim/go-micro/v3/metadata"
@@ -26,6 +25,7 @@ import (
 	"github.com/asim/go-micro/v3/util/backoff"
 	mgrpc "github.com/asim/go-micro/v3/util/grpc"
 	mnet "github.com/asim/go-micro/v3/util/net"
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/netutil"
 
 	"google.golang.org/grpc"
@@ -405,6 +405,7 @@ func (g *grpcServer) processRequest(stream grpc.ServerStream, service *service, 
 				// micro.Error now proto based and we can attach it to grpc status
 				statusCode = microError(verr)
 				statusDesc = verr.Error()
+				verr.Detail = strings.ToValidUTF8(verr.Detail, "")
 				errStatus, err = status.New(statusCode, statusDesc).WithDetails(verr)
 				if err != nil {
 					return err
@@ -477,6 +478,7 @@ func (g *grpcServer) processStream(stream grpc.ServerStream, service *service, m
 			// micro.Error now proto based and we can attach it to grpc status
 			statusCode = microError(verr)
 			statusDesc = verr.Error()
+			verr.Detail = strings.ToValidUTF8(verr.Detail, "")
 			errStatus, err = status.New(statusCode, statusDesc).WithDetails(verr)
 			if err != nil {
 				return err

--- a/plugins/server/grpc/grpc_test.go
+++ b/plugins/server/grpc/grpc_test.go
@@ -56,7 +56,7 @@ func (s *testServer) CallPcreInvalid(ctx context.Context, req *pb.Request, rsp *
 // TestHello implements helloworld.GreeterServer
 func (s *testServer) Call(ctx context.Context, req *pb.Request, rsp *pb.Response) error {
 	if req.Name == "Error" {
-		return &errors.Error{Id: "1", Code: 99, Detail: "detail"}
+		return &errors.Error{Id: "1", Code: 99, Detail: "detail\xc5"}
 	}
 
 	rsp.Msg = "Hello " + req.Name
@@ -196,7 +196,7 @@ func TestGRPCServer(t *testing.T) {
 		if !ok {
 			t.Fatalf("invalid error received %#+v\n", st.Details()[0])
 		}
-		if verr.Code != 99 && verr.Id != "1" && verr.Detail != "detail" {
+		if verr.Code != 99 || verr.Id != "1" || verr.Detail != "detail" {
 			t.Fatalf("invalid error received %#+v\n", verr)
 		}
 	}


### PR DESCRIPTION
I'm using an third party service, which throw an error with invalid utf-8 characters, my client got an error with "string field contains invalid UTF-8", instead of the real error.
This is an simple demo of my issue:
```go
package main

import (
	"context"
	"time"

	pb "github.com/asim/go-micro/examples/v3/greeter/srv/proto/hello"
	gc "github.com/asim/go-micro/plugins/client/grpc/v3"
	gs "github.com/asim/go-micro/plugins/server/grpc/v3"
	"github.com/asim/go-micro/v3"
	"github.com/asim/go-micro/v3/errors"
	"github.com/asim/go-micro/v3/logger"
)

type Greeter struct{}

func (h *Greeter) Hello(ctx context.Context, req *pb.Request, rsp *pb.Response) error {
	return &errors.Error{Code: 500, Detail: "a\xc5z"}
}

func main() {
	srv := micro.NewService(micro.Server(gs.NewServer()), micro.Client(gc.NewClient()), micro.Name("greeter"))
	srv.Init()
	if err := pb.RegisterSayHandler(srv.Server(), new(Greeter)); err != nil {
		logger.Fatal(err)
	}
	go func() {
		time.Sleep(5 * time.Second)
		client := pb.NewSayService("greeter", srv.Client())
		if _, err := client.Hello(context.TODO(), &pb.Request{Name: "tester"}); err != nil {
			logger.Error(err)
		}
	}()
	if err := srv.Run(); err != nil {
		logger.Fatal(err)
	}
}
```
