### PR TITLE
support etcd auth with env args

### DIFF
--- a/plugins/registry/etcd/etcd.go
+++ b/plugins/registry/etcd/etcd.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -17,7 +18,7 @@ import (
 	"github.com/asim/go-micro/v3/registry"
 	hash "github.com/mitchellh/hashstructure"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
@@ -36,9 +37,13 @@ type etcdRegistry struct {
 
 func NewRegistry(opts ...registry.Option) registry.Registry {
 	e := &etcdRegistry{
-		options:  registry.Options{},
+		options:  registry.Options{Addrs: []string{os.Getenv("MICRO_REGISTRY_ADDRESS")}},
 		register: make(map[string]uint64),
 		leases:   make(map[string]clientv3.LeaseID),
+	}
+	username, password := os.Getenv("ETCD_USERNAME"), os.Getenv("ETCD_PASSWORD")
+	if len(username) > 0 && len(password) > 0 {
+		opts = append(opts, Auth(username, password))
 	}
 	configure(e, opts...)
 	return e

--- a/plugins/registry/etcd/etcd.go
+++ b/plugins/registry/etcd/etcd.go
@@ -37,13 +37,17 @@ type etcdRegistry struct {
 
 func NewRegistry(opts ...registry.Option) registry.Registry {
 	e := &etcdRegistry{
-		options:  registry.Options{Addrs: []string{os.Getenv("MICRO_REGISTRY_ADDRESS")}},
+		options:  registry.Options{},
 		register: make(map[string]uint64),
 		leases:   make(map[string]clientv3.LeaseID),
 	}
 	username, password := os.Getenv("ETCD_USERNAME"), os.Getenv("ETCD_PASSWORD")
 	if len(username) > 0 && len(password) > 0 {
 		opts = append(opts, Auth(username, password))
+	}
+	address := os.Getenv("MICRO_REGISTRY_ADDRESS")
+	if len(address) > 0 {
+		opts = append(opts, registry.Addrs(address))
 	}
 	configure(e, opts...)
 	return e


### PR DESCRIPTION
set etcd auth username and password from env args
set default registry address with env arg instead of 127.0.0.1

default etcd address 127.0.0.1 is invalid in prod environment usually.

