### PR TITLE
Add simple in-memory cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -51,8 +51,15 @@ func (i *Item) Expired() bool {
 
 // NewCache returns a new cache.
 func NewCache(opts ...Option) Cache {
+	options := NewOptions(opts...)
+	items := make(map[string]Item)
+
+	if len(options.Items) > 0 {
+		items = options.Items
+	}
+
 	return &memCache{
-		opts:  NewOptions(opts...),
-		items: make(map[string]Item),
+		opts:  options,
+		items: items,
 	}
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,60 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// DefaultCache is the default cache.
+	DefaultCache Cache = NewCache()
+
+	// ErrItemExpired is returned in Cache.Get when the item found in the cache
+	// has expired.
+	ErrItemExpired error = errors.New("item has expired")
+	// ErrKeyNotFound is returned in Cache.Get and Cache.Delete when the
+	// provided key could not be found in cache.
+	ErrKeyNotFound error = errors.New("key not found in cache")
+)
+
+// Cache is the interface that wraps the cache.
+//
+// Context specifies the context for the cache.
+// Get gets a cached value by key.
+// Put stores a key-value pair into cache.
+// Delete removes a key from cache.
+type Cache interface {
+	Context(ctx context.Context) Cache
+	Get(key string) (interface{}, time.Time, error)
+	Put(key string, val interface{}, d time.Duration) error
+	Delete(key string) error
+}
+
+// Item represents an item stored in the cache.
+type Item struct {
+	Value      interface{}
+	Expiration int64
+}
+
+// Expired returns true if the item has expired.
+func (i *Item) Expired() bool {
+	if i.Expiration == 0 {
+		return false
+	}
+
+	return time.Now().UnixNano() > i.Expiration
+}
+
+// NewCache returns a new cache.
+func NewCache(opts ...Option) Cache {
+	var options Options
+	for _, o := range opts {
+		o(&options)
+	}
+
+	return &memCache{
+		opts:  options,
+		items: make(map[string]Item),
+	}
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -9,6 +9,9 @@ import (
 var (
 	// DefaultCache is the default cache.
 	DefaultCache Cache = NewCache()
+	// DefaultExpiration is the default duration for items stored in
+	// the cache to expire.
+	DefaultExpiration time.Duration = 0
 
 	// ErrItemExpired is returned in Cache.Get when the item found in the cache
 	// has expired.
@@ -48,13 +51,8 @@ func (i *Item) Expired() bool {
 
 // NewCache returns a new cache.
 func NewCache(opts ...Option) Cache {
-	var options Options
-	for _, o := range opts {
-		o(&options)
-	}
-
 	return &memCache{
-		opts:  options,
+		opts:  NewOptions(opts...),
 		items: make(map[string]Item),
 	}
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,86 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestMemCache tests the in-memory cache implementation.
+func TestCache(t *testing.T) {
+	var (
+		ctx context.Context = context.TODO()
+		key string          = "test"
+		val interface{}     = "hello go-micro"
+	)
+
+	t.Run("CacheGetMiss", func(t *testing.T) {
+		if _, _, err := NewCache().Context(ctx).Get(key); err == nil {
+			t.Error("expected to get no value from cache")
+		}
+	})
+
+	t.Run("CacheGetHit", func(t *testing.T) {
+		c := NewCache()
+
+		if err := c.Context(ctx).Put(key, val, 0); err != nil {
+			t.Error(err)
+		}
+
+		if a, _, err := c.Context(ctx).Get(key); err != nil {
+			t.Errorf("Expected a value, got err: %s", err)
+		} else if a != val {
+			t.Errorf("Expected '%v', got '%v'", val, a)
+		}
+	})
+
+	t.Run("CacheGetExpired", func(t *testing.T) {
+		c := NewCache()
+		e := 20 * time.Millisecond
+
+		if err := c.Context(ctx).Put(key, val, e); err != nil {
+			t.Error(err)
+		}
+
+		<-time.After(25 * time.Millisecond)
+		if _, _, err := c.Context(ctx).Get(key); err == nil {
+			t.Error("expected to get no value from cache")
+		}
+	})
+
+	t.Run("CacheGetNotExpired", func(t *testing.T) {
+		c := NewCache()
+		e := 25 * time.Millisecond
+
+		if err := c.Context(ctx).Put(key, val, e); err != nil {
+			t.Error(err)
+		}
+
+		<-time.After(20 * time.Millisecond)
+		if _, _, err := c.Context(ctx).Get(key); err != nil {
+			t.Errorf("expected a value, got err: %s", err)
+		}
+	})
+
+	t.Run("CacheDeleteMiss", func(t *testing.T) {
+		if err := NewCache().Context(ctx).Delete(key); err == nil {
+			t.Error("expected to delete no value from cace")
+		}
+	})
+
+	t.Run("CacheDeleteHit", func(t *testing.T) {
+		c := NewCache()
+
+		if err := c.Context(ctx).Put(key, val, 0); err != nil {
+			t.Error(err)
+		}
+
+		if err := c.Context(ctx).Delete(key); err != nil {
+			t.Errorf("Expected to delete an item, got err: %s", err)
+		}
+
+		if _, _, err := c.Context(ctx).Get(key); err == nil {
+			t.Errorf("Expected error")
+		}
+	})
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -34,6 +34,19 @@ func TestCache(t *testing.T) {
 		}
 	})
 
+	t.Run("CacheExpiration", func(t *testing.T) {
+		c := NewCache(Expiration(20 * time.Millisecond))
+
+		if err := c.Context(ctx).Put(key, val, 0); err != nil {
+			t.Error(err)
+		}
+
+		<-time.After(25 * time.Millisecond)
+		if _, _, err := c.Context(ctx).Get(key); err == nil {
+			t.Error("expected to get no value from cache")
+		}
+	})
+
 	t.Run("CacheGetExpired", func(t *testing.T) {
 		c := NewCache()
 		e := 20 * time.Millisecond
@@ -48,7 +61,7 @@ func TestCache(t *testing.T) {
 		}
 	})
 
-	t.Run("CacheGetNotExpired", func(t *testing.T) {
+	t.Run("CacheGetValid", func(t *testing.T) {
 		c := NewCache()
 		e := 25 * time.Millisecond
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 )
 
+var (
+	ctx context.Context = context.TODO()
+	key string          = "test"
+	val interface{}     = "hello go-micro"
+)
+
 // TestMemCache tests the in-memory cache implementation.
 func TestCache(t *testing.T) {
-	var (
-		ctx context.Context = context.TODO()
-		key string          = "test"
-		val interface{}     = "hello go-micro"
-	)
-
 	t.Run("CacheGetMiss", func(t *testing.T) {
 		if _, _, err := NewCache().Context(ctx).Get(key); err == nil {
 			t.Error("expected to get no value from cache")
@@ -31,19 +31,6 @@ func TestCache(t *testing.T) {
 			t.Errorf("Expected a value, got err: %s", err)
 		} else if a != val {
 			t.Errorf("Expected '%v', got '%v'", val, a)
-		}
-	})
-
-	t.Run("CacheExpiration", func(t *testing.T) {
-		c := NewCache(Expiration(20 * time.Millisecond))
-
-		if err := c.Context(ctx).Put(key, val, 0); err != nil {
-			t.Error(err)
-		}
-
-		<-time.After(25 * time.Millisecond)
-		if _, _, err := c.Context(ctx).Get(key); err == nil {
-			t.Error("expected to get no value from cache")
 		}
 	})
 
@@ -77,7 +64,7 @@ func TestCache(t *testing.T) {
 
 	t.Run("CacheDeleteMiss", func(t *testing.T) {
 		if err := NewCache().Context(ctx).Delete(key); err == nil {
-			t.Error("expected to delete no value from cace")
+			t.Error("expected to delete no value from cache")
 		}
 	})
 
@@ -94,6 +81,31 @@ func TestCache(t *testing.T) {
 
 		if _, _, err := c.Context(ctx).Get(key); err == nil {
 			t.Errorf("Expected error")
+		}
+	})
+}
+
+func TestCacheWithOptions(t *testing.T) {
+	t.Run("CacheWithExpiration", func(t *testing.T) {
+		c := NewCache(Expiration(20 * time.Millisecond))
+
+		if err := c.Context(ctx).Put(key, val, 0); err != nil {
+			t.Error(err)
+		}
+
+		<-time.After(25 * time.Millisecond)
+		if _, _, err := c.Context(ctx).Get(key); err == nil {
+			t.Error("expected to get no value from cache")
+		}
+	})
+
+	t.Run("CacheWithItems", func(t *testing.T) {
+		c := NewCache(Items(map[string]Item{key: {val, 0}}))
+
+		if a, _, err := c.Context(ctx).Get(key); err != nil {
+			t.Errorf("Expected a value, got err: %s", err)
+		} else if a != val {
+			t.Errorf("Expected '%v', got '%v'", val, a)
 		}
 	})
 }

--- a/cache/default.go
+++ b/cache/default.go
@@ -14,6 +14,11 @@ type memCache struct {
 	items map[string]Item
 }
 
+func (c *memCache) Context(ctx context.Context) Cache {
+	c.ctx = ctx
+	return c
+}
+
 func (c *memCache) Get(key string) (interface{}, time.Time, error) {
 	c.RWMutex.Lock()
 	defer c.RWMutex.Unlock()
@@ -31,6 +36,9 @@ func (c *memCache) Get(key string) (interface{}, time.Time, error) {
 
 func (c *memCache) Put(key string, val interface{}, d time.Duration) error {
 	var e int64
+	if d == DefaultExpiration {
+		d = c.opts.Expiration
+	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
 	}
@@ -57,9 +65,4 @@ func (c *memCache) Delete(key string) error {
 
 	delete(c.items, key)
 	return nil
-}
-
-func (c *memCache) Context(ctx context.Context) Cache {
-	c.ctx = ctx
-	return c
 }

--- a/cache/default.go
+++ b/cache/default.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type memCache struct {
+	opts Options
+	sync.RWMutex
+	ctx context.Context
+
+	items map[string]Item
+}
+
+func (c *memCache) Get(key string) (interface{}, time.Time, error) {
+	c.RWMutex.Lock()
+	defer c.RWMutex.Unlock()
+
+	item, found := c.items[key]
+	if !found {
+		return nil, time.Time{}, ErrKeyNotFound
+	}
+	if item.Expired() {
+		return nil, time.Time{}, ErrItemExpired
+	}
+
+	return item.Value, time.Unix(0, item.Expiration), nil
+}
+
+func (c *memCache) Put(key string, val interface{}, d time.Duration) error {
+	var e int64
+	if d > 0 {
+		e = time.Now().Add(d).UnixNano()
+	}
+
+	c.RWMutex.Lock()
+	defer c.RWMutex.Unlock()
+
+	c.items[key] = Item{
+		Value:      val,
+		Expiration: e,
+	}
+
+	return nil
+}
+
+func (c *memCache) Delete(key string) error {
+	c.RWMutex.Lock()
+	defer c.RWMutex.Unlock()
+
+	_, found := c.items[key]
+	if !found {
+		return ErrKeyNotFound
+	}
+
+	delete(c.items, key)
+	return nil
+}
+
+func (c *memCache) Context(ctx context.Context) Cache {
+	c.ctx = ctx
+	return c
+}

--- a/cache/options.go
+++ b/cache/options.go
@@ -1,5 +1,31 @@
 package cache
 
-type Options struct{}
+import "time"
 
+// Options represents the options for the cache.
+type Options struct {
+	Expiration time.Duration
+}
+
+// Option manipulates the Options passed.
 type Option func(o *Options)
+
+// Expiration sets the duration for items stored in the cache to expire.
+func Expiration(d time.Duration) Option {
+	return func(o *Options) {
+		o.Expiration = d
+	}
+}
+
+// NewOptions returns a new options struct.
+func NewOptions(opts ...Option) Options {
+	options := Options{
+		Expiration: DefaultExpiration,
+	}
+
+	for _, o := range opts {
+		o(&options)
+	}
+
+	return options
+}

--- a/cache/options.go
+++ b/cache/options.go
@@ -1,0 +1,5 @@
+package cache
+
+type Options struct{}
+
+type Option func(o *Options)

--- a/cache/options.go
+++ b/cache/options.go
@@ -5,6 +5,7 @@ import "time"
 // Options represents the options for the cache.
 type Options struct {
 	Expiration time.Duration
+	Items      map[string]Item
 }
 
 // Option manipulates the Options passed.
@@ -17,10 +18,18 @@ func Expiration(d time.Duration) Option {
 	}
 }
 
+// Items initializes the cache with preconfigured items.
+func Items(i map[string]Item) Option {
+	return func(o *Options) {
+		o.Items = i
+	}
+}
+
 // NewOptions returns a new options struct.
 func NewOptions(opts ...Option) Options {
 	options := Options{
 		Expiration: DefaultExpiration,
+		Items:      make(map[string]Item),
 	}
 
 	for _, o := range opts {

--- a/cache/options_test.go
+++ b/cache/options_test.go
@@ -9,9 +9,10 @@ func TestOptions(t *testing.T) {
 	testData := map[string]struct {
 		set        bool
 		expiration time.Duration
+		items      map[string]Item
 	}{
-		"DefaultOptions":  {false, DefaultExpiration},
-		"ModifiedOptions": {true, time.Second},
+		"DefaultOptions":  {false, DefaultExpiration, map[string]Item{}},
+		"ModifiedOptions": {true, time.Second, map[string]Item{"test": {"hello go-micro", 0}}},
 	}
 
 	for k, d := range testData {
@@ -21,6 +22,7 @@ func TestOptions(t *testing.T) {
 			if d.set {
 				opts = NewOptions(
 					Expiration(d.expiration),
+					Items(d.items),
 				)
 			} else {
 				opts = NewOptions()
@@ -30,6 +32,10 @@ func TestOptions(t *testing.T) {
 			for _, o := range []Options{opts} {
 				if o.Expiration != d.expiration {
 					t.Fatalf("Expected expiration '%v', got '%v'", d.expiration, o.Expiration)
+				}
+
+				if o.Items["test"] != d.items["test"] {
+					t.Fatalf("Expected items %#v, got %#v", d.items, o.Items)
 				}
 			}
 		})

--- a/cache/options_test.go
+++ b/cache/options_test.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOptions(t *testing.T) {
+	testData := map[string]struct {
+		set        bool
+		expiration time.Duration
+	}{
+		"DefaultOptions":  {false, DefaultExpiration},
+		"ModifiedOptions": {true, time.Second},
+	}
+
+	for k, d := range testData {
+		t.Run(k, func(t *testing.T) {
+			var opts Options
+
+			if d.set {
+				opts = NewOptions(
+					Expiration(d.expiration),
+				)
+			} else {
+				opts = NewOptions()
+			}
+
+			// test options
+			for _, o := range []Options{opts} {
+				if o.Expiration != d.expiration {
+					t.Fatalf("Expected expiration '%v', got '%v'", d.expiration, o.Expiration)
+				}
+			}
+		})
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/asim/go-micro/v3/auth"
 	"github.com/asim/go-micro/v3/broker"
+	"github.com/asim/go-micro/v3/cache"
 	"github.com/asim/go-micro/v3/client"
 	"github.com/asim/go-micro/v3/config"
 	"github.com/asim/go-micro/v3/debug/profile"
@@ -265,6 +266,8 @@ var (
 	}
 
 	DefaultConfigs = map[string]func(...config.Option) (config.Config, error){}
+
+	DefaultCaches = map[string]func(...cache.Option) cache.Cache{}
 )
 
 func init() {
@@ -285,6 +288,7 @@ func newCmd(opts ...Option) Cmd {
 		Tracer:    &trace.DefaultTracer,
 		Profile:   &profile.DefaultProfile,
 		Config:    &config.DefaultConfig,
+		Cache:     &cache.DefaultCache,
 
 		Brokers:    DefaultBrokers,
 		Clients:    DefaultClients,
@@ -298,6 +302,7 @@ func newCmd(opts ...Option) Cmd {
 		Auths:      DefaultAuths,
 		Profiles:   DefaultProfiles,
 		Configs:    DefaultConfigs,
+		Caches:     DefaultCaches,
 	}
 
 	for _, o := range opts {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/asim/go-micro/v3/auth"
 	"github.com/asim/go-micro/v3/broker"
+	"github.com/asim/go-micro/v3/cache"
 	"github.com/asim/go-micro/v3/client"
 	"github.com/asim/go-micro/v3/config"
 	"github.com/asim/go-micro/v3/debug/profile"
@@ -28,6 +29,7 @@ type Options struct {
 	Registry  *registry.Registry
 	Selector  *selector.Selector
 	Transport *transport.Transport
+	Cache     *cache.Cache
 	Config    *config.Config
 	Client    *client.Client
 	Server    *server.Server
@@ -38,6 +40,7 @@ type Options struct {
 	Profile   *profile.Profile
 
 	Brokers    map[string]func(...broker.Option) broker.Broker
+	Caches     map[string]func(...cache.Option) cache.Cache
 	Configs    map[string]func(...config.Option) (config.Config, error)
 	Clients    map[string]func(...client.Option) client.Client
 	Registries map[string]func(...registry.Option) registry.Registry
@@ -79,6 +82,12 @@ func Version(v string) Option {
 func Broker(b *broker.Broker) Option {
 	return func(o *Options) {
 		o.Broker = b
+	}
+}
+
+func Cache(c *cache.Cache) Option {
+	return func(o *Options) {
+		o.Cache = c
 	}
 }
 
@@ -152,6 +161,13 @@ func Profile(p *profile.Profile) Option {
 func NewBroker(name string, b func(...broker.Option) broker.Broker) Option {
 	return func(o *Options) {
 		o.Brokers[name] = b
+	}
+}
+
+// New cache func
+func NewCache(name string, c func(...cache.Option) cache.Cache) Option {
+	return func(o *Options) {
+		o.Caches[name] = c
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/asim/go-micro/v3/auth"
 	"github.com/asim/go-micro/v3/broker"
+	"github.com/asim/go-micro/v3/cache"
 	"github.com/asim/go-micro/v3/client"
 	"github.com/asim/go-micro/v3/cmd"
 	"github.com/asim/go-micro/v3/config"
@@ -24,6 +25,7 @@ import (
 type Options struct {
 	Auth      auth.Auth
 	Broker    broker.Broker
+	Cache     cache.Cache
 	Cmd       cmd.Cmd
 	Config    config.Config
 	Client    client.Client
@@ -51,6 +53,7 @@ func newOptions(opts ...Option) Options {
 	opt := Options{
 		Auth:      auth.DefaultAuth,
 		Broker:    broker.DefaultBroker,
+		Cache:     cache.DefaultCache,
 		Cmd:       cmd.DefaultCmd,
 		Config:    config.DefaultConfig,
 		Client:    client.DefaultClient,
@@ -77,6 +80,12 @@ func Broker(b broker.Broker) Option {
 		// Update Client and Server
 		o.Client.Init(client.Broker(b))
 		o.Server.Init(server.Broker(b))
+	}
+}
+
+func Cache(c cache.Cache) Option {
+	return func(o *Options) {
+		o.Cache = c
 	}
 }
 


### PR DESCRIPTION
This PR adds a `cache` package with a default in-memory cache implementation registered in the `micro` and `cmd` packages. The `cache` package is fully documented and tested.

Closes #2227.