### PR TITLE
logger helper: add "inject" method, to make a pair with "extract"

### DIFF
--- a/logger/helper.go
+++ b/logger/helper.go
@@ -14,14 +14,18 @@ func NewHelper(logger Logger) *Helper {
 }
 
 // Extract always returns valid Helper with logger from context or with DefaultLogger as fallback.
-// Can be used in pair with function NewContext(ctx context.Context, l Logger) context.Context.
-// (e.g. propagate RequestID to logger in service handler methods).
+// Can be used in pair with function Inject.
+// Example: propagate RequestID to logger in service handler methods.
 func Extract(ctx context.Context) *Helper {
 	if l, ok := FromContext(ctx); ok {
 		return NewHelper(l)
 	}
 
 	return NewHelper(DefaultLogger)
+}
+
+func (h *Helper) Inject(ctx context.Context) context.Context {
+	return NewContext(ctx, h.logger)
 }
 
 func (h *Helper) Log(level Level, args ...interface{}) {


### PR DESCRIPTION
Adding "Inject" method to Helper, to work in pair with "Extract" while building log wrappers.

Now you can do following:

```
func LogSomething() server.HandlerWrapper {
	return func(h server.HandlerFunc) server.HandlerFunc {
		return func(ctx context.Context, req server.Request, rsp interface{}) error {
			l := logger.Extract(ctx)

			l.Infof("logger from context")

			l = l.WithFields(map[string]interface{}{
				"additional_field": "123",
			})

			ctx = l.Inject(ctx)
			
			return h(ctx, req, rsp)
		}
	}
}

```

