### PR TITLE
Correctly check error on redis command XTRIM

### DIFF
--- a/plugins/events/redis/janitor.go
+++ b/plugins/events/redis/janitor.go
@@ -71,7 +71,9 @@ func (r *redisStream) cleanupConsumers() error {
 			}
 		}
 
-		if err := r.redisClient.XTrimMinID(ctx, streamName, strconv.FormatInt(time.Now().Add(-d).Unix()*1000, 10)); err != nil {
+		// `XTRIM MINID` requires Redis 6.2
+		minID := strconv.FormatInt(time.Now().Add(-d).Unix()*1000, 10)
+		if err := r.redisClient.XTrimMinID(ctx, streamName, minID).Err(); err != nil {
 			logger.Errorf("Error trimming %s", err)
 		}
 	}


### PR DESCRIPTION
In Redis event plugin, janitor was throwing error when calling XTRIM. It was just a false-positive.

```
Error trimming xtrim stream-62bc2d05ade03bddea6a8862-000d-req minid 1656135783000: 0
github.com/asim/go-micro/plugins/events/redis/v4.(*redisStream).cleanupConsumers
  github.com/asim/go-micro/plugins/events/redis/v4@v4.0.0-20220530075002-cf51ddeb26c8/janitor.go:75
github.com/asim/go-micro/plugins/events/redis/v4.(*redisStream).runJanitor.func1
  github.com/asim/go-micro/plugins/events/redis/v4@v4.0.0-20220530075002-cf51ddeb26c8/janitor.go:23
```