### PR TITLE
Fix and improvement for logger.Helper

### DIFF
--- a/logger/default.go
+++ b/logger/default.go
@@ -19,7 +19,7 @@ func init() {
 		lvl = InfoLevel
 	}
 
-	DefaultLogger = NewHelper(NewLogger(WithLevel(lvl)))
+	DefaultLogger = NewLogger(WithLevel(lvl))
 }
 
 type defaultLogger struct {
@@ -41,9 +41,23 @@ func (l *defaultLogger) String() string {
 
 func (l *defaultLogger) Fields(fields map[string]interface{}) Logger {
 	l.Lock()
-	l.opts.Fields = copyFields(fields)
+	nfields := make(map[string]interface{}, len(l.opts.Fields))
+	for k, v := range l.opts.Fields {
+		nfields[k] = v
+	}
 	l.Unlock()
-	return l
+
+	for k, v := range fields {
+		nfields[k] = v
+	}
+
+	return &defaultLogger{opts: Options{
+		Level:           l.opts.Level,
+		Fields:          nfields,
+		Out:             l.opts.Out,
+		CallerSkipCount: l.opts.CallerSkipCount,
+		Context:         l.opts.Context,
+	}}
 }
 
 func copyFields(src map[string]interface{}) map[string]interface{} {

--- a/logger/helper.go
+++ b/logger/helper.go
@@ -1,93 +1,104 @@
 package logger
 
 import (
+	"context"
 	"os"
 )
 
 type Helper struct {
 	Logger
-	fields map[string]interface{}
 }
 
 func NewHelper(log Logger) *Helper {
 	return &Helper{Logger: log}
 }
 
+// Extract always returns valid Helper with logger from context or with DefaultLogger as fallback.
+// Can be used in pair with function NewContext(ctx context.Context, l Logger) context.Context.
+// (e.g. propagate RequestID to logger in service handler methods).
+func Extract(ctx context.Context) *Helper {
+	if l, ok := FromContext(ctx); ok {
+		return NewHelper(l)
+	}
+
+	return NewHelper(DefaultLogger)
+}
+
 func (h *Helper) Info(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(InfoLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(InfoLevel, args...)
+	h.Log(InfoLevel, args...)
 }
 
 func (h *Helper) Infof(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(InfoLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(InfoLevel, template, args...)
+	h.Logf(InfoLevel, template, args...)
 }
 
 func (h *Helper) Trace(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(TraceLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(TraceLevel, args...)
+	h.Log(TraceLevel, args...)
 }
 
 func (h *Helper) Tracef(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(TraceLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(TraceLevel, template, args...)
+	h.Logf(TraceLevel, template, args...)
 }
 
 func (h *Helper) Debug(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(DebugLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(DebugLevel, args...)
+	h.Log(DebugLevel, args...)
 }
 
 func (h *Helper) Debugf(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(DebugLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(DebugLevel, template, args...)
+	h.Logf(DebugLevel, template, args...)
 }
 
 func (h *Helper) Warn(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(WarnLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(WarnLevel, args...)
+	h.Log(WarnLevel, args...)
 }
 
 func (h *Helper) Warnf(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(WarnLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(WarnLevel, template, args...)
+	h.Logf(WarnLevel, template, args...)
 }
 
 func (h *Helper) Error(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(ErrorLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(ErrorLevel, args...)
+	h.Log(ErrorLevel, args...)
 }
 
 func (h *Helper) Errorf(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(ErrorLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(ErrorLevel, template, args...)
+	h.Logf(ErrorLevel, template, args...)
 }
 
 func (h *Helper) Fatal(args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(FatalLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Log(FatalLevel, args...)
+	h.Log(FatalLevel, args...)
 	os.Exit(1)
 }
 
@@ -95,20 +106,14 @@ func (h *Helper) Fatalf(template string, args ...interface{}) {
 	if !h.Logger.Options().Level.Enabled(FatalLevel) {
 		return
 	}
-	h.Logger.Fields(h.fields).Logf(FatalLevel, template, args...)
+	h.Logf(FatalLevel, template, args...)
 	os.Exit(1)
 }
 
 func (h *Helper) WithError(err error) *Helper {
-	fields := copyFields(h.fields)
-	fields["error"] = err
-	return &Helper{Logger: h.Logger, fields: fields}
+	return &Helper{Logger: h.Logger.Fields(map[string]interface{}{"error": err})}
 }
 
 func (h *Helper) WithFields(fields map[string]interface{}) *Helper {
-	nfields := copyFields(fields)
-	for k, v := range h.fields {
-		nfields[k] = v
-	}
-	return &Helper{Logger: h.Logger, fields: nfields}
+	return &Helper{Logger: h.Logger.Fields(fields)}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,7 +3,7 @@ package logger
 
 var (
 	// Default logger
-	DefaultLogger Logger = NewHelper(NewLogger())
+	DefaultLogger Logger = NewLogger()
 )
 
 // Logger is a generic logging interface

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,18 +1,32 @@
 package logger
 
 import (
+	"context"
 	"testing"
 )
 
 func TestLogger(t *testing.T) {
 	l := NewLogger(WithLevel(TraceLevel))
 	h1 := NewHelper(l).WithFields(map[string]interface{}{"key1": "val1"})
+	h1.Log(TraceLevel, "simple log before trace_msg1")
 	h1.Trace("trace_msg1")
+	h1.Log(TraceLevel, "simple log after trace_msg1")
 	h1.Warn("warn_msg1")
 
 	h2 := NewHelper(l).WithFields(map[string]interface{}{"key2": "val2"})
+	h2.Logf(TraceLevel, "formatted log before trace_msg%s", "2")
 	h2.Trace("trace_msg2")
+	h2.Logf(TraceLevel, "formatted log after trace_msg%s", "2")
 	h2.Warn("warn_msg2")
 
 	l.Fields(map[string]interface{}{"key3": "val4"}).Log(InfoLevel, "test_msg")
+}
+
+func TestExtract(t *testing.T) {
+	l := NewLogger(WithLevel(TraceLevel)).Fields(map[string]interface{}{"requestID": "req-1"})
+
+	ctx := NewContext(context.Background(), l)
+
+	Info("info message without request ID")
+	Extract(ctx).Info("info message with request ID")
 }


### PR DESCRIPTION
Issue: `logger.Helper` struct contains redundant `fields map[string]interface{}` field which causes problems. 

Here is modified `TestLogger` function from `logger_test.go` that shows the problem:
```
func TestLogger(t *testing.T) {
	l := NewLogger(WithLevel(TraceLevel))
	h1 := NewHelper(l).WithFields(map[string]interface{}{"key1": "val1"})
	h1.Log(TraceLevel, "simple log before trace_msg1") // This is a new line
	h1.Trace("trace_msg1")
	h1.Log(TraceLevel, "simple log after trace_msg1")  // This is a new line
	h1.Warn("warn_msg1")

	h2 := NewHelper(l).WithFields(map[string]interface{}{"key2": "val2"})
	h2.Logf(TraceLevel, "formatted log before trace_msg%s", "2")  // This is a new line
	h2.Trace("trace_msg2")
	h2.Logf(TraceLevel, "formatted log after trace_msg%s", "2")  // This is a new line
	h2.Warn("warn_msg2")

	l.Fields(map[string]interface{}{"key3": "val4"}).Log(InfoLevel, "test_msg")
}
```
Just 4 new lines in function with calls: `Helper.Log(level Level, v ...interface{})` and `Helper.Logf(level Level, format string, v ...interface{})`. Output is following:
```
file=testing/testing.go:1193 level=trace simple log before trace_msg1
file=logger/logger_test.go:11 key1=val1 level=trace trace_msg1
file=testing/testing.go:1193 key1=val1 level=trace simple log after trace_msg1
file=logger/logger_test.go:13 key1=val1 level=warn warn_msg1
file=testing/testing.go:1193 key1=val1 level=trace formatted log before trace_msg2
file=logger/logger_test.go:17 key2=val2 level=trace trace_msg2
file=testing/testing.go:1193 key2=val2 level=trace formatted log after trace_msg2
file=logger/logger_test.go:19 key2=val2 level=warn warn_msg2
file=testing/testing.go:1193 key3=val4 level=info test_msg
```

For first log statement `h1.Log(TraceLevel, "simple log before trace_msg1")` we do not see `key1=val1` property, 
but for next `h1.Log(TraceLevel, "simple log after trace_msg1")` we already have `key1=val1` in log output. This is because in between we had `h1.Trace("trace_msg1")`.
Also note output for `h2.Logf(TraceLevel, "formatted log before trace_msg%s", "2")` statement: `"key1=val1 level=trace formatted log before trace_msg2"` - we see here "key1=val1" (this field from h1 !!).

We have all these problems because Helper has its own `fields map[string]interface{}`, but in fact Helper should be just decorator and provides handy Info/Trace/etc. methods.
In addition to these problems every time we call, for example, Helper.Trace("some message") we have to build new logger with Fields. This is not ideal from performance point of view, since this operation requires a number of allocations/map copies (and we do it for each log statement).



**To address these issues, the following changes have been made:**
- `fields map[string]interface{}` was removed from Helper
- `Helper.WithError` / `Helper.WithFields` methods return `Helper` instance with `h.Logger.Fields(...)`, so logger itself will contain required fields. I've checked git-history and initially Helper worked in exactly this way - just nice and small "decorator" #1272 / #1273
- After above update one issue was found in logger.default.go Fields method:
```
func (l *defaultLogger) Fields(fields map[string]interface{}) Logger {
	l.Lock()
	l.opts.Fields = copyFields(fields)
	l.Unlock()
	return l
}
```
New fields were just set to current logger instance (maybe it was the actual initial reason, why fields map was added to `Helper`). This method was updated to be consistent with all other logger plugins (apex, logrus, zap, zerolog) - Fields method returns new instance of logger with merged fields.

**In addition 2 small updates were done:**
- Value for `DefaultLogger` is a bit confusing, since it is set with `NewHelper` wrapper:
`DefaultLogger Logger = NewHelper(NewLogger())`
But since `DefaultLogger` has `Logger` type it won't be possible to use `Helper` methods, so it doesn't make sense to have `NewHelper` wrapper here. So it was updated to: `DefaultLogger Logger = NewLogger()`

- Added new function `Extract(ctx context.Context) *Helper` - it always returns valid Helper with logger from context or with DefaultLogger as fallback. This function is very useful in service handlers were we can log something with "request context data" (of course, to achieve this first of all we should have some handler wrapper on service level that will put logger with fields to context). Here is just an example of how it looks in server handler:
```
func (h *SomeService) SomeAction(ctx context.Context, req *pb.SomeRequest, rsp *pb.SomeResponse) {
    data, _ := getDataFromStorage(req)
    logger.Extract(ctx).Debugf("SomeAction: found %d records", len(data))
    /*...*/
}
```
Really nice is that we have same interface for "global logger" from package level `logger.Debugf(...)` and for context specific log `logger.Extract(ctx).Debugf(...)`




