### PR TITLE
fix(config/source/cli): mergo.Map error, src and dst must be of same …

### DIFF
--- a/config/source/cli/cli.go
+++ b/config/source/cli/cli.go
@@ -25,7 +25,9 @@ func (c *cliSource) Read() (*source.ChangeSet, error) {
 	for _, f := range c.ctx.App.Flags {
 		name := f.Names()[0]
 		tmp := toEntry(name, c.ctx.Generic(name))
-		mergo.Map(&changes, tmp) // need to sort error handling
+		if err := mergo.Map(&changes, tmp, mergo.WithOverride); err != nil {
+			return nil, err
+		}
 	}
 
 	b, err := c.opts.Encoder.Encode(changes)


### PR DESCRIPTION
config/source/cli error

read config/srouce/cli return errr (src and dst must be of same type error).
use the Merge function with the WithOverride option to merge two structs or maps with different types .
