### PR TITLE
Replace ioutil with io and os

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/api/server/http/http_test.go
+++ b/api/server/http/http_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"go-micro.dev/v4/api/server"
 	"go-micro.dev/v4/api/server/cors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -28,7 +28,7 @@ func TestHTTPServer(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestCORSHTTPServer(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/broker/http.go
+++ b/broker/http.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -300,7 +299,7 @@ func (h *httpBroker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	req.ParseForm()
 
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		errr := merr.InternalServerError("go.micro.broker", "Error reading request body: %v", err)
 		w.WriteHeader(500)
@@ -558,7 +557,7 @@ func (h *httpBroker) Publish(topic string, msg *Message, opts ...PublishOption) 
 		}
 
 		// discard response body
-		io.Copy(ioutil.Discard, r.Body)
+		io.Copy(io.Discard, r.Body)
 		r.Body.Close()
 		return nil
 	}

--- a/cmd/protoc-gen-micro/main.go
+++ b/cmd/protoc-gen-micro/main.go
@@ -49,7 +49,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"go-micro.dev/v4/cmd/protoc-gen-micro/generator"
@@ -63,7 +63,7 @@ func main() {
 	// report failure.
 	g := generator.New()
 
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		g.Error(err, "reading input")
 	}

--- a/codec/bytes/bytes.go
+++ b/codec/bytes/bytes.go
@@ -4,7 +4,6 @@ package bytes
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"go-micro.dev/v4/codec"
 )
