### PR TITLE
fix(api/handler): avoid zombie goroutine when connection unexpectedly closes

### DIFF
--- a/api/handler/rpc/stream.go
+++ b/api/handler/rpc/stream.go
@@ -103,9 +103,13 @@ func serveWebsocket(ctx context.Context, w http.ResponseWriter, r *http.Request,
 		client.StreamingRequest(),
 	)
 
+	cCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	so := selector.WithStrategy(strategy(service.Versions))
+
 	// create a new stream
-	stream, err := c.Stream(ctx, req, client.WithSelectOption(so))
+	stream, err := c.Stream(cCtx, req, client.WithSelectOption(so))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In API handler, when serving stream through web-socket, the `writeLoop` goroutine may never finishes if the websocket connection closes unexpectedly.

Solution: Pass a cancellable context when creating a new stream.
