### PR TITLE
zap plugin: allow injecting zap logger options

### DIFF
--- a/plugins/logger/zap/options.go
+++ b/plugins/logger/zap/options.go
@@ -30,3 +30,9 @@ type namespaceKey struct{}
 func WithNamespace(namespace string) logger.Option {
 	return logger.SetOption(namespaceKey{}, namespace)
 }
+
+type optionsKey struct{}
+
+func WithOptions(opts ...zap.Option) logger.Option {
+	return logger.SetOption(optionsKey{}, opts)
+}

--- a/plugins/logger/zap/zap.go
+++ b/plugins/logger/zap/zap.go
@@ -62,6 +62,11 @@ func (l *zaplog) Init(opts ...logger.Option) error {
 		log = log.With(zap.Namespace(namespace))
 	}
 
+	// Adding options
+	if options, ok := l.opts.Context.Value(optionsKey{}).([]zap.Option); ok {
+		log = log.WithOptions(options...)
+	}
+
 	// defer log.Sync() ??
 
 	l.cfg = zapConfig


### PR DESCRIPTION
Though some of the Zap logger option can be customized through
plugins/logger/zap.Options, this change allows go.uber.org/zap.Option be
be injected directly for deeper customization.