@@ -24,7 +23,7 @@ func (c *Codec) ReadHeader(m *codec.Message, t codec.MessageType) error {
 
 func (c *Codec) ReadBody(b interface{}) error {
 	// read bytes
-	buf, err := ioutil.ReadAll(c.Conn)
+	buf, err := io.ReadAll(c.Conn)
 	if err != nil {
 		return err
 	}

--- a/codec/proto/proto.go
+++ b/codec/proto/proto.go
@@ -3,7 +3,6 @@ package proto
 
 import (
 	"io"
-	"io/ioutil"
 
 	"go-micro.dev/v4/codec"
 	"github.com/golang/protobuf/proto"
@@ -21,7 +20,7 @@ func (c *Codec) ReadBody(b interface{}) error {
 	if b == nil {
 		return nil
 	}
-	buf, err := ioutil.ReadAll(c.Conn)
+	buf, err := io.ReadAll(c.Conn)
 	if err != nil {
 		return err
 	}

--- a/codec/text/text.go
+++ b/codec/text/text.go
@@ -4,7 +4,6 @@ package text
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"go-micro.dev/v4/codec"
 )
@@ -24,7 +23,7 @@ func (c *Codec) ReadHeader(m *codec.Message, t codec.MessageType) error {
 
 func (c *Codec) ReadBody(b interface{}) error {
 	// read bytes
-	buf, err := ioutil.ReadAll(c.Conn)
+	buf, err := io.ReadAll(c.Conn)
 	if err != nil {
 		return err
 	}

--- a/config/source/cli/cli.go
+++ b/config/source/cli/cli.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -119,7 +119,7 @@ func NewSource(opts ...source.Option) source.Source {
 		}
 
 		// parse flags
-		set.SetOutput(ioutil.Discard)
+		set.SetOutput(io.Discard)
 		set.Parse(os.Args[1:])
 
 		// normalise flags

--- a/config/source/file/file.go
+++ b/config/source/file/file.go
@@ -2,7 +2,7 @@
 package file
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"go-micro.dev/v4/config/source"
@@ -23,7 +23,7 @@ func (f *file) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 	defer fh.Close()
-	b, err := ioutil.ReadAll(fh)
+	b, err := io.ReadAll(fh)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/config/modify/modify.go
+++ b/examples/config/modify/modify.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"go-micro.dev/v4/config"
 	"github.com/asim/go-micro/plugins/config/encoder/toml/v4"
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	// write the file
-	if err := ioutil.WriteFile("./example.conf", v, 0644); err != nil {
+	if err := os.WriteFile("./example.conf", v, 0644); err != nil {
 		fmt.Println(err)
 		return
 	}

--- a/examples/greeter/cli/sidecar/sidecar.go
+++ b/examples/greeter/cli/sidecar/sidecar.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
@@ -24,7 +24,7 @@ func main() {
 	}
 	defer r.Body.Close()
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/plugins/auth/jwt/token/jwt_test.go
+++ b/plugins/auth/jwt/token/jwt_test.go
@@ -1,7 +1,7 @@
 package token
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	privKey, err := ioutil.ReadFile("test/sample_key")
+	privKey, err := os.ReadFile("test/sample_key")
 	if err != nil {
 		t.Fatalf("Unable to read private key: %v", err)
 	}
@@ -25,11 +25,11 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestInspect(t *testing.T) {
-	pubKey, err := ioutil.ReadFile("test/sample_key.pub")
+	pubKey, err := os.ReadFile("test/sample_key.pub")
 	if err != nil {
 		t.Fatalf("Unable to read public key: %v", err)
 	}
-	privKey, err := ioutil.ReadFile("test/sample_key")
+	privKey, err := os.ReadFile("test/sample_key")
 	if err != nil {
 		t.Fatalf("Unable to read private key: %v", err)
 	}

--- a/plugins/broker/http/http.go
+++ b/plugins/broker/http/http.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -304,7 +303,7 @@ func (h *httpBroker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	req.ParseForm()
 
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		errr := merr.InternalServerError("go.micro.broker", "Error reading request body: %v", err)
 		w.WriteHeader(500)
@@ -562,7 +561,7 @@ func (h *httpBroker) Publish(topic string, msg *broker.Message, opts ...broker.P
 		}
 
 		// discard response body
-		io.Copy(ioutil.Discard, r.Body)
+		io.Copy(io.Discard, r.Body)
 		r.Body.Close()
 		return nil
 	}

--- a/plugins/broker/proxy/proxy.go
+++ b/plugins/broker/proxy/proxy.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"go-micro.dev/v4/broker"
@@ -109,7 +108,7 @@ func (s *sidecar) Publish(topic string, msg *broker.Message, opts ...broker.Publ
 		}
 
 		// discard response
-		io.Copy(ioutil.Discard, rsp.Body)
+		io.Copy(io.Discard, rsp.Body)
 		rsp.Body.Close()
 
 		return nil

--- a/plugins/client/http/http.go
+++ b/plugins/client/http/http.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -137,7 +137,7 @@ func (h *httpClient) call(ctx context.Context, node *registry.Node, req client.R
 	defer hrsp.Body.Close()
 
 	// parse response
-	b, err = ioutil.ReadAll(hrsp.Body)
+	b, err = io.ReadAll(hrsp.Body)
 	if err != nil {
 		return errors.InternalServerError("go.micro.client", err.Error())
 	}

--- a/plugins/client/http/http_test.go
+++ b/plugins/client/http/http_test.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -41,7 +41,7 @@ func TestHTTPClient(t *testing.T) {
 			http.Error(w, "codec not found", 500)
 			return
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -146,7 +146,7 @@ func TestHTTPClientStream(t *testing.T) {
 			http.Error(w, "codec not found", 500)
 			return
 		}
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -191,7 +191,7 @@ func TestHTTPClientStream(t *testing.T) {
 				return
 			}
 
-			b, err = ioutil.ReadAll(r.Body)
+			b, err = io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, err.Error(), 500)
 				return

--- a/plugins/client/http/stream.go
+++ b/plugins/client/http/stream.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -102,7 +102,7 @@ func (h *httpStream) Recv(msg interface{}) error {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}

--- a/plugins/config/source/pkger/pkger.go
+++ b/plugins/config/source/pkger/pkger.go
@@ -1,7 +1,7 @@
 package pkger
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/markbates/pkger"
 	"go-micro.dev/v4/config/source"
@@ -22,7 +22,7 @@ func (f *file) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 	defer fh.Close()
-	b, err := ioutil.ReadAll(fh)
+	b, err := io.ReadAll(fh)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/config/source/url/url.go
+++ b/plugins/config/source/url/url.go
@@ -2,7 +2,7 @@
 package url
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -25,7 +25,7 @@ func (u *urlSource) Read() (*source.ChangeSet, error) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/proxy/http/http.go
+++ b/plugins/proxy/http/http.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -174,7 +173,7 @@ func (p *Router) ServeRequest(ctx context.Context, req server.Request, rsp serve
 		}
 
 		// read body
-		b, err := ioutil.ReadAll(hrsp.Body)
+		b, err := io.ReadAll(hrsp.Body)
 		hrsp.Body.Close()
 		if err != nil {
 			return errors.InternalServerError(req.Service(), err.Error())

--- a/plugins/registry/consul/encoding.go
+++ b/plugins/registry/consul/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/zlib"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"go-micro.dev/v4/registry"
 )
@@ -35,7 +35,7 @@ func decode(d string) []byte {
 		return nil
 	}
 
-	rbuf, err := ioutil.ReadAll(zr)
+	rbuf, err := io.ReadAll(zr)
 	if err != nil {
 		return nil
 	}

--- a/plugins/registry/gossip/gossip.go
+++ b/plugins/registry/gossip/gossip.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"strconv"
@@ -179,7 +179,7 @@ func configure(g *gossipRegistry, opts ...registry.Option) error {
 	c := memberlist.DefaultLocalConfig()
 
 	// sane good default options
-	c.LogOutput = ioutil.Discard // log to /dev/null
+	c.LogOutput = io.Discard // log to /dev/null
 	c.PushPullInterval = 0       // disable expensive tcp push/pull
 	c.ProtocolVersion = 4        // suport latest stable features
 

--- a/plugins/registry/kubernetes/client/api/response.go
+++ b/plugins/registry/kubernetes/client/api/response.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	log "go-micro.dev/v4/logger"
@@ -84,7 +84,7 @@ func newResponse(res *http.Response, err error) *Response {
 
 	log.Errorf("K8s: request failed with code %v", r.res.StatusCode)
 
-	b, err := ioutil.ReadAll(r.res.Body)
+	b, err := io.ReadAll(r.res.Body)
 	if err == nil {
 		log.Error("K8s: request failed with body:")
 		log.Error(string(b))

--- a/plugins/registry/kubernetes/client/client.go
+++ b/plugins/registry/kubernetes/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"crypto/tls"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -54,7 +53,7 @@ func detectNamespace() (string, error) {
 	}
 
 	// Read the file, and cast to a string
-	if ns, e := ioutil.ReadFile(nsPath); e != nil {
+	if ns, e := os.ReadFile(nsPath); e != nil {
 		return string(ns), e
 	} else {
 		return string(ns), nil
@@ -97,7 +96,7 @@ func NewClientInCluster() Kubernetes {
 		log.Fatal(errors.New("no k8s service account found"))
 	}
 
-	token, err := ioutil.ReadFile(path.Join(serviceAccountPath, "token"))
+	token, err := os.ReadFile(path.Join(serviceAccountPath, "token"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/plugins/registry/kubernetes/client/utils.go
+++ b/plugins/registry/kubernetes/client/utils.go
@@ -5,7 +5,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // COPIED FROM
@@ -31,7 +31,7 @@ func certificatesFromFile(file string) ([]*x509.Certificate, error) {
 	if len(file) == 0 {
 		return nil, errors.New("error reading certificates from an empty filename")
 	}
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/registry/proxy/proxy.go
+++ b/plugins/registry/proxy/proxy.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -75,7 +74,7 @@ func (s *proxy) Register(service *registry.Service, opts ...registry.RegisterOpt
 			continue
 		}
 		if rsp.StatusCode != 200 {
-			b, err := ioutil.ReadAll(rsp.Body)
+			b, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				return err
 			}
@@ -83,7 +82,7 @@ func (s *proxy) Register(service *registry.Service, opts ...registry.RegisterOpt
 			gerr = errors.New(string(b))
 			continue
 		}
-		io.Copy(ioutil.Discard, rsp.Body)
+		io.Copy(io.Discard, rsp.Body)
 		rsp.Body.Close()
 		return nil
 	}
@@ -117,7 +116,7 @@ func (s *proxy) Deregister(service *registry.Service, opts ...registry.Deregiste
 		}
 
 		if rsp.StatusCode != 200 {
-			b, err := ioutil.ReadAll(rsp.Body)
+			b, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				return err
 			}
@@ -126,7 +125,7 @@ func (s *proxy) Deregister(service *registry.Service, opts ...registry.Deregiste
 			continue
 		}
 
-		io.Copy(ioutil.Discard, rsp.Body)
+		io.Copy(io.Discard, rsp.Body)
 		rsp.Body.Close()
 		return nil
 	}
@@ -149,7 +148,7 @@ func (s *proxy) GetService(service string, opts ...registry.GetOption) ([]*regis
 		}
 
 		if rsp.StatusCode != 200 {
-			b, err := ioutil.ReadAll(rsp.Body)
+			b, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				return nil, err
 			}
@@ -158,7 +157,7 @@ func (s *proxy) GetService(service string, opts ...registry.GetOption) ([]*regis
 			continue
 		}
 
-		b, err := ioutil.ReadAll(rsp.Body)
+		b, err := io.ReadAll(rsp.Body)
 		if err != nil {
 			gerr = err
 			continue
@@ -189,7 +188,7 @@ func (s *proxy) ListServices(opts ...registry.ListOption) ([]*registry.Service, 
 		}
 
 		if rsp.StatusCode != 200 {
-			b, err := ioutil.ReadAll(rsp.Body)
+			b, err := io.ReadAll(rsp.Body)
 			if err != nil {
 				return nil, err
 			}
@@ -198,7 +197,7 @@ func (s *proxy) ListServices(opts ...registry.ListOption) ([]*registry.Service, 
 			continue
 		}
 
-		b, err := ioutil.ReadAll(rsp.Body)
+		b, err := io.ReadAll(rsp.Body)
 		if err != nil {
 			gerr = err
 			continue

--- a/plugins/server/http/http_test.go
+++ b/plugins/server/http/http_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -56,7 +56,7 @@ func TestHTTPServer(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -114,7 +114,7 @@ func decode(record []string) (*mdnsTxt, error) {
 		return nil, err
 	}
 
-	rbuf, err := ioutil.ReadAll(zr)
+	rbuf, err := io.ReadAll(zr)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/local/build/docker/docker.go
+++ b/runtime/local/build/docker/docker.go
@@ -4,7 +4,7 @@ package docker
 import (
 	"archive/tar"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -33,7 +33,7 @@ func (d *Builder) Build(s *build.Source) (*build.Package, error) {
 		return nil, err
 	}
 	// read docker file
-	by, err := ioutil.ReadAll(f)
+	by, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (d *Builder) Build(s *build.Source) (*build.Package, error) {
 		Name:           image,
 		Dockerfile:     dockerFile,
 		InputStream:    tr,
-		OutputStream:   ioutil.Discard,
+		OutputStream:   io.Discard,
 		RmTmpContainer: true,
 		SuppressOutput: true,
 	})

--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -144,7 +143,7 @@ func (h *httpTransportClient) Recv(m *Message) error {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}
@@ -218,7 +217,7 @@ func (h *httpTransportSocket) Recv(m *Message) error {
 		}
 
 		// read body
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}
@@ -292,7 +291,7 @@ func (h *httpTransportSocket) Send(m *Message) error {
 
 		rsp := &http.Response{
 			Header:        hdr,
-			Body:          ioutil.NopCloser(bytes.NewReader(m.Body)),
+			Body:          io.NopCloser(bytes.NewReader(m.Body)),
 			Status:        "200 OK",
 			StatusCode:    200,
 			Proto:         "HTTP/1.1",
@@ -343,7 +342,7 @@ func (h *httpTransportSocket) error(m *Message) error {
 	if h.r.ProtoMajor == 1 {
 		rsp := &http.Response{
 			Header:        make(http.Header),
-			Body:          ioutil.NopCloser(bytes.NewReader(m.Body)),
+			Body:          io.NopCloser(bytes.NewReader(m.Body)),
 			Status:        "500 Internal Server Error",
 			StatusCode:    500,
 			Proto:         "HTTP/1.1",
@@ -403,12 +402,12 @@ func (h *httpTransportListener) Accept(fn func(Socket)) error {
 
 		// read a regular request
 		if r.ProtoMajor == 1 {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			r.Body = ioutil.NopCloser(bytes.NewReader(b))
+			r.Body = io.NopCloser(bytes.NewReader(b))
 			// hijack the conn
 			hj, ok := w.(http.Hijacker)
 			if !ok {

--- a/util/http/http_test.go
+++ b/util/http/http_test.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -48,7 +48,7 @@ func TestRoundTripper(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(w.Body)
+	b, err := io.ReadAll(w.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestRoundTripper(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err = ioutil.ReadAll(rsp.Body)
+	b, err = io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util/kubernetes/api/response.go
+++ b/util/kubernetes/api/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -87,7 +87,7 @@ func newResponse(res *http.Response, err error) *Response {
 		return r
 	}
 
-	b, err := ioutil.ReadAll(r.res.Body)
+	b, err := io.ReadAll(r.res.Body)
 	if err == nil {
 		r.err = errors.New(string(b))
 		return r

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -360,7 +359,7 @@ func NewClusterClient() *client {
 		logger.Fatal(errors.New("service account not found"))
 	}
 
-	token, err := ioutil.ReadFile(path.Join(serviceAccountPath, "token"))
+	token, err := os.ReadFile(path.Join(serviceAccountPath, "token"))
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/util/kubernetes/client/util.go
+++ b/util/kubernetes/client/util.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"text/template"
 )
@@ -45,7 +45,7 @@ func certificatesFromFile(file string) ([]*x509.Certificate, error) {
 	if len(file) == 0 {
 		return nil, errors.New("error reading certificates from an empty filename")
 	}
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/web/service_test.go
+++ b/web/service_test.go
@@ -3,7 +3,7 @@ package web
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -80,7 +80,7 @@ func TestService(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestTLS(t *testing.T) {
 	}
 	defer rsp.Body.Close()
 
-	b, err := ioutil.ReadAll(rsp.Body)
+	b, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.

The go version in go.mod is 1.16, but the go version in .github/workflows/*.yml is still 1.15, so we need to bump the go version to 1.16 as well. 