### PR TITLE
fix(registry/cache): do not watch when ttl=0 eg: some custom registry no s…

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -174,7 +174,7 @@ func (c *cache) get(service string) ([]*registry.Service, error) {
 	c.RUnlock()
 
 	// check if its being watched
-	if !ok {
+	if c.opts.TTL > 0 && !ok {
 		c.Lock()
 
 		// set to watched


### PR DESCRIPTION
…upport watch
