### PR TITLE
util/addr: Fixes findIP to return the correct public IP

### DIFF
--- a/util/addr/addr_test.go
+++ b/util/addr/addr_test.go
@@ -1,6 +1,7 @@
 package addr
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net"
 	"testing"
 )
@@ -51,6 +52,81 @@ func TestExtractor(t *testing.T) {
 			}
 		} else if addr != d.expect {
 			t.Errorf("Expected %s got %s", d.expect, addr)
+		}
+	}
+}
+
+func TestFindIP(t *testing.T) {
+	localhost, _ := net.ResolveIPAddr("ip", "127.0.0.1")
+	localhostIPv6, _ := net.ResolveIPAddr("ip", "::1")
+	privateIP, _ := net.ResolveIPAddr("ip", "10.0.0.1")
+	publicIP, _ := net.ResolveIPAddr("ip", "100.0.0.1")
+	publicIPv6, _ := net.ResolveIPAddr("ip", "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+
+	testCases := []struct {
+		addrs  []net.Addr
+		ip     net.IP
+		errMsg string
+	}{
+		{
+			addrs:  []net.Addr{},
+			ip:     nil,
+			errMsg: ErrIPNotFound.Error(),
+		},
+		{
+			addrs: []net.Addr{localhost},
+			ip: localhost.IP,
+		},
+		{
+			addrs: []net.Addr{localhost, localhostIPv6},
+			ip: localhost.IP,
+		},
+		{
+			addrs: []net.Addr{localhostIPv6},
+			ip: localhostIPv6.IP,
+		},
+		{
+			addrs: []net.Addr{privateIP, localhost},
+			ip: privateIP.IP,
+		},
+		{
+			addrs: []net.Addr{privateIP, publicIP, localhost},
+			ip: privateIP.IP,
+		},
+		{
+			addrs: []net.Addr{publicIP, privateIP, localhost},
+			ip: privateIP.IP,
+		},
+		{
+			addrs: []net.Addr{publicIP, localhost},
+			ip: publicIP.IP,
+		},
+		{
+			addrs: []net.Addr{publicIP, localhostIPv6},
+			ip: publicIP.IP,
+		},
+		{
+			addrs: []net.Addr{localhostIPv6, publicIP},
+			ip: publicIP.IP,
+		},
+		{
+			addrs: []net.Addr{localhostIPv6, publicIPv6, publicIP},
+			ip: publicIPv6.IP,
+		},
+		{
+			addrs: []net.Addr{publicIP, publicIPv6},
+			ip: publicIP.IP,
+		},
+	}
+
+	for _, tc := range testCases {
+		ip, err := findIP(tc.addrs)
+		if tc.errMsg == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, tc.ip.String(), ip.String())
+		} else {
+			assert.NotNil(t, err)
+			assert.Equal(t, tc.errMsg, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
When run on a host with no private IP, but with a public IP available, `go-micro` incorrectly figures out its service's address and uses the loopback address. This is due to the `findIP` function in `utils/addr` returning the wrong IP address when run on a host with a Public IP and no Private IP, leading to `go-micro` advertising the wrong address for its service (e.g. when using `etcd` as the registry).

## What was done

- Update `util/addr_test.go` with a test for `findIP`. 
- Update `findIP` to return the first public IP (if available) if no private IP is available.
- Update `findIP` to return the first loopback IP (if available) if no public IP is available.
- Fix typos in the `Extract` function documentation.

## How to reproduce the initial issue

To reproduce the initial issue, you can setup a docker-compose with `etcd` and a `go-micro` service and check the information available in `etcd`.

<details><summary>Details</summary>
<p>
<br/>

**Step 1.** Create a `go-micro` app with the following `main.go`:

```go
package main

import (
	"context"
	"fmt"
	"go-micro.dev/v4"
	"os"

        _ "github.com/go-micro/plugins/v4/registry/etcd"
)

type Request struct {
	Name string `json:"name"`
}

type Response struct {
	Message string `json:"message"`
}

type Helloworld struct{}

func (h *Helloworld) Greeting(ctx context.Context, req *Request, rsp *Response) error {
	rsp.Message = "Hello " + req.Name
	return nil
}

func main() {
	serviceName := os.Getenv("SERVICE_NAME")

	fmt.Printf("--- Starting %s ---\n", serviceName)

	// create a new service
	service := micro.NewService(
		micro.Name(serviceName),
		micro.Handle(new(Helloworld)),
	)

	// initialise flags
	service.Init()

	// start the service
	err := service.Run()
	if err != nil {
		return
	}
}

```

**Step 2.** Use the following Dockerfile to build the application's image with the tag `helloworld:latest`:

```Dockerfile
# syntax=docker/dockerfile:1
FROM golang:1.20 as builder

WORKDIR /app

COPY go.mod go.sum ./
RUN go mod download

COPY . .

RUN CGO_ENABLED=0 GOOS=linux go build -o helloworld

FROM debian

WORKDIR /app

COPY --from=builder /app/helloworld /bin/helloworld

CMD ["/bin/helloworld"]
```

**Step 3.** Use the following `docker-compose.yaml` to deploy `etcd` alongside the app:

```yaml
version: "3"
services:
  etcd-test:
    container_name: etcd-test
    image: bitnami/etcd:latest
    environment:
      - ALLOW_NONE_AUTHENTICATION=yes
    networks:
      test_net:
        ipv4_address: 109.0.0.8
  helloworld1:
    container_name: helloworld
    image: helloworld:latest
    environment:
      - SERVICE_NAME=helloworld-1
      - MICRO_SERVER_ADDRESS=:8080
      - MICRO_REGISTRY=etcd
      - MICRO_REGISTRY_ADDRESS=etcd-test:2379
    depends_on:
      - etcd-test
    networks:
      test_net:
        ipv4_address: 109.0.0.10
networks:
  test_net:
    ipam:
      driver: default
      config:
        - subnet: 109.0.0.0/24
```

**Step 4.** Use the following command to get the address advertised by the service:

`docker exec -it etcd-test "/opt/bitnami/etcd/bin/etcdctl" get "" --prefix | sed -n '2 p' | jq '.nodes | first.address'`

With the docker network setup with a public IP range, it will be: `"127.0.0.1:8080"`, while without, it will use the container private IP. 

</p>
</details> 
