### PR TITLE
typo fix;

### DIFF
--- a/plugins/config/source/consul/util.go
+++ b/plugins/config/source/consul/util.go
@@ -54,7 +54,7 @@ func makeMap(e encoder.Encoder, kv api.KVPairs, stripPrefix string) (map[string]
 			case mapV.Decode(e, v.Value) == nil:
 				val = mapV
 			default:
-				return nil, fmt.Errorf("faild decode value. path: %s, error: %s", pathString, err)
+				return nil, fmt.Errorf("failed decode value. path: %s, error: %s", pathString, err)
 			}
 		}
 


### PR DESCRIPTION
Why do we only support Consul config plugin values to be json compatible? meaning only []interface{}{} and map[string]interface{}{}? Can't it be just a string type?
Didn't do a PR for the String support, just want to do a sanity check first, is this feature by design?

Fixed a typo found during the debug.
