### PR TITLE
Fix codec/bytes

### DIFF
--- a/codec/bytes/marshaler.go
+++ b/codec/bytes/marshaler.go
@@ -27,8 +27,10 @@ func (n Marshaler) Unmarshal(d []byte, v interface{}) error {
 	switch ve := v.(type) {
 	case *[]byte:
 		*ve = d
+		return nil
 	case *Message:
 		ve.Body = d
+		return nil
 	}
 	return codec.ErrInvalidMessage
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-micro.dev/v4
+module github.com/grissom1/go-micro/v4
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grissom1/go-micro/v4
+module go-micro.dev/v4
 
 go 1.17
 


### PR DESCRIPTION
codec bytes Unmarshal always return Error "invalid message" now.
