### PR TITLE
#2453 Fix with associated test update

### DIFF
--- a/registry/mdns_registry.go
+++ b/registry/mdns_registry.go
@@ -354,10 +354,10 @@ func (m *mdnsRegistry) GetService(service string, opts ...GetOption) ([]*Service
 				addr := ""
 				// prefer ipv4 addrs
 				if len(e.AddrV4) > 0 {
-					addr = e.AddrV4.String()
+					addr = net.JoinHostPort(e.AddrV4.String(), fmt.Sprint(e.Port))
 					// else use ipv6
 				} else if len(e.AddrV6) > 0 {
-					addr = "[" + e.AddrV6.String() + "]"
+					addr = net.JoinHostPort(e.AddrV6.String(), fmt.Sprint(e.Port))
 				} else {
 					if logger.V(logger.InfoLevel, logger.DefaultLogger) {
 						logger.Infof("[mdns]: invalid endpoint received: %v", e)
@@ -366,7 +366,7 @@ func (m *mdnsRegistry) GetService(service string, opts ...GetOption) ([]*Service
 				}
 				s.Nodes = append(s.Nodes, &Node{
 					Id:       strings.TrimSuffix(e.Name, "."+p.Service+"."+p.Domain+"."),
-					Address:  net.JoinHostPort(addr, fmt.Sprint(e.Port)),
+					Address:  addr,
 					Metadata: txt.Metadata,
 				})
 
@@ -584,16 +584,16 @@ func (m *mdnsWatcher) Next() (*Result, error) {
 
 			var addr string
 			if len(e.AddrV4) > 0 {
-				addr = e.AddrV4.String()
+				addr = net.JoinHostPort(e.AddrV4.String(), fmt.Sprint(e.Port))
 			} else if len(e.AddrV6) > 0 {
-				addr = "[" + e.AddrV6.String() + "]"
+				addr = net.JoinHostPort(e.AddrV6.String(), fmt.Sprint(e.Port))
 			} else {
 				addr = e.Addr.String()
 			}
 
 			service.Nodes = append(service.Nodes, &Node{
 				Id:       strings.TrimSuffix(e.Name, suffix),
-				Address:  net.JoinHostPort(addr, fmt.Sprint(e.Port)),
+				Address:  addr,
 				Metadata: txt.Metadata,
 			})
 

--- a/registry/mdns_test.go
+++ b/registry/mdns_test.go
@@ -52,6 +52,19 @@ func TestMDNS(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:    "test4",
+			Version: "1.0.4",
+			Nodes: []*Node{
+				{
+					Id:      "test4-1",
+					Address: "[::]:10004",
+					Metadata: map[string]string{
+						"foo4": "bar4",
+					},
+				},
+			},
+		},
 	}
 
 	travis := os.Getenv("TRAVIS")
@@ -239,6 +252,19 @@ func TestWatcher(t *testing.T) {
 					Address: "10.0.0.3:10003",
 					Metadata: map[string]string{
 						"foo3": "bar3",
+					},
+				},
+			},
+		},
+		{
+			Name:    "test4",
+			Version: "1.0.4",
+			Nodes: []*Node{
+				{
+					Id:      "test4-1",
+					Address: "[::]:10004",
+					Metadata: map[string]string{
+						"foo4": "bar4",
 					},
 				},
 			},


### PR DESCRIPTION
I did not see a develop branch (per the PR template).

This PR fixes an issue with mdns_registry wrapping ipv6 addresses with an extra `[]`. This causes the address to be invalid and `net.Dial` calls fail because of the extra `[]`.