### PR TITLE
Grpc server injection

### DIFF
--- a/plugins/server/grpc/README.md
+++ b/plugins/server/grpc/README.md
@@ -1,6 +1,6 @@
 # GRPC Server
 
-The grpc server is a [micro.Server](https://godoc.org/github.com/micro/go-micro/server#Server) compatible server.
+The grpc server is a [micro.Server](https://pkg.go.dev/github.com/asim/go-micro/server#Server) compatible server.
 
 ## Overview
 
@@ -13,8 +13,8 @@ Specify the server to your micro service
 
 ```go
 import (
-        "github.com/micro/go-micro"
-        "github.com/micro/go-plugins/server/grpc"
+        "github.com/asim/go-micro/v3"
+        "github.com/asim/go-micro/plugins/server/grpc/v3"
 )
 
 func main() {

--- a/plugins/server/grpc/grpc_test.go
+++ b/plugins/server/grpc/grpc_test.go
@@ -5,19 +5,21 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/asim/go-micro/v3"
-	bmemory "github.com/asim/go-micro/plugins/broker/memory/v3"
-	"github.com/asim/go-micro/v3/client"
-	gcli "github.com/asim/go-micro/plugins/client/grpc/v3"
-	"github.com/asim/go-micro/v3/errors"
-	rmemory "github.com/asim/go-micro/plugins/registry/memory/v3"
-	"github.com/asim/go-micro/v3/server"
-	gsrv "github.com/asim/go-micro/plugins/server/grpc/v3"
-	tgrpc "github.com/asim/go-micro/plugins/transport/grpc/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 
+	"github.com/asim/go-micro/v3"
+	"github.com/asim/go-micro/v3/client"
+	"github.com/asim/go-micro/v3/errors"
+	"github.com/asim/go-micro/v3/registry"
+	"github.com/asim/go-micro/v3/server"
+
+	bmemory "github.com/asim/go-micro/plugins/broker/memory/v3"
+	gcli "github.com/asim/go-micro/plugins/client/grpc/v3"
+	rmemory "github.com/asim/go-micro/plugins/registry/memory/v3"
+	gsrv "github.com/asim/go-micro/plugins/server/grpc/v3"
 	pb "github.com/asim/go-micro/plugins/server/grpc/v3/proto"
+	tgrpc "github.com/asim/go-micro/plugins/transport/grpc/v3"
 )
 
 // server is used to implement helloworld.GreeterServer.
@@ -106,21 +108,7 @@ func BenchmarkServer(b *testing.B) {
 
 }
 */
-func TestGRPCServer(t *testing.T) {
-	r := rmemory.NewRegistry()
-	b := bmemory.NewBroker()
-	tr := tgrpc.NewTransport()
-	s := gsrv.NewServer(
-		server.Broker(b),
-		server.Name("foo"),
-		server.Registry(r),
-		server.Transport(tr),
-	)
-	c := gcli.NewClient(
-		client.Registry(r),
-		client.Broker(b),
-		client.Transport(tr),
-	)
+func testGRPCServer(t *testing.T, s server.Server, c client.Client, r registry.Registry) {
 	ctx := context.TODO()
 
 	h := &testServer{}
@@ -200,4 +188,22 @@ func TestGRPCServer(t *testing.T) {
 			t.Fatalf("invalid error received %#+v\n", verr)
 		}
 	}
+}
+
+func TestDefaultGRPCServer(t *testing.T) {
+	r := rmemory.NewRegistry()
+	b := bmemory.NewBroker()
+	tr := tgrpc.NewTransport()
+	s := gsrv.NewServer(
+		server.Broker(b),
+		server.Name("foo"),
+		server.Registry(r),
+		server.Transport(tr),
+	)
+	c := gcli.NewClient(
+		client.Registry(r),
+		client.Broker(b),
+		client.Transport(tr),
+	)
+	testGRPCServer(t, s, c, r)
 }

--- a/plugins/server/grpc/options.go
+++ b/plugins/server/grpc/options.go
@@ -20,6 +20,7 @@ type netListener struct{}
 type maxMsgSizeKey struct{}
 type maxConnKey struct{}
 type tlsAuth struct{}
+type grpcServerKey struct{}
 
 // gRPC Codec to be used to encode/decode requests for a given content type
 func Codec(contentType string, c encoding.Codec) server.Option {
@@ -49,6 +50,14 @@ func MaxConn(n int) server.Option {
 // Listener specifies the net.Listener to use instead of the default
 func Listener(l net.Listener) server.Option {
 	return setServerOption(netListener{}, l)
+}
+
+// Server specifies a *grpc.Server to use instead of the default
+// This is for rare use case where user need to expose grpc.Server for
+// customization. Please NOTE however user injected grpcServer doesn't support
+// server Handler abstraction
+func Server(srv *grpc.Server) server.Option {
+	return setServerOption(grpcServerKey{}, srv)
 }
 
 // Options to be used to configure gRPC options


### PR DESCRIPTION
This PR allows `grpc.Server` itself to be injected through grpc server plugin options. The use case is that externally (outside of go-micro) created / pre-created grpc.Server can be re-used and managed through micro server framework. Please let me know if this change doesn't make sense.

As for the actual code change itself, several pieces, one in each self-contained commit. The commit subject should be self descriptive. The actual `grpc.Server` injection is in the last one while the first three for preparation.