### PR TITLE
Config CORS

### DIFF
--- a/api/server/cors/cors.go
+++ b/api/server/cors/cors.go
@@ -4,41 +4,52 @@ import (
 	"net/http"
 )
 
+type Config struct {
+	AllowOrigin      string
+	AllowCredentials bool
+	AllowMethods     string
+	AllowHeaders     string
+}
+
 // CombinedCORSHandler wraps a server and provides CORS headers
-func CombinedCORSHandler(h http.Handler) http.Handler {
-	return corsHandler{h}
-}
+func CombinedCORSHandler(h http.Handler, config *Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SetHeaders(w, r, config)
+		if r.Method == "OPTIONS" {
+			return
+		}
 
-type corsHandler struct {
-	handler http.Handler
-}
-
-func (c corsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	SetHeaders(w, r)
-
-	if r.Method == "OPTIONS" {
-		return
-	}
-
-	c.handler.ServeHTTP(w, r)
+		h.ServeHTTP(w, r)
+	})
 }
 
 // SetHeaders sets the CORS headers
-func SetHeaders(w http.ResponseWriter, r *http.Request) {
+func SetHeaders(w http.ResponseWriter, _ *http.Request, config *Config) {
 	set := func(w http.ResponseWriter, k, v string) {
 		if v := w.Header().Get(k); len(v) > 0 {
 			return
 		}
 		w.Header().Set(k, v)
 	}
-
-	if origin := r.Header.Get("Origin"); len(origin) > 0 {
-		set(w, "Access-Control-Allow-Origin", origin)
+	//For forward-compatible code, default values may not be provided in the future
+	if config.AllowCredentials {
+		set(w, "Access-Control-Allow-Credentials", "true")
 	} else {
-		set(w, "Access-Control-Allow-Origin", "*")
+		set(w, "Access-Control-Allow-Credentials", "false")
 	}
-
-	set(w, "Access-Control-Allow-Credentials", "true")
-	set(w, "Access-Control-Allow-Methods", "POST, PATCH, GET, OPTIONS, PUT, DELETE")
-	set(w, "Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	if config.AllowOrigin == "" {
+		set(w, "Access-Control-Allow-Origin", "*")
+	} else {
+		set(w, "Access-Control-Allow-Origin", config.AllowOrigin)
+	}
+	if config.AllowMethods == "" {
+		set(w, "Access-Control-Allow-Methods", "POST, PATCH, GET, OPTIONS, PUT, DELETE")
+	} else {
+		set(w, "Access-Control-Allow-Methods", config.AllowMethods)
+	}
+	if config.AllowHeaders == "" {
+		set(w, "Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	} else {
+		set(w, "Access-Control-Allow-Headers", config.AllowHeaders)
+	}
 }

--- a/api/server/cors/cors.go
+++ b/api/server/cors/cors.go
@@ -14,7 +14,9 @@ type Config struct {
 // CombinedCORSHandler wraps a server and provides CORS headers
 func CombinedCORSHandler(h http.Handler, config *Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		SetHeaders(w, r, config)
+		if config != nil {
+			SetHeaders(w, r, config)
+		}
 		if r.Method == "OPTIONS" {
 			return
 		}

--- a/api/server/http/http.go
+++ b/api/server/http/http.go
@@ -60,7 +60,7 @@ func (s *httpServer) Handle(path string, handler http.Handler) {
 
 	// wrap with cors
 	if s.opts.EnableCORS {
-		handler = cors.CombinedCORSHandler(handler)
+		handler = cors.CombinedCORSHandler(handler, s.opts.CORSConfig)
 	}
 
 	// wrap with logger

--- a/api/server/http/http_test.go
+++ b/api/server/http/http_test.go
@@ -2,8 +2,8 @@ package http
 
 import (
 	"fmt"
-	"github.com/micro/go-micro/v2/api/server"
-	"github.com/micro/go-micro/v2/api/server/cors"
+	"github.com/asim/go-micro/v3/api/server"
+	"github.com/asim/go-micro/v3/api/server/cors"
 	"io/ioutil"
 	"net/http"
 	"testing"

--- a/api/server/http/http_test.go
+++ b/api/server/http/http_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"fmt"
+	"github.com/micro/go-micro/v2/api/server"
+	"github.com/micro/go-micro/v2/api/server/cors"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -33,6 +35,77 @@ func TestHTTPServer(t *testing.T) {
 
 	if string(b) != testResponse {
 		t.Fatalf("Unexpected response, got %s, expected %s", string(b), testResponse)
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCORSHTTPServer(t *testing.T) {
+	testResponse := "hello world"
+	testAllowOrigin := "*"
+	testAllowCredentials := true
+	testAllowMethods := "GET"
+	testAllowHeaders := "Accept, Content-Type, Content-Length"
+
+	s := NewServer("localhost:0",
+		server.EnableCORS(true),
+		server.CORSConfig(&cors.Config{
+			AllowCredentials: testAllowCredentials,
+			AllowOrigin:      testAllowOrigin,
+			AllowMethods:     testAllowMethods,
+			AllowHeaders:     testAllowHeaders,
+		}),
+	)
+
+	s.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testResponse)
+	}))
+
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	rsp, err := http.Get(fmt.Sprintf("http://%s/", s.Address()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rsp.Body.Close()
+
+	b, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != testResponse {
+		t.Fatalf("Unexpected response, got %s, expected %s", string(b), testResponse)
+	}
+
+	allowCredentials := rsp.Header.Get("Access-Control-Allow-Credentials")
+	getTestCredentialsStr := func() string {
+		if testAllowCredentials == true {
+			return "true"
+		} else {
+			return "false"
+		}
+	}
+	if getTestCredentialsStr() != allowCredentials {
+		t.Fatalf("Unexpected Access-Control-Allow-Credentials, got %s, expected %s", allowCredentials, getTestCredentialsStr())
+	}
+
+	allowOrigin := rsp.Header.Get("Access-Control-Allow-Origin")
+	if testAllowOrigin != allowOrigin {
+		t.Fatalf("Unexpected Access-Control-Allow-Origins, got %s, expected %s", allowOrigin, testAllowOrigin)
+	}
+
+	allowMethods := rsp.Header.Get("Access-Control-Allow-Methods")
+	if testAllowMethods != allowMethods {
+		t.Fatalf("Unexpected Access-Control-Allow-Methods, got %s, expected %s", allowMethods, testAllowMethods)
+	}
+	allowHeaders := rsp.Header.Get("Access-Control-Allow-Headers")
+	if testAllowHeaders != allowHeaders {
+		t.Fatalf("Unexpected Access-Control-Allow-Headers, got %s, expected %s", allowHeaders, testAllowHeaders)
 	}
 
 	if err := s.Stop(); err != nil {

--- a/api/server/options.go
+++ b/api/server/options.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"crypto/tls"
-	"github.com/micro/go-micro/v2/api/server/cors"
+	"github.com/asim/go-micro/v3/api/server/cors"
 	"net/http"
 
 	"github.com/asim/go-micro/v3/api/resolver"

--- a/api/server/options.go
+++ b/api/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/tls"
+	"github.com/micro/go-micro/v2/api/server/cors"
 	"net/http"
 
 	"github.com/micro/go-micro/v2/api/resolver"
@@ -13,6 +14,7 @@ type Option func(o *Options)
 type Options struct {
 	EnableACME   bool
 	EnableCORS   bool
+	CORSConfig   *cors.Config
 	ACMEProvider acme.Provider
 	EnableTLS    bool
 	ACMEHosts    []string
@@ -32,6 +34,12 @@ func WrapHandler(w Wrapper) Option {
 func EnableCORS(b bool) Option {
 	return func(o *Options) {
 		o.EnableCORS = b
+	}
+}
+
+func CORSConfig(c *cors.Config) Option {
+	return func(o *Options) {
+		o.CORSConfig = c
 	}
 }
 


### PR DESCRIPTION
###  FEATURES
Add parameters for CORS to micro/micro can input args on commandline.

### Why need
#### CORS parameters are not fixed when using http server.


E.g
    my project need http head: 
```
  Access-Control-Allow-Origin: *.mydomin.com
    Access-Control-Allow-Headers: token,ver,uuid,sign,t,type,Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,X-Requested-With
    Access-Control-Allow-Headers: POST, OPTIONS
```

#### MICRO's Web/API/RPC modules no longer need to implement CORS repeatedly in v2 version.
https://github.com/micro/micro/blob/77504c21e6bfeacf8828a7a110dac41b3aa9949a/client/web/web.go#L256
https://github.com/micro/micro/blob/77504c21e6bfeacf8828a7a110dac41b3aa9949a/internal/handler/rpc.go#L29

I am work in v2.9.1. 
