### PR TITLE
fix: go version breaking unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.24
           check-latest: true
           cache: true
       - name: Get dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go-micro.dev/v5
 
-go 1.23
+go 1.24
 
 toolchain go1.24.1
 


### PR DESCRIPTION
tests running go 1.19 which doesn't support `toolchain`
