### PR TITLE
Move from micro/cli/v2 to urfave/cli/v2

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,7 +22,7 @@ import (
 	"github.com/asim/go-micro/v3/server"
 	"github.com/asim/go-micro/v3/store"
 	"github.com/asim/go-micro/v3/transport"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 type Cmd interface {

--- a/cmd/gomu/cmd/cli/call/call.go
+++ b/cmd/gomu/cmd/cli/call/call.go
@@ -9,7 +9,7 @@ import (
 	"github.com/asim/go-micro/cmd/gomu/cmd"
 	"github.com/asim/go-micro/v3"
 	"github.com/asim/go-micro/v3/client"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // NewCommand returns a new call cli command.

--- a/cmd/gomu/cmd/cli/cli.go
+++ b/cmd/gomu/cmd/cli/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asim/go-micro/cmd/gomu/cmd/cli/run"
 	"github.com/asim/go-micro/cmd/gomu/cmd/cli/services"
 	"github.com/asim/go-micro/cmd/gomu/cmd/cli/stream"
-	mcli "github.com/micro/cli/v2"
+	mcli "github.com/urfave/cli/v2"
 )
 
 func init() {

--- a/cmd/gomu/cmd/cli/describe/describe.go
+++ b/cmd/gomu/cmd/cli/describe/describe.go
@@ -2,7 +2,7 @@ package describe
 
 import (
 	"github.com/asim/go-micro/cmd/gomu/cmd"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 var flags []cli.Flag = []cli.Flag{

--- a/cmd/gomu/cmd/cli/describe/service.go
+++ b/cmd/gomu/cmd/cli/describe/service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/asim/go-micro/cmd/gomu/cmd"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
 )
 

--- a/cmd/gomu/cmd/cli/new/new.go
+++ b/cmd/gomu/cmd/cli/new/new.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/asim/go-micro/cmd/gomu/cmd"
 	tmpl "github.com/asim/go-micro/cmd/gomu/cmd/cli/new/template"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 var flags []cli.Flag = []cli.Flag{

--- a/cmd/gomu/cmd/cli/run/run.go
+++ b/cmd/gomu/cmd/cli/run/run.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // NewCommand returns a new run command.

--- a/cmd/gomu/cmd/cli/services/services.go
+++ b/cmd/gomu/cmd/cli/services/services.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 
 	"github.com/asim/go-micro/cmd/gomu/cmd"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // NewCommand returns a new services command.

--- a/cmd/gomu/cmd/cli/stream/bidi.go
+++ b/cmd/gomu/cmd/cli/stream/bidi.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/asim/go-micro/v3"
 	"github.com/asim/go-micro/v3/client"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Bidirectional streams client requests and prints the server stream responses

--- a/cmd/gomu/cmd/cli/stream/server.go
+++ b/cmd/gomu/cmd/cli/stream/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/asim/go-micro/v3"
 	"github.com/asim/go-micro/v3/client"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Server sends a single client request and prints the server stream responses

--- a/cmd/gomu/cmd/cli/stream/stream.go
+++ b/cmd/gomu/cmd/cli/stream/stream.go
@@ -2,7 +2,7 @@ package stream
 
 import (
 	"github.com/asim/go-micro/cmd/gomu/cmd"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // NewCommand returns a new stream command.

--- a/cmd/gomu/cmd/cmd.go
+++ b/cmd/gomu/cmd/cmd.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	mcmd "github.com/asim/go-micro/v3/cmd"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/cmd/gomu/go.mod
+++ b/cmd/gomu/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/asim/go-micro/v3 v3.6.0
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/micro/cli/v2 v2.1.2
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
+	github.com/urfave/cli/v2 v2.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/cmd/gomu/go.sum
+++ b/cmd/gomu/go.sum
@@ -496,7 +496,9 @@ github.com/uber/jaeger-client-go v2.29.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=

--- a/config/source/cli/README.md
+++ b/config/source/cli/README.md
@@ -4,7 +4,7 @@ The cli source reads config from parsed flags via a cli.Context.
 
 ## Format
 
-We expect the use of the `micro/cli` package. Upper case flags will be lower cased. Dashes will be used as delimiters for nesting.
+We expect the use of the `urfave/cli` package. Upper case flags will be lower cased. Dashes will be used as delimiters for nesting.
 
 ### Example
 

--- a/config/source/cli/cli.go
+++ b/config/source/cli/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asim/go-micro/v3/cmd"
 	"github.com/asim/go-micro/v3/config/source"
 	"github.com/imdario/mergo"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 type cliSource struct {
@@ -84,7 +84,7 @@ func (c *cliSource) String() string {
 	return "cli"
 }
 
-// NewSource returns a config source for integrating parsed flags from a micro/cli.Context.
+// NewSource returns a config source for integrating parsed flags from a urfave/cli.Context.
 // Hyphens are delimiters for nesting, and all keys are lowercased. The assumption is that
 // command line flags have already been parsed.
 //

--- a/config/source/cli/cli_test.go
+++ b/config/source/cli/cli_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/asim/go-micro/v3/cmd"
 	"github.com/asim/go-micro/v3/config"
 	"github.com/asim/go-micro/v3/config/source"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 func TestCliSourceDefault(t *testing.T) {

--- a/config/source/cli/cli_test.go
+++ b/config/source/cli/cli_test.go
@@ -31,6 +31,9 @@ func TestCliSourceDefault(t *testing.T) {
 				Name: "test.testlogfile",
 			},
 			&cli.StringFlag{
+				Name: "test.paniconexit0",
+			},
+			&cli.StringFlag{
 				Name:    "flag",
 				Usage:   "It changes something",
 				EnvVars: []string{"flag"},

--- a/config/source/cli/options.go
+++ b/config/source/cli/options.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/asim/go-micro/v3/config/source"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 type contextKey struct{}

--- a/config/source/cli/util.go
+++ b/config/source/cli/util.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {

--- a/examples/flags/main.go
+++ b/examples/flags/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/micro/cli/v2"
 	"github.com/asim/go-micro/v3"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {

--- a/examples/mocking/main.go
+++ b/examples/mocking/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/micro/cli/v2"
 	proto "github.com/asim/go-micro/examples/v3/helloworld/proto"
 	"github.com/asim/go-micro/examples/v3/mocking/mock"
 	"github.com/asim/go-micro/v3"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -5,9 +5,10 @@ import (
 	"os"
 
 	"context"
-	"github.com/micro/cli/v2"
+
 	proto "github.com/asim/go-micro/examples/v3/service/proto"
 	"github.com/asim/go-micro/v3"
+	"github.com/urfave/cli/v2"
 )
 
 /*

--- a/go.mod
+++ b/go.mod
@@ -18,13 +18,13 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/imdario/mergo v0.3.12
-	github.com/micro/cli/v2 v2.1.2
 	github.com/miekg/dns v1.1.43
 	github.com/nxadm/tail v1.4.8
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
+	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -151,7 +151,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -356,8 +355,6 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
-github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
@@ -509,7 +506,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/transip/gotransip/v6 v6.2.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=

--- a/options.go
+++ b/options.go
@@ -17,7 +17,7 @@ import (
 	"github.com/asim/go-micro/v3/server"
 	"github.com/asim/go-micro/v3/store"
 	"github.com/asim/go-micro/v3/transport"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Options for micro service

--- a/web/options.go
+++ b/web/options.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/asim/go-micro/v3"
 	"github.com/asim/go-micro/v3/registry"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 //Options for web

--- a/web/service.go
+++ b/web/service.go
@@ -22,7 +22,7 @@ import (
 	mnet "github.com/asim/go-micro/v3/util/net"
 	signalutil "github.com/asim/go-micro/v3/util/signal"
 	mls "github.com/asim/go-micro/v3/util/tls"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 type service struct {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asim/go-micro/v3"
 	"github.com/asim/go-micro/v3/logger"
 	"github.com/asim/go-micro/v3/web"
-	"github.com/micro/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 func TestWeb(t *testing.T) {


### PR DESCRIPTION
@asim mentioned it may be favourable to move away from using github.com/micro imports in #2223, so I thought in undoing my own errors, I might as well elevate the Go Micro source code. I'm opting to use github.com/urfave/cli/v2, since github.com/micro/cli/v2 was forked from that, so it's pretty simple to move to without extending too much effort.