### PR TITLE
default the content type to json

### DIFF
--- a/client/rpc_codec.go
+++ b/client/rpc_codec.go
@@ -50,7 +50,7 @@ type readWriteCloser struct {
 }
 
 var (
-	DefaultContentType = "application/protobuf"
+	DefaultContentType = "application/json"
 
 	DefaultCodecs = map[string]codec.NewCodec{
 		"application/grpc":         grpc.NewCodec,


### PR DESCRIPTION
We cannot guarantee the types being passed in are protobuf so we should default to json encoding. This does not apply to the grpc plugin which defaults to application/grpc+proto.