### PR TITLE
fix: imported and not used (log, os) (plugins/registry/consul/watcher.go)

### DIFF
--- a/plugins/registry/consul/watcher.go
+++ b/plugins/registry/consul/watcher.go
@@ -2,8 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"sync"
 
 	"github.com/asim/go-micro/v3/registry"


### PR DESCRIPTION
github.com/asim/go-micro/plugins/registry/consul/v3@v3.0.0-20210716165540-546225f1d8db/watcher.go:5:2: imported and not used: "log"
github.com/asim/go-micro/plugins/registry/consul/v3@v3.0.0-20210716165540-546225f1d8db/watcher.go:6:2: imported and not used: "os"