### PR TITLE
Fix Micro CLI's proto comments

### DIFF
--- a/cmd/micro/cli/new/new.go
+++ b/cmd/micro/cli/new/new.go
@@ -181,7 +181,7 @@ func protoComments(name, dir string) []string {
 		"\ndownload protobuf for go-micro:",
 		"\ngo get -u google.golang.org/protobuf/proto",
 		"go install github.com/golang/protobuf/protoc-gen-go@latest",
-		"go install github.com/asim/go-micro/cmd/protoc-gen-micro/v4@latest",
+		"go install go-micro.dev/v4/cmd/protoc-gen-micro@v4",
 		"\ncompile the proto file " + name + ".proto and install dependencies:",
 		"\ncd " + dir,
 		"make proto update tidy",


### PR DESCRIPTION
Micro CLI would still suggest to download the `protoc-gen-micro` binary from the old location upon generating new projects. I've updated the comments to point to the new package name.

Relates to #2344.