### PR TITLE
Fix Gomu's call response

### DIFF
--- a/cmd/gomu/cmd/cli/call/call.go
+++ b/cmd/gomu/cmd/cli/call/call.go
@@ -47,7 +47,7 @@ func RunCall(ctx *cli.Context) error {
 	c := srv.Client()
 
 	request := c.NewRequest(service, endpoint, creq, client.WithContentType("application/json"))
-	response := map[string]string{}
+	var response map[string]interface{}
 
 	if err := c.Call(context.Background(), request, &response); err != nil {
 		return err


### PR DESCRIPTION
`gomu call` expects a `map[string]string` type response back, but this isn't
always the case. When Gomu calls a service endpoint that responds with,
let's say, a key where its value is a map or a list, Gomu would be
unable to decode that response. By expecting a `map[string]interface{}`
type response, Gomu is able to decode those responses as well.
