### PR TITLE
Fix wrong usage of RWMutex in default cache implementation

### DIFF
--- a/cache/default.go
+++ b/cache/default.go
@@ -20,8 +20,8 @@ func (c *memCache) Context(ctx context.Context) Cache {
 }
 
 func (c *memCache) Get(key string) (interface{}, time.Time, error) {
-	c.RWMutex.Lock()
-	defer c.RWMutex.Unlock()
+	c.RWMutex.RLock()
+	defer c.RWMutex.RUnlock()
 
 	item, found := c.items[key]
 	if !found {


### PR DESCRIPTION
I saw the usage of `RWMutex` in default cache implementation and wanted to fix it. It should use `RLock` and `RUnlock` mechanism in `Get`.
