### PR TITLE
fix：Kubernetes registry get k8s pod list

### DIFF
--- a/plugins/registry/kubernetes/client/kubernetes.go
+++ b/plugins/registry/kubernetes/client/kubernetes.go
@@ -25,6 +25,7 @@ type Meta struct {
 	Name        string             `json:"name,omitempty"`
 	Labels      map[string]*string `json:"labels,omitempty"`
 	Annotations map[string]*string `json:"annotations,omitempty"`
+	DeletionTimestamp    string    `json:"deletionTimestamp,omitempty"`
 }
 
 // Status ...

--- a/plugins/registry/kubernetes/kubernetes.go
+++ b/plugins/registry/kubernetes/kubernetes.go
@@ -191,7 +191,7 @@ func (c *kregistry) GetService(name string, opts ...registry.GetOption) ([]*regi
 
 	// loop through items
 	for _, pod := range pods.Items {
-		if pod.Status.Phase != podRunning {
+		if pod.Status.Phase != podRunning || pod.Meta.DeletionTimestamp != "" {
 			continue
 		}
 		// get serialised service from annotation
@@ -235,7 +235,7 @@ func (c *kregistry) ListServices(opts ...registry.ListOption) ([]*registry.Servi
 	svcs := make(map[string]bool)
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase != podRunning {
+		if pod.Status.Phase != podRunning || pod.Meta.DeletionTimestamp != "" {
 			continue
 		}
 		for k, v := range pod.Metadata.Annotations {

--- a/plugins/registry/kubernetes/watcher.go
+++ b/plugins/registry/kubernetes/watcher.go
@@ -155,7 +155,7 @@ func (k *k8sWatcher) handleEvent(event watch.Event) {
 
 		for _, result := range results {
 			// pod isnt running
-			if pod.Status.Phase != podRunning {
+			if pod.Status.Phase != podRunning || pod.Meta.DeletionTimestamp != "" {
 				result.Action = "delete"
 			}
 			k.next <- result


### PR DESCRIPTION

When kubernetes is deleting a pod，it will first update the metadate  of the pod object and add "Deletiontimestamp" field。But at this time, the action received by the watch at this time is update.which will result in untimely service discovery.I think at this time, you can delete the pod and judge that if the metadate of the pod has the deletiontimestamp field,the pod is not available by default. 
This is my opinion. Please code review.
