### PR TITLE
[fix] http transport deadlock

### DIFF
--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -141,6 +141,7 @@ func (h *httpTransportClient) Recv(m *Message) error {
 
 	h.Lock()
 	if h.closed {
+		h.Unlock()
 		return io.EOF
 	}
 	rsp, err := http.ReadResponse(h.buff, r)

--- a/transport/http_transport_test.go
+++ b/transport/http_transport_test.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -303,11 +302,11 @@ func TestHTTPTransportCloseWhenRecv(t *testing.T) {
 
 			if err := c.Recv(&rm); err != nil {
 				if err == io.EOF {
+					c.Recv(&rm)
 					return
 				}
 				t.Errorf("Unexpected recv err: %v", err)
 			}
-			fmt.Println("aa")
 		}
 	}()
 	for i := 1; i < 3; i++ {


### PR DESCRIPTION
Fixed dead lock, when try to receive message after http transport closed