### PR TITLE
fix context value nil

### DIFF
--- a/plugins/registry/nacos/nacos.go
+++ b/plugins/registry/nacos/nacos.go
@@ -1,6 +1,7 @@
 package nacos
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -27,7 +28,9 @@ func init() {
 // NewRegistry NewRegistry
 func NewRegistry(opts ...registry.Option) registry.Registry {
 	n := &nacosRegistry{
-		opts: registry.Options{},
+		opts: registry.Options{
+			Context: context.Background(),
+		},
 	}
 	if err := configure(n, opts...); err != nil {
 		panic(err)


### PR DESCRIPTION
when i try dashboard, get err

```
dashboard --registry nacos --registry_address 127.0.0.1:8848
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x4de87fd]
```

fix it.