### PR TITLE
Add grpc,memory,quic transport automatically discover

### DIFF
--- a/plugins/transport/grpc/grpc.go
+++ b/plugins/transport/grpc/grpc.go
@@ -10,7 +10,7 @@ import (
 	maddr "github.com/asim/go-micro/v3/util/addr"
 	mnet "github.com/asim/go-micro/v3/util/net"
 	mls "github.com/asim/go-micro/v3/util/tls"
-
+	"github.com/asim/go-micro/v3/cmd"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 

--- a/plugins/transport/grpc/grpc.go
+++ b/plugins/transport/grpc/grpc.go
@@ -27,6 +27,10 @@ type grpcTransportListener struct {
 	tls      *tls.Config
 }
 
+func init() {
+	cmd.DefaultTransports["grpc"] = NewTransport
+}
+
 func getTLSConfig(addr string) (*tls.Config, error) {
 	hosts := []string{addr}
 

--- a/plugins/transport/memory/memory.go
+++ b/plugins/transport/memory/memory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/asim/go-micro/v3/transport"
 	maddr "github.com/asim/go-micro/v3/util/addr"
 	mnet "github.com/asim/go-micro/v3/util/net"
+	"github.com/asim/go-micro/v3/cmd"
 )
 
 type memorySocket struct {

--- a/plugins/transport/memory/memory.go
+++ b/plugins/transport/memory/memory.go
@@ -53,6 +53,10 @@ type memoryTransport struct {
 	listeners map[string]*memoryListener
 }
 
+func init() {
+	cmd.DefaultTransports["memory"] = NewTransport
+}
+
 func (ms *memorySocket) Recv(m *transport.Message) error {
 	ms.RLock()
 	defer ms.RUnlock()

--- a/plugins/transport/quic/quic.go
+++ b/plugins/transport/quic/quic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/gob"
+	"github.com/asim/go-micro/v3/cmd"
 	"time"
 
 	"github.com/asim/go-micro/v3/transport"
@@ -32,6 +33,10 @@ type quicListener struct {
 	l    quic.Listener
 	t    *quicTransport
 	opts transport.ListenOptions
+}
+
+func init() {
+	cmd.DefaultTransports["quic"] = NewTransport
 }
 
 func (q *quicClient) Close() error {


### PR DESCRIPTION
When I use Transport, I found that `init` functions for `grpc`, `memory`, `quic`, which didn't load in the init function, causing me to execute `--transport` in the command command, so I added an initialized `init` method for initialization.
