### PR TITLE
Add Kubernetes resources

### DIFF
--- a/cmd/gomu/cmd/cli/new/new.go
+++ b/cmd/gomu/cmd/cli/new/new.go
@@ -113,8 +113,12 @@ func createProject(ctx *cli.Context, fn bool) error {
 
 	if ctx.Bool("skaffold") {
 		files = append(files, []file{
+			{"plugins.go", tmpl.Plugins},
+			{"resources/clusterrole.yaml", tmpl.KubernetesClusterRole},
+			{"resources/configmap.yaml", tmpl.KubernetesEnv},
+			{"resources/deployment.yaml", tmpl.KubernetesDeployment},
+			{"resources/rolebinding.yaml", tmpl.KubernetesRoleBinding},
 			{"skaffold.yaml", tmpl.SkaffoldCFG},
-			{"resources/deployment.yaml", tmpl.KubernetesDEP},
 		}...)
 	}
 

--- a/cmd/gomu/cmd/cli/new/new.go
+++ b/cmd/gomu/cmd/cli/new/new.go
@@ -114,7 +114,7 @@ func createProject(ctx *cli.Context, fn bool) error {
 	if ctx.Bool("skaffold") {
 		files = append(files, []file{
 			{"skaffold.yaml", tmpl.SkaffoldCFG},
-			{"resources/deployment.yaml", tmpl.SkaffoldDEP},
+			{"resources/deployment.yaml", tmpl.KubernetesDEP},
 		}...)
 	}
 

--- a/cmd/gomu/cmd/cli/new/template/kubernetes.go
+++ b/cmd/gomu/cmd/cli/new/template/kubernetes.go
@@ -1,0 +1,26 @@
+package template
+
+// KubernetesDEP is the Kubernetes deployment manifest template used for new
+// projects.
+var KubernetesDEP = `---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Alias}}
+  labels:
+    app: {{.Alias}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Alias}}
+  template:
+    metadata:
+      labels:
+        app: {{.Alias}}
+    spec:
+      containers:
+      - name: {{.Alias}}
+        image: {{.Alias}}:latest
+`

--- a/cmd/gomu/cmd/cli/new/template/kubernetes.go
+++ b/cmd/gomu/cmd/cli/new/template/kubernetes.go
@@ -1,8 +1,57 @@
 package template
 
-// KubernetesDEP is the Kubernetes deployment manifest template used for new
-// projects.
-var KubernetesDEP = `---
+// KubernetesEnv is a Kubernetes configmap manifest template used for
+// environment variables in new projects.
+var KubernetesEnv = `---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.Alias}}-env
+data:
+  MICRO_REGISTRY: kubernetes
+`
+
+// KubernetesClusterRole is a Kubernetes cluster role manifest template
+// required for the Kubernetes registry plugin to function correctly.
+var KubernetesClusterRole = `---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: micro-registry
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - patch
+  - watch
+`
+
+// KubernetesRoleBinding is a Kubernetes role binding manifest template
+// required for the Kubernetes registry plugin to function correctly.
+var KubernetesRoleBinding = `---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: micro-registry
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: micro-registry
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+`
+
+// KubernetesDeployment is a Kubernetes deployment manifest template used for
+// new projects.
+var KubernetesDeployment = `---
 
 apiVersion: apps/v1
 kind: Deployment
@@ -23,4 +72,7 @@ spec:
       containers:
       - name: {{.Alias}}
         image: {{.Alias}}:latest
+        envFrom:
+        - configMapRef:
+            name: {{.Alias}}-env
 `

--- a/cmd/gomu/cmd/cli/new/template/plugins.go
+++ b/cmd/gomu/cmd/cli/new/template/plugins.go
@@ -1,0 +1,9 @@
+package template
+
+// Plugins is the plugins template used for new projects.
+var Plugins = `package main
+
+import (
+	_ "github.com/asim/go-micro/plugins/registry/kubernetes/v3"
+)
+`

--- a/cmd/gomu/cmd/cli/new/template/skaffold.go
+++ b/cmd/gomu/cmd/cli/new/template/skaffold.go
@@ -15,28 +15,3 @@ deploy:
     manifests:
     - resources/*.yaml
 `
-
-// SkaffoldDEP is the Kubernetes deployment manifest template used for new
-// projects.
-var SkaffoldDEP = `---
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{.Alias}}
-  labels:
-    app: {{.Alias}}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: {{.Alias}}
-  template:
-    metadata:
-      labels:
-        app: {{.Alias}}
-    spec:
-      containers:
-      - name: {{.Alias}}
-        image: {{.Alias}}:latest
-`


### PR DESCRIPTION
This PR adds extra Kubernetes resources when generating projects using [Gomu][1]. In combination with the `--skaffold` flag, `gomu new <function|service> --skaffold <name>` will generate just enough to have `skaffold dev` deploy the service on a Kubernetes cluster that registers itself using Go Micro's [Kubernetes plugin][2].

[1]: https://github.com/asim/go-micro/tree/master/cmd/gomu
[2]: https://github.com/asim/go-micro/tree/master/plugins/registry/kubernetes