### PR TITLE
Fix http transport client blocking recv

### DIFF
--- a/transport/http_client.go
+++ b/transport/http_client.go
@@ -115,13 +115,13 @@ func (h *httpTransportClient) Recv(msg *Message) (err error) {
 		var rc *http.Request
 		var ok bool
 
+		h.Lock()
 		select {
 		case rc, ok = <-h.req:
 		default:
 		}
 
 		if !ok {
-			h.Lock()
 			if len(h.reqList) == 0 {
 				h.Unlock()
 				return io.EOF
@@ -129,8 +129,8 @@ func (h *httpTransportClient) Recv(msg *Message) (err error) {
 
 			rc = h.reqList[0]
 			h.reqList = h.reqList[1:]
-			h.Unlock()
 		}
+		h.Unlock()
 
 		req = rc
 	}

--- a/transport/http_client.go
+++ b/transport/http_client.go
@@ -111,7 +111,15 @@ func (h *httpTransportClient) Recv(msg *Message) (err error) {
 	var req *http.Request
 
 	if !h.dialOpts.Stream {
-		rc, ok := <-h.req
+
+		var rc *http.Request
+		var ok bool
+
+		select {
+		case rc, ok = <-h.req:
+		default:
+		}
+
 		if !ok {
 			h.Lock()
 			if len(h.reqList) == 0 {

--- a/transport/http_client_test.go
+++ b/transport/http_client_test.go
@@ -1,0 +1,77 @@
+package transport
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestHttpClientTransport(t *testing.T) {
+	// arrange
+	l, c, err := echoHttpClient("127.0.0.1:")
+	if err != nil {
+		t.Error(err)
+	}
+	defer l.Close()
+	defer c.Close()
+
+	// act + assert
+	N := cap(c.req)
+	// Send N+1 messages to overflow the buffered channel and place the extra message in the internal buffer
+	for i := 0; i < N+1; i++ {
+		body := fmt.Sprintf("msg-%d", i)
+		if err := c.Send(&Message{Body: []byte(body)}); err != nil {
+			t.Errorf("Unexpected send err: %v", err)
+		}
+	}
+
+	// consume all requests from the buffered channel
+	for i := 0; i < N; i++ {
+		msg := Message{}
+		if err := c.Recv(&msg); err != nil {
+			t.Errorf("Unexpected recv err: %v", err)
+		}
+	}
+
+	if len(c.reqList) != 1 {
+		t.Error("Unexpected reqList")
+	}
+
+	msg := Message{}
+	if err := c.Recv(&msg); err != nil {
+		t.Errorf("Unexpected recv err: %v", err)
+	}
+	want := fmt.Sprintf("msg-%d", N)
+	got := string(msg.Body)
+	if want != got {
+		t.Errorf("Unexpected message: got %q, want %q", got, want)
+	}
+}
+
+func echoHttpClient(addr string) (*httpTransportListener, *httpTransportClient, error) {
+	tr := NewHTTPTransport()
+	l, err := tr.Listen(addr)
+	if err != nil {
+		return nil, nil, errors.Errorf("Unexpected listen err: %v", err)
+	}
+	c, err := tr.Dial(l.Addr())
+	if err != nil {
+		return nil, nil, errors.Errorf("Unexpected dial err: %v", err)
+	}
+	go l.Accept(echoHandler)
+	return l.(*httpTransportListener), c.(*httpTransportClient), nil
+}
+
+func echoHandler(sock Socket) {
+	defer sock.Close()
+	for {
+		var msg Message
+		if err := sock.Recv(&msg); err != nil {
+			return
+		}
+		if err := sock.Send(&msg); err != nil {
+			return
+		}
+	}
+}

--- a/transport/http_client_test.go
+++ b/transport/http_client_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestDefaultHttpClientTransport(t *testing.T) {
+func TestHttpTransportClient(t *testing.T) {
 	// arrange
-	l, c, err := echoHttpClient("127.0.0.1:")
+	l, c, err := echoHttpTransportClient("127.0.0.1:")
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,7 +49,7 @@ func TestDefaultHttpClientTransport(t *testing.T) {
 	}
 }
 
-func echoHttpClient(addr string) (*httpTransportListener, *httpTransportClient, error) {
+func echoHttpTransportClient(addr string) (*httpTransportListener, *httpTransportClient, error) {
 	tr := NewHTTPTransport()
 	l, err := tr.Listen(addr)
 	if err != nil {

--- a/transport/http_client_test.go
+++ b/transport/http_client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestHttpClientTransport(t *testing.T) {
+func TestDefaultHttpClientTransport(t *testing.T) {
 	// arrange
 	l, c, err := echoHttpClient("127.0.0.1:")
 	if err != nil {


### PR DESCRIPTION
I observed that the `Recv` call gets blocked in the default implementation of the HTTP transport client under certain conditions.

1) The issue is reproduced in the unit tests introduced in commit 2529793014b61e07c5c4178cedcefe144d00ab88
2) The commit 9ee16e2c27059868bd7bbd87e819369a4b91d601 demonstrates a fix for the issue
3) The commit 182b73664f7afdbbdfaf9289f63c502c31ac0ed6 fixes race condition 
The race condition lies in the fact that the `http.Response` may be associated with the wrong `http.Request`
I created a [separate branch in my repository](https://github.com/mapogolions/go-micro/tree/recv-send-race-condition) to reproduce the race condition. I added a unit test. [Here is the link](https://github.com/mapogolions/go-micro/blob/c0d57b043651abc5807c8f6a7f8fd1d68c7262e4/transport/http_client_test.go#L12). So, we need to adjust the scope of the lock to resolve the problem.

