### PR TITLE
Option to disable file config watcher (backport from master to v3)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,8 @@ type Options struct {
 
 	// for alternative data
 	Context context.Context
+
+	WithWatcherDisabled bool
 }
 
 type Option func(o *Options)

--- a/config/default.go
+++ b/config/default.go
@@ -37,7 +37,9 @@ func newConfig(opts ...Option) (Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	go c.run()
+	if !c.opts.WithWatcherDisabled {
+		go c.run()
+	}
 
 	return &c, nil
 }
@@ -53,7 +55,12 @@ func (c *config) Init(opts ...Option) error {
 
 	// default loader uses the configured reader
 	if c.opts.Loader == nil {
-		c.opts.Loader = memory.NewLoader(memory.WithReader(c.opts.Reader))
+		loaderOpts := []loader.Option{memory.WithReader(c.opts.Reader)}
+		if c.opts.WithWatcherDisabled {
+			loaderOpts = append(loaderOpts, memory.WithWatcherDisabled())
+		}
+
+		c.opts.Loader = memory.NewLoader(loaderOpts...)
 	}
 
 	err := c.opts.Loader.Load(c.opts.Source...)

--- a/config/loader/loader.go
+++ b/config/loader/loader.go
@@ -48,6 +48,8 @@ type Options struct {
 
 	// for alternative data
 	Context context.Context
+
+	WithWatcherDisabled bool
 }
 
 type Option func(o *Options)

--- a/config/loader/memory/options.go
+++ b/config/loader/memory/options.go
@@ -19,3 +19,9 @@ func WithReader(r reader.Reader) loader.Option {
 		o.Reader = r
 	}
 }
+
+func WithWatcherDisabled() loader.Option {
+	return func(o *loader.Options) {
+		o.WithWatcherDisabled = true
+	}
+}

--- a/config/options.go
+++ b/config/options.go
@@ -26,3 +26,9 @@ func WithReader(r reader.Reader) Option {
 		o.Reader = r
 	}
 }
+
+func WithWatcherDisabled() Option {
+	return func(o *Options) {
+		o.WithWatcherDisabled = true
+	}
+}


### PR DESCRIPTION
Watch config changes are not always needed (e.g. app is packed into immutable containter; running tests). For such use cases we can avoid.

PR to master: https://github.com/asim/go-micro/pull/2485
