### PR TITLE
Support direct generation of grpc method

### DIFF
--- a/plugins/broker/rabbitmq/rabbitmq.go
+++ b/plugins/broker/rabbitmq/rabbitmq.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/streadway/amqp"
 	"go-micro.dev/v4/broker"
 	"go-micro.dev/v4/cmd"
-	"github.com/streadway/amqp"
 )
 
 type rbroker struct {
@@ -267,6 +267,13 @@ func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker
 		for k, v := range msg.Headers {
 			header[k], _ = v.(string)
 		}
+
+		// Get rid of dependence on 'Micro-Topic'
+		msgTopic := header["Micro-Topic"]
+		if msgTopic == "" {
+			header["Micro-Topic"] = msg.RoutingKey
+		}
+
 		m := &broker.Message{
 			Header: header,
 			Body:   msg.Body,

--- a/plugins/broker/rabbitmq/rabbitmq.go
+++ b/plugins/broker/rabbitmq/rabbitmq.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/streadway/amqp"
 	"go-micro.dev/v4/broker"
 	"go-micro.dev/v4/cmd"
+	"github.com/streadway/amqp"
 )
 
 type rbroker struct {
@@ -267,13 +267,6 @@ func (r *rbroker) Subscribe(topic string, handler broker.Handler, opts ...broker
 		for k, v := range msg.Headers {
 			header[k], _ = v.(string)
 		}
-
-		// Get rid of dependence on 'Micro-Topic'
-		msgTopic := header["Micro-Topic"]
-		if msgTopic == "" {
-			header["Micro-Topic"] = msg.RoutingKey
-		}
-
 		m := &broker.Message{
 			Header: header,
 			Body:   msg.Body,

--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -557,7 +557,7 @@ func (router *router) ProcessMessage(ctx context.Context, msg Message) (err erro
 			}
 
 			// read the body into the handler request value
-			if err = cc.ReadBody(req.Interface()); err != nil {
+			if err = cc.ReadBody(req.Addr().Interface()); err != nil {
 				return err
 			}
 

--- a/server/rpc_router.go
+++ b/server/rpc_router.go
@@ -557,7 +557,7 @@ func (router *router) ProcessMessage(ctx context.Context, msg Message) (err erro
 			}
 
 			// read the body into the handler request value
-			if err = cc.ReadBody(req.Addr().Interface()); err != nil {
+			if err = cc.ReadBody(req.Interface()); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Support direct generation of grpc method when the package and service names of proto files are different.

The 'method' generated by protoc-gen-micro does not contain 'package', when the proto file contains a package declaration. When the package and service names of proto files are different, and use service discovery, the correct method cannot be accessed.

1. 
proto example:

> syntax = "proto3";
> option go_package="/hello";
> package HelloA;
> 
> service HelloA{
> ....
> }

2. 
But the registered service name is: Hello.

3. 
Use the following way,  the corresponding method cannot be accessed, when accessing grpc services developed by other frameworks or languages.
`client := NewHelloAService("Hello", service.Client())`

Because the package name is not included when the method is called in the generated proxy.
 `req := c.c.NewRequest(c.name, "HelloA.XXX", in)`

--------------
protoc-gen-go-grpc handles this case correctly, so I think support for this should be added.

The code generated by protoc-gen-go-grpc is:
`err := c.cc.Invoke(ctx, "/HelloA.HelloA/XXX", in, out, opts...)`

After modification, we can: 
protoc --go_out=. --micro_out=. --micro_opt=use_grpc=1 xxx.proto

Set the parameter 'use_grpc', regardless of the value, the package name will be added when the method is generated.

This modification can also be used to solve the problem of calling gRPC services developed by other frameworks or languages.