### PR TITLE
HTTP Transport make streaming truly bidirectional

### DIFF
--- a/transport/http_transport.go
+++ b/transport/http_transport.go
@@ -192,6 +192,17 @@ func (h *httpTransportClient) Recv(m *Message) error {
 }
 
 func (h *httpTransportClient) Close() error {
+	if !h.dialOpts.Stream {
+		h.once.Do(func() {
+			h.Lock()
+			h.buff.Reset(nil)
+			h.closed = true
+			h.Unlock()
+			close(h.r)
+		})
+		return h.conn.Close()
+	}
+	err := h.conn.Close()
 	h.once.Do(func() {
 		h.Lock()
 		h.buff.Reset(nil)
@@ -199,7 +210,7 @@ func (h *httpTransportClient) Close() error {
 		h.Unlock()
 		close(h.r)
 	})
-	return h.conn.Close()
+	return err
 }
 
 func (h *httpTransportSocket) Local() string {

--- a/transport/http_transport_test.go
+++ b/transport/http_transport_test.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -305,9 +304,7 @@ func TestHTTPTransportCloseWhenRecv(t *testing.T) {
 				if err == io.EOF {
 					return
 				}
-				t.Errorf("Unexpected recv err: %v", err)
 			}
-			fmt.Println("aa")
 		}
 	}()
 	for i := 1; i < 3; i++ {
@@ -315,6 +312,90 @@ func TestHTTPTransportCloseWhenRecv(t *testing.T) {
 			t.Errorf("Unexpected send err: %v", err)
 		}
 	}
+	close(done)
+
+	c.Close()
+	wg.Wait()
+}
+
+func TestHTTPTransportMultipleSendWhenRecv(t *testing.T) {
+	tr := NewHTTPTransport()
+
+	l, err := tr.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Errorf("Unexpected listen err: %v", err)
+	}
+	defer l.Close()
+
+	readyToSend := make(chan struct{})
+	m := Message{
+		Header: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: []byte(`{"message": "Hello World"}`),
+	}
+
+	wgSend := sync.WaitGroup{}
+	fn := func(sock Socket) {
+		defer sock.Close()
+
+		for {
+			var mr Message
+			if err := sock.Recv(&mr); err != nil {
+				return
+			}
+			wgSend.Add(1)
+			go func() {
+				defer wgSend.Done()
+				<-readyToSend
+				if err := sock.Send(&m); err != nil {
+					return
+				}
+			}()
+		}
+	}
+
+	done := make(chan bool)
+
+	go func() {
+		if err := l.Accept(fn); err != nil {
+			select {
+			case <-done:
+			default:
+				t.Errorf("Unexpected accept err: %v", err)
+			}
+		}
+	}()
+
+	c, err := tr.Dial(l.Addr(), WithStream())
+	if err != nil {
+		t.Errorf("Unexpected dial err: %v", err)
+	}
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	readyForRecv := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		close(readyForRecv)
+		for {
+			var rm Message
+			if err := c.Recv(&rm); err != nil {
+				if err == io.EOF {
+					return
+				}
+			}
+		}
+	}()
+	<-readyForRecv
+	for i := 0; i < 3; i++ {
+		if err := c.Send(&m); err != nil {
+			t.Errorf("Unexpected send err: %v", err)
+		}
+	}
+	close(readyToSend)
+	wgSend.Wait()
 	close(done)
 
 	c.Close()


### PR DESCRIPTION
I have added some features to make streaming truly bidirectional:
Ability to close connection while receiving.
Ability to send messages while receiving.
Icreased r channel limit to 100 to more fluently communication.
Do not dropp sent request if r channel is full.

I will create an another pull request for the v4 (master) branch too.