### PR TITLE
fix: log.Fatal() and log.Fatalf() will not exit with code 1

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -189,11 +189,13 @@ func Errorf(format string, v ...interface{}) {
 // Fatal logs with Log and then exits with os.Exit(1)
 func Fatal(v ...interface{}) {
 	WithLevel(LevelFatal, v...)
+	os.Exit(1)
 }
 
 // Fatalf logs with Logf and then exits with os.Exit(1)
 func Fatalf(format string, v ...interface{}) {
 	WithLevelf(LevelFatal, format, v...)
+	os.Exit(1)
 }
 
 // SetLogger sets the local logger


### PR DESCRIPTION
log.Fatal() will not exit with code 1

If you execute the following code.
`
if err!=nil{
    log.Faltal(err)
}
`
The expected situation is that the program prints an error and exits. Otherwise, execution with errors may cause the program to crash. 

it seems to be missing `os.exit(1)` after logging.


