### PR TITLE
Fix registry cache broken

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -161,8 +161,8 @@ func (c *cache) get(service string) ([]*registry.Service, error) {
 		}
 
 		// cache results
-		c.Lock()
 		cp := util.Copy(services)
+		c.Lock()
 		c.set(service, services)
 		c.Unlock()
 

--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -162,10 +162,11 @@ func (c *cache) get(service string) ([]*registry.Service, error) {
 
 		// cache results
 		c.Lock()
-		c.set(service, util.Copy(services))
+		cp := util.Copy(services)
+		c.set(service, services)
 		c.Unlock()
 
-		return services, nil
+		return cp, nil
 	}
 
 	// watch service if not watched


### PR DESCRIPTION
services varable here may be shared by routines, when application changes services returned by get function may lead to other routine set a changed services to cache. （which has happened on our live evn）
we need make sure services set to cache is what we get from registry by return the copy





