### PR TITLE
fix(registry/cache): start watcher loop for other services

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -178,10 +178,7 @@ func (c *cache) get(service string) ([]*registry.Service, error) {
 		// set to watched
 		c.watched[service] = true
 
-		// only kick it off if not running
-		if !c.running {
-			go c.run(service)
-		}
+		go c.run(service)
 
 		c.Unlock()
 	}


### PR DESCRIPTION
The registry watcher loop starts only for the first service and does not for others.

Now it starts for all services and there are no "connection refused" errors when dependent services are rolling out.