### PR TITLE
feat(sync): Add additional context option to sync for plugin extensions

### DIFF
--- a/sync/options.go
+++ b/sync/options.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"crypto/tls"
 	"time"
 )
@@ -37,5 +38,12 @@ func LockWait(t time.Duration) LockOption {
 func WithTLS(t *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = t
+	}
+}
+
+// WithContext sets the syncs context, for any extra configuration
+func WithContext(c context.Context) Option {
+	return func(o *Options) {
+		o.Context = c
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -2,6 +2,7 @@
 package sync
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"time"
@@ -39,6 +40,7 @@ type Options struct {
 	Nodes     []string
 	Prefix    string
 	TLSConfig *tls.Config
+	Context   context.Context
 }
 
 type Option func(o *Options)


### PR DESCRIPTION
Like other plugin interfaces, this adds a `Context` option to the sync interface to allow for plugins to define and utilize additional parameter options.

Specifically, this would be helpful in order to add credential support to the etcd plugin, per https://github.com/go-micro/plugins/issues/41 

Ideally, this would be used to match up how credentials are already being passed in to other etcd-based plugins, like for registry which expect credentials within the Context option, [see here](https://github.com/go-micro/plugins/blob/0ed40ba1aacebe0d38d871a6272f78125bf68dbc/v4/registry/etcd/etcd.go#L86-L96).