### PR TITLE
Use context to log "panic recovered" errors in grpc-server plugin #2269

### DIFF
--- a/plugins/server/grpc/grpc.go
+++ b/plugins/server/grpc/grpc.go
@@ -398,10 +398,7 @@ func (g *grpcServer) processRequest(stream grpc.ServerStream, service *service, 
 		fn := func(ctx context.Context, req server.Request, rsp interface{}) (err error) {
 			defer func() {
 				if r := recover(); r != nil {
-					if logger.V(logger.ErrorLevel, logger.DefaultLogger) {
-						logger.Error("panic recovered: ", r)
-						logger.Error(string(debug.Stack()))
-					}
+					logger.Extract(ctx).Errorf("panic recovered: %v, stack: %s", r, string(debug.Stack()))
 					err = errors.InternalServerError("go.micro.server", "panic recovered: %v", r)
 				}
 			}()


### PR DESCRIPTION
With new logger.Extract function we can log "panic recovered" errors in grpc server plugin with context data.

Closes #2269


