### PR TITLE
fix: store table initialization

### DIFF
--- a/service.go
+++ b/service.go
@@ -61,11 +61,14 @@ func (s *service) Init(opts ...Option) {
 			s.opts.Logger.Log(log.FatalLevel, err)
 		}
 
-		// Explicitly set the table name to the service name
-		name := s.opts.Cmd.App().Name
-		err := s.opts.Store.Init(store.Table(name))
-		if err != nil {
-			s.opts.Logger.Log(log.FatalLevel, err)
+		// If the store has no Table set, fallback to the
+		// services name
+		if len(s.opts.Store.Options().Table) == 0 {
+			name := s.opts.Cmd.App().Name
+			err := s.opts.Store.Init(store.Table(name))
+			if err != nil {
+				s.opts.Logger.Log(log.FatalLevel, err)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Set the table name to the service name only if table name is empty.

closes #2583