### PR TITLE
Add Wait option support for sync/etcd plugins

### DIFF
--- a/plugins/sync/etcd/etcd.go
+++ b/plugins/sync/etcd/etcd.go
@@ -121,7 +121,9 @@ func (e *etcdSync) Lock(id string, opts ...sync.LockOption) error {
 		lockCtx, cancel = context.WithTimeout(lockCtx, options.Wait)
 		defer cancel()
 	}
-	if err := m.Lock(lockCtx); err != nil {
+	if err := m.Lock(lockCtx); err != nil && err == context.DeadlineExceeded {
+		return sync.ErrLockTimeout
+	} else if err != nil {
 		return err
 	}
 

--- a/plugins/sync/etcd/etcd.go
+++ b/plugins/sync/etcd/etcd.go
@@ -115,7 +115,13 @@ func (e *etcdSync) Lock(id string, opts ...sync.LockOption) error {
 
 	m := cc.NewMutex(s, path)
 
-	if err := m.Lock(context.TODO()); err != nil {
+	lockCtx := context.Background()
+	if options.Wait > 0 {
+		var cancel context.CancelFunc
+		lockCtx, cancel = context.WithTimeout(lockCtx, options.Wait)
+		defer cancel()
+	}
+	if err := m.Lock(lockCtx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Current implementation of plugins/sync/etcd Lock doesn't use Wait parameter. This PR adds support for Wait option to be included when trying to acquire lock. The Mutex Lock method's comments hints that this approach is expected. Small snippet of the Mutex comments:

```
...
// Lock locks the mutex with a cancelable context. If the context is canceled
// while trying to acquire the lock, the mutex tries to clean its stale lock entry.
func (m *Mutex) Lock(ctx context.Context) error {
	resp, err := m.tryAcquire(ctx)
...
```
