### PR TITLE
Add Context in event options

### DIFF
--- a/events/options.go
+++ b/events/options.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"time"
 
 	"go-micro.dev/v4/logger"
@@ -148,6 +149,8 @@ func WithTTL(d time.Duration) WriteOption {
 type ReadOptions struct {
 	// Limit the number of results to return
 	Limit uint
+	// Context should contain all implementation specific options, using context.WithValue.
+	Context context.Context
 	// Offset the results by this number, useful for paginated queries
 	Offset uint
 }
@@ -158,13 +161,13 @@ type ReadOption func(o *ReadOptions)
 // ReadLimit sets the limit attribute on ReadOptions.
 func ReadLimit(l uint) ReadOption {
 	return func(o *ReadOptions) {
-		o.Limit = 1
+		o.Limit = l
 	}
 }
 
 // ReadOffset sets the offset attribute on ReadOptions.
 func ReadOffset(l uint) ReadOption {
 	return func(o *ReadOptions) {
-		o.Offset = 1
+		o.Offset = l
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -338,7 +338,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=

--- a/util/kubernetes/client/client.go
+++ b/util/kubernetes/client/client.go
@@ -258,7 +258,9 @@ func NewService(name, version, typ, namespace string) *Service {
 		Type:     "ClusterIP",
 		Selector: Labels,
 		Ports: []ServicePort{{
-			"service-port", 8080, "",
+			Name:     "service-port",
+			Protocol: "",
+			Port:     8080,
 		}},
 	}
 


### PR DESCRIPTION
This pull request includes a bug fix and introduces additional context in the ReadOptions events, allowing for more flexibility in plugins.

Actually, the reason that I have made these changes is that I wanted to use go-micro events in my project that aims to implement a pull-based nats jetstream package for time-based consuming scenarios. 

If you wanted to know more about pull-based scenarios in nats jetstream you can refer to this link:
https://www.byronruth.com/grokking-nats-consumers-part-3/
 
These are the links related to the nats jetstream plugin and a simple example of its usage:
https://github.com/mamadeusia/CallbackService 
https://github.com/mamadeusia/plugins/tree/main/v4/events/natsjs

and if this PR were merged, I will be able to create a PR for this plugin too. 
Thanks in advance. 

I'm always open to further questions.  