### PR TITLE
remove unused variable in loop

### DIFF
--- a/plugins/broker/grpc/grpc_test.go
+++ b/plugins/broker/grpc/grpc_test.go
@@ -110,7 +110,7 @@ func pub(be *testing.B, c int) {
 
 	for i := 0; i < c; i++ {
 		go func() {
-			for _ = range ch {
+			for range ch {
 				if err := b.Publish(topic, msg); err != nil {
 					be.Fatalf("Unexpected publish error: %v", err)
 				}


### PR DESCRIPTION
remove unused variable `_` in for loop. better to use `for range` instead of `for _ = range`