### PR TITLE
api package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -11,6 +11,8 @@ import (
 	"go-micro.dev/v4/server"
 )
 
+// The Api interface provides a way to 
+// create composable API gateways
 type Api interface {
 	// Initialise options
 	Init(...Option) error

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,8 @@
+// Package api is for building api gateways
 package api
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strings"
@@ -18,11 +20,16 @@ type Api interface {
 	Register(*Endpoint) error
 	// Register a route
 	Deregister(*Endpoint) error
+	// Run the api
+	Run(context.Context) error
 	// Implemenation of api
 	String() string
 }
 
-type Options struct{}
+type Options struct {
+	// Address of the server
+	Address string
+}
 
 type Option func(*Options) error
 
@@ -184,4 +191,9 @@ func NewGateway() Gateway {
 //	))
 func WithEndpoint(e *Endpoint) server.HandlerOption {
 	return server.EndpointMetadata(e.Name, Encode(e))
+}
+
+// NewApi returns a new api gateway
+func NewApi(opts ...Option) Api {
+	return newApi(opts...)
 }

--- a/api/default.go
+++ b/api/default.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+
+	"go-micro.dev/v4/api/handler"
+	"go-micro.dev/v4/api/handler/rpc"
+	"go-micro.dev/v4/api/router/registry"
+	"go-micro.dev/v4/api/server"
+	"go-micro.dev/v4/api/server/http"
+)
+
+type api struct {
+	options Options
+
+	server server.Server
+}
+
+func newApi(opts ...Option) Api {
+	options := NewOptions(opts...)
+
+	// TODO: make configurable
+	rtr := registry.NewRouter()
+
+	// TODO: make configurable
+	hdlr := rpc.NewHandler(
+		handler.WithRouter(rtr),
+	)
+
+	// TODO: make configurable
+	// create a new server
+	srv := http.NewServer(options.Address)
+
+	// TODO: allow multiple handlers
+	// define the handler
+	srv.Handle("/", hdlr)
+
+	return &api{
+		options: options,
+		server:  srv,
+	}
+}
+
+// Initialise options
+func (a *api) Init(opts ...Option) error {
+	for _, o := range opts {
+		o(&a.options)
+	}
+	return nil
+}
+
+// Get the options
+func (a *api) Options() Options {
+	return a.options
+}
+
+// Register a http handler
+func (a *api) Register(*Endpoint) error {
+	return nil
+}
+
+// Register a route
+func (a *api) Deregister(*Endpoint) error {
+	return nil
+}
+
+func (a *api) Run(ctx context.Context) error {
+	if err := a.server.Start(); err != nil {
+		return err
+	}
+
+	// wait to finish
+	<-ctx.Done()
+
+	if err := a.server.Stop(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *api) String() string {
+	return "http"
+}

--- a/api/handler/options.go
+++ b/api/handler/options.go
@@ -26,12 +26,7 @@ func NewOptions(opts ...Option) Options {
 	}
 
 	if options.Client == nil {
-		WithClient(client.NewClient())(&options)
-	}
-
-	// set namespace if blank
-	if len(options.Namespace) == 0 {
-		WithNamespace("go.micro.api")(&options)
+		WithClient(client.DefaultClient)(&options)
 	}
 
 	if options.MaxRecvSize == 0 {

--- a/api/options.go
+++ b/api/options.go
@@ -1,0 +1,13 @@
+package api
+
+func NewOptions(opts ...Option) Options {
+	options := Options{
+		Address: ":8080",
+	}
+
+	for _, o := range opts {
+		o(&options)
+	}
+
+	return options
+}

--- a/api/router/endpoint.go
+++ b/api/router/endpoint.go
@@ -1,0 +1,99 @@
+package router
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+func strip(s string) string {
+	return strings.TrimSpace(s)
+}
+
+func slice(s string) []string {
+	var sl []string
+
+	for _, p := range strings.Split(s, ",") {
+		if str := strip(p); len(str) > 0 {
+			sl = append(sl, strip(p))
+		}
+	}
+
+	return sl
+}
+
+// Encode encodes an endpoint to endpoint metadata
+func Encode(e *Endpoint) map[string]string {
+	if e == nil {
+		return nil
+	}
+
+	// endpoint map
+	ep := make(map[string]string)
+
+	// set vals only if they exist
+	set := func(k, v string) {
+		if len(v) == 0 {
+			return
+		}
+		ep[k] = v
+	}
+
+	set("endpoint", e.Name)
+	set("description", e.Description)
+	set("handler", e.Handler)
+	set("method", strings.Join(e.Method, ","))
+	set("path", strings.Join(e.Path, ","))
+	set("host", strings.Join(e.Host, ","))
+
+	return ep
+}
+
+// Decode decodes endpoint metadata into an endpoint
+func Decode(e map[string]string) *Endpoint {
+	if e == nil {
+		return nil
+	}
+
+	return &Endpoint{
+		Name:        e["endpoint"],
+		Description: e["description"],
+		Method:      slice(e["method"]),
+		Path:        slice(e["path"]),
+		Host:        slice(e["host"]),
+		Handler:     e["handler"],
+	}
+}
+
+// Validate validates an endpoint to guarantee it won't blow up when being served
+func Validate(e *Endpoint) error {
+	if e == nil {
+		return errors.New("endpoint is nil")
+	}
+
+	if len(e.Name) == 0 {
+		return errors.New("name required")
+	}
+
+	for _, p := range e.Path {
+		ps := p[0]
+		pe := p[len(p)-1]
+
+		if ps == '^' && pe == '$' {
+			_, err := regexp.CompilePOSIX(p)
+			if err != nil {
+				return err
+			}
+		} else if ps == '^' && pe != '$' {
+			return errors.New("invalid path")
+		} else if ps != '^' && pe == '$' {
+			return errors.New("invalid path")
+		}
+	}
+
+	if len(e.Handler) == 0 {
+		return errors.New("invalid handler")
+	}
+
+	return nil
+}

--- a/api/router/registry/registry.go
+++ b/api/router/registry/registry.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"go-micro.dev/v4/api"
 	"go-micro.dev/v4/api/router"
 	"go-micro.dev/v4/api/router/util"
 	"go-micro.dev/v4/logger"
@@ -35,12 +34,12 @@ type registryRouter struct {
 	rc cache.Cache
 
 	sync.RWMutex
-	eps map[string]*api.Service
+	eps map[string]*router.Route
 	// compiled regexp for host and path
 	ceps map[string]*endpoint
 }
 
-func (r *registryRouter) isClosed() bool {
+func (r *registryRouter) isStopd() bool {
 	select {
 	case <-r.exit:
 		return true
@@ -111,7 +110,7 @@ func (r *registryRouter) process(res *registry.Result) {
 // store local endpoint cache
 func (r *registryRouter) store(services []*registry.Service) {
 	// endpoints
-	eps := map[string]*api.Service{}
+	eps := map[string]*router.Route{}
 
 	// services
 	names := map[string]bool{}
@@ -126,10 +125,10 @@ func (r *registryRouter) store(services []*registry.Service) {
 			// create a key service:endpoint_name
 			key := fmt.Sprintf("%s.%s", service.Name, sep.Name)
 			// decode endpoint
-			end := api.Decode(sep.Metadata)
+			end := router.Decode(sep.Metadata)
 
 			// if we got nothing skip
-			if err := api.Validate(end); err != nil {
+			if err := router.Validate(end); err != nil {
 				if logger.V(logger.TraceLevel, logger.DefaultLogger) {
 					logger.Tracef("endpoint validation failed: %v", err)
 				}
@@ -139,13 +138,13 @@ func (r *registryRouter) store(services []*registry.Service) {
 			// try get endpoint
 			ep, ok := eps[key]
 			if !ok {
-				ep = &api.Service{Name: service.Name}
+				ep = &router.Route{Service: service.Name}
 			}
 
 			// overwrite the endpoint
 			ep.Endpoint = end
 			// append services
-			ep.Services = append(ep.Services, service)
+			ep.Versions = append(ep.Versions, service)
 			// store it
 			eps[key] = ep
 		}
@@ -155,9 +154,9 @@ func (r *registryRouter) store(services []*registry.Service) {
 	defer r.Unlock()
 
 	// delete any existing eps for services we know
-	for key, service := range r.eps {
+	for key, route := range r.eps {
 		// skip what we don't care about
-		if !names[service.Name] {
+		if !names[route.Service] {
 			continue
 		}
 
@@ -226,7 +225,7 @@ func (r *registryRouter) watch() {
 	var attempts int
 
 	for {
-		if r.isClosed() {
+		if r.isStopd() {
 			return
 		}
 
@@ -274,7 +273,7 @@ func (r *registryRouter) Options() router.Options {
 	return r.opts
 }
 
-func (r *registryRouter) Close() error {
+func (r *registryRouter) Stop() error {
 	select {
 	case <-r.exit:
 		return nil
@@ -285,16 +284,16 @@ func (r *registryRouter) Close() error {
 	return nil
 }
 
-func (r *registryRouter) Register(ep *api.Endpoint) error {
+func (r *registryRouter) Register(ep *router.Route) error {
 	return nil
 }
 
-func (r *registryRouter) Deregister(ep *api.Endpoint) error {
+func (r *registryRouter) Deregister(ep *router.Route) error {
 	return nil
 }
 
-func (r *registryRouter) Endpoint(req *http.Request) (*api.Service, error) {
-	if r.isClosed() {
+func (r *registryRouter) Endpoint(req *http.Request) (*router.Route, error) {
+	if r.isStopd() {
 		return nil, errors.New("router closed")
 	}
 
@@ -409,8 +408,8 @@ func (r *registryRouter) Endpoint(req *http.Request) (*api.Service, error) {
 	return nil, errors.New("not found")
 }
 
-func (r *registryRouter) Route(req *http.Request) (*api.Service, error) {
-	if r.isClosed() {
+func (r *registryRouter) Route(req *http.Request) (*router.Route, error) {
+	if r.isStopd() {
 		return nil, errors.New("router closed")
 	}
 
@@ -451,27 +450,27 @@ func (r *registryRouter) Route(req *http.Request) (*api.Service, error) {
 		}
 
 		// construct api service
-		return &api.Service{
-			Name: name,
-			Endpoint: &api.Endpoint{
+		return &router.Route{
+			Service: name,
+			Endpoint: &router.Endpoint{
 				Name:    rp.Method,
 				Handler: handler,
 			},
-			Services: services,
+			Versions: services,
 		}, nil
 	// http handler
 	case "http", "proxy", "web":
 		// construct api service
-		return &api.Service{
-			Name: name,
-			Endpoint: &api.Endpoint{
+		return &router.Route{
+			Service: name,
+			Endpoint: &router.Endpoint{
 				Name:    req.URL.String(),
 				Handler: r.opts.Handler,
 				Host:    []string{req.Host},
 				Method:  []string{req.Method},
 				Path:    []string{req.URL.Path},
 			},
-			Services: services,
+			Versions: services,
 		}, nil
 	}
 
@@ -484,7 +483,7 @@ func newRouter(opts ...router.Option) *registryRouter {
 		exit: make(chan bool),
 		opts: options,
 		rc:   cache.New(options.Registry),
-		eps:  make(map[string]*api.Service),
+		eps:  make(map[string]*router.Route),
 		ceps: make(map[string]*endpoint),
 	}
 	go r.watch()

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -4,21 +4,50 @@ package router
 import (
 	"net/http"
 
-	"go-micro.dev/v4/api"
+	"go-micro.dev/v4/registry"
 )
 
 // Router is used to determine an endpoint for a request
 type Router interface {
 	// Returns options
 	Options() Options
-	// Stop the router
-	Close() error
-	// Endpoint returns an api.Service endpoint or an error if it does not exist
-	Endpoint(r *http.Request) (*api.Service, error)
 	// Register endpoint in router
-	Register(ep *api.Endpoint) error
+	Register(r *Route) error
 	// Deregister endpoint from router
-	Deregister(ep *api.Endpoint) error
+	Deregister(r *Route) error
 	// Route returns an api.Service route
-	Route(r *http.Request) (*api.Service, error)
+	Route(r *http.Request) (*Route, error)
+	// Stop the router
+	Stop() error
+}
+
+type Route struct {
+	// Name of service
+	Service string
+	// The endpoint for this service
+	Endpoint *Endpoint
+	// Versions of this service
+	Versions []*registry.Service
+}
+
+// Endpoint is a mapping between an RPC method and HTTP endpoint
+type Endpoint struct {
+	// RPC Method e.g. Greeter.Hello
+	Name string
+	// Description e.g what's this endpoint for
+	Description string
+	// API Handler e.g rpc, proxy
+	Handler string
+	// HTTP Host e.g example.com
+	Host []string
+	// HTTP Methods e.g GET, POST
+	Method []string
+	// HTTP Path e.g /greeter. Expect POSIX regex
+	Path []string
+	// Body destination
+	// "*" or "" - top level message value
+	// "string" - inner message value
+	Body string
+	// Stream flag
+	Stream bool
 }

--- a/api/router/static/static.go
+++ b/api/router/static/static.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"go-micro.dev/v4/api"
 	"go-micro.dev/v4/api/router"
 	"go-micro.dev/v4/api/router/util"
 	"go-micro.dev/v4/logger"
@@ -18,7 +17,7 @@ import (
 )
 
 type endpoint struct {
-	apiep    *api.Endpoint
+	apiep    *router.Endpoint
 	hostregs []*regexp.Regexp
 	pathregs []util.Pattern
 	pcreregs []*regexp.Regexp
@@ -32,7 +31,7 @@ type staticRouter struct {
 	eps map[string]*endpoint
 }
 
-func (r *staticRouter) isClosed() bool {
+func (r *staticRouter) isStopd() bool {
 	select {
 	case <-r.exit:
 		return true
@@ -47,7 +46,7 @@ func (r *staticRouter) watch() {
 	var attempts int
 
 	for {
-		if r.isClosed() {
+		if r.isStopd() {
 			return
 		}
 
@@ -88,8 +87,10 @@ func (r *staticRouter) watch() {
 }
 */
 
-func (r *staticRouter) Register(ep *api.Endpoint) error {
-	if err := api.Validate(ep); err != nil {
+func (r *staticRouter) Register(route *router.Route) error {
+	ep := route.Endpoint
+
+	if err := router.Validate(ep); err != nil {
 		return err
 	}
 
@@ -146,8 +147,9 @@ func (r *staticRouter) Register(ep *api.Endpoint) error {
 	return nil
 }
 
-func (r *staticRouter) Deregister(ep *api.Endpoint) error {
-	if err := api.Validate(ep); err != nil {
+func (r *staticRouter) Deregister(route *router.Route) error {
+	ep := route.Endpoint
+	if err := router.Validate(ep); err != nil {
 		return err
 	}
 	r.Lock()
@@ -160,7 +162,7 @@ func (r *staticRouter) Options() router.Options {
 	return r.opts
 }
 
-func (r *staticRouter) Close() error {
+func (r *staticRouter) Stop() error {
 	select {
 	case <-r.exit:
 		return nil
@@ -170,7 +172,7 @@ func (r *staticRouter) Close() error {
 	return nil
 }
 
-func (r *staticRouter) Endpoint(req *http.Request) (*api.Service, error) {
+func (r *staticRouter) Endpoint(req *http.Request) (*router.Route, error) {
 	ep, err := r.endpoint(req)
 	if err != nil {
 		return nil, err
@@ -203,9 +205,9 @@ func (r *staticRouter) Endpoint(req *http.Request) (*api.Service, error) {
 		services = svcs
 	}
 
-	svc := &api.Service{
-		Name: epf[0],
-		Endpoint: &api.Endpoint{
+	svc := &router.Route{
+		Service: epf[0],
+		Endpoint: &router.Endpoint{
 			Name:    strings.Join(epf[1:], "."),
 			Handler: "rpc",
 			Host:    ep.apiep.Host,
@@ -214,14 +216,14 @@ func (r *staticRouter) Endpoint(req *http.Request) (*api.Service, error) {
 			Body:    ep.apiep.Body,
 			Stream:  ep.apiep.Stream,
 		},
-		Services: services,
+		Versions: services,
 	}
 
 	return svc, nil
 }
 
 func (r *staticRouter) endpoint(req *http.Request) (*endpoint, error) {
-	if r.isClosed() {
+	if r.isStopd() {
 		return nil, errors.New("router closed")
 	}
 
@@ -329,8 +331,8 @@ func (r *staticRouter) endpoint(req *http.Request) (*endpoint, error) {
 	return nil, fmt.Errorf("endpoint not found for %v", req.URL)
 }
 
-func (r *staticRouter) Route(req *http.Request) (*api.Service, error) {
-	if r.isClosed() {
+func (r *staticRouter) Route(req *http.Request) (*router.Route, error) {
+	if r.isStopd() {
 		return nil, errors.New("router closed")
 	}
 


### PR DESCRIPTION
Making the api package work as an api gateway

- Enables creation of gateway through `api.NewApi()`
- Gateway runs on ":8080" by default
- Uses registry router by default meaning routes for any service on /[service]/[endpoint]
- Requires some level of testing