### PR TITLE
Avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/api/handler/event/event.go
+++ b/api/handler/event/event.go
@@ -54,7 +54,7 @@ func evRoute(namespace, myPath string) (string, string) {
 
 	// Treat /v[0-9]+ as versioning
 	// /v1/foo/bar => topic: v1.foo action: bar
-	if len(parts) >= 2 && versionRe.Match([]byte(parts[0])) {
+	if len(parts) >= 2 && versionRe.MatchString(parts[0]) {
 		topic := namespace + "." + strings.Join(parts[:2], ".")
 		action := eventName(parts[1:])
 


### PR DESCRIPTION
We should use (*regexp.Regexp).MatchString instead of (*regexp.Regexp).Match([]byte(...)) when matching string to avoid unnecessary []byte conversions. A simple one-line change for free small performance improvement.

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := versionRe.Match([]byte("v1")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := versionRe.MatchString("v1"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: go-micro.dev/v4/api/handler/event
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	11430127	       127.4 ns/op	       2 B/op	       1 allocs/op
BenchmarkMatchString-16    	12220628	        97.54 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	go-micro.dev/v4/api/handler/event	3.822s
```
