### PR TITLE
feat: add WebSocket transport for MCP gateway

### DIFF
--- a/gateway/mcp/mcp.go
+++ b/gateway/mcp/mcp.go
@@ -368,7 +368,7 @@ func (s *Server) watchServices() {
 	}
 }
 
-// serveHTTP starts an HTTP server with SSE transport
+// serveHTTP starts an HTTP server with SSE and WebSocket transports
 func (s *Server) serveHTTP() error {
 	mux := http.NewServeMux()
 
@@ -377,12 +377,16 @@ func (s *Server) serveHTTP() error {
 	mux.HandleFunc("/mcp/call", s.handleCallTool)
 	mux.HandleFunc("/health", s.handleHealth)
 
+	// WebSocket endpoint for bidirectional streaming
+	ws := NewWebSocketTransport(s)
+	mux.Handle("/mcp/ws", ws)
+
 	s.server = &http.Server{
 		Addr:    s.opts.Address,
 		Handler: mux,
 	}
 
-	s.opts.Logger.Printf("[mcp] MCP gateway listening on %s", s.opts.Address)
+	s.opts.Logger.Printf("[mcp] MCP gateway listening on %s (HTTP + WebSocket)", s.opts.Address)
 	return s.server.ListenAndServe()
 }
 

--- a/gateway/mcp/websocket.go
+++ b/gateway/mcp/websocket.go
@@ -1,0 +1,347 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"go-micro.dev/v5/auth"
+	"go-micro.dev/v5/metadata"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// WebSocketTransport implements MCP JSON-RPC 2.0 over WebSocket.
+// It supports bidirectional streaming for real-time AI agents.
+type WebSocketTransport struct {
+	server *Server
+}
+
+// wsConn wraps a single WebSocket connection with write serialization.
+type wsConn struct {
+	conn    *websocket.Conn
+	writeMu sync.Mutex
+	server  *Server
+	account *auth.Account // set once during initial auth
+}
+
+// NewWebSocketTransport creates a WebSocket transport for the MCP server.
+func NewWebSocketTransport(server *Server) *WebSocketTransport {
+	return &WebSocketTransport{server: server}
+}
+
+// ServeHTTP implements http.Handler and upgrades HTTP to WebSocket.
+func (t *WebSocketTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		t.server.opts.Logger.Printf("[mcp] WebSocket upgrade failed: %v", err)
+		return
+	}
+
+	// Extract bearer token from the upgrade request (if present).
+	var account *auth.Account
+	if t.server.opts.Auth != nil {
+		token := r.Header.Get("Authorization")
+		if strings.HasPrefix(token, "Bearer ") {
+			token = strings.TrimPrefix(token, "Bearer ")
+		}
+		// Allow connection-level auth from header. Per-message auth via
+		// _token param is also supported (checked in handleToolsCall).
+		if token != "" {
+			acc, err := t.server.opts.Auth.Inspect(token)
+			if err == nil {
+				account = acc
+			}
+		}
+	}
+
+	wc := &wsConn{
+		conn:    conn,
+		server:  t.server,
+		account: account,
+	}
+
+	t.server.opts.Logger.Printf("[mcp] WebSocket client connected from %s", r.RemoteAddr)
+	go wc.readLoop()
+}
+
+// readLoop reads JSON-RPC messages from the WebSocket connection.
+func (wc *wsConn) readLoop() {
+	defer wc.conn.Close()
+
+	for {
+		_, message, err := wc.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				wc.server.opts.Logger.Printf("[mcp] WebSocket read error: %v", err)
+			}
+			return
+		}
+
+		var req JSONRPCRequest
+		if err := json.Unmarshal(message, &req); err != nil {
+			wc.sendError(nil, ParseError, "Parse error", err.Error())
+			continue
+		}
+
+		if req.JSONRPC != "2.0" {
+			wc.sendError(req.ID, InvalidRequest, "Invalid request", "jsonrpc must be '2.0'")
+			continue
+		}
+
+		go wc.handleRequest(&req)
+	}
+}
+
+// handleRequest dispatches a JSON-RPC request to the appropriate handler.
+func (wc *wsConn) handleRequest(req *JSONRPCRequest) {
+	switch req.Method {
+	case "initialize":
+		wc.handleInitialize(req)
+	case "tools/list":
+		wc.handleToolsList(req)
+	case "tools/call":
+		wc.handleToolsCall(req)
+	default:
+		wc.sendError(req.ID, MethodNotFound, "Method not found", req.Method)
+	}
+}
+
+// handleInitialize handles the initialize request.
+func (wc *wsConn) handleInitialize(req *JSONRPCRequest) {
+	result := map[string]interface{}{
+		"protocolVersion": "2024-11-05",
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "go-micro-mcp",
+			"version": "1.0.0",
+		},
+	}
+	wc.sendResponse(req.ID, result)
+}
+
+// handleToolsList handles the tools/list request.
+func (wc *wsConn) handleToolsList(req *JSONRPCRequest) {
+	wc.server.toolsMu.RLock()
+	tools := make([]interface{}, 0, len(wc.server.tools))
+	for _, tool := range wc.server.tools {
+		tools = append(tools, map[string]interface{}{
+			"name":        tool.Name,
+			"description": tool.Description,
+			"inputSchema": tool.InputSchema,
+		})
+	}
+	wc.server.toolsMu.RUnlock()
+
+	wc.sendResponse(req.ID, map[string]interface{}{
+		"tools": tools,
+	})
+}
+
+// handleToolsCall handles the tools/call request.
+func (wc *wsConn) handleToolsCall(req *JSONRPCRequest) {
+	var params struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+		Token     string                 `json:"_token,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		wc.sendError(req.ID, InvalidParams, "Invalid params", err.Error())
+		return
+	}
+
+	// Get tool info
+	wc.server.toolsMu.RLock()
+	tool, exists := wc.server.tools[params.Name]
+	wc.server.toolsMu.RUnlock()
+
+	if !exists {
+		wc.sendError(req.ID, InvalidParams, "Tool not found", params.Name)
+		return
+	}
+
+	traceID := uuid.New().String()
+
+	// Start OTel span
+	ctx, span := wc.server.startToolSpan(wc.server.opts.Context, params.Name, "websocket", traceID)
+	defer span.End()
+
+	// Resolve account: prefer connection-level auth, fall back to per-message _token.
+	account := wc.account
+	if wc.server.opts.Auth != nil {
+		if account == nil {
+			token := params.Token
+			if token == "" {
+				span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "missing token"))
+				setSpanError(span, fmt.Errorf("missing token"))
+				wc.server.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: params.Name, Allowed: false, DeniedReason: "missing token"})
+				wc.sendError(req.ID, InvalidParams, "Unauthorized", "missing token")
+				return
+			}
+			if strings.HasPrefix(token, "Bearer ") {
+				token = strings.TrimPrefix(token, "Bearer ")
+			}
+			acc, err := wc.server.opts.Auth.Inspect(token)
+			if err != nil {
+				span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "invalid token"))
+				setSpanError(span, fmt.Errorf("invalid token"))
+				wc.server.audit(AuditRecord{TraceID: traceID, Timestamp: time.Now(), Tool: params.Name, Allowed: false, DeniedReason: "invalid token"})
+				wc.sendError(req.ID, InvalidParams, "Unauthorized", "invalid token")
+				return
+			}
+			account = acc
+		}
+		span.SetAttributes(attribute.String(AttrAccountID, account.ID))
+
+		// Check per-tool scopes
+		if len(tool.Scopes) > 0 {
+			span.SetAttributes(attribute.StringSlice(AttrScopesRequired, tool.Scopes))
+			if !hasScope(account.Scopes, tool.Scopes) {
+				span.SetAttributes(attribute.Bool(AttrAuthAllowed, false), attribute.String(AttrAuthDeniedReason, "insufficient scopes"))
+				setSpanError(span, fmt.Errorf("insufficient scopes"))
+				wc.server.audit(AuditRecord{
+					TraceID: traceID, Timestamp: time.Now(), Tool: params.Name,
+					AccountID: account.ID, ScopesRequired: tool.Scopes,
+					Allowed: false, DeniedReason: "insufficient scopes",
+				})
+				wc.sendError(req.ID, InvalidParams, "Forbidden", "insufficient scopes")
+				return
+			}
+		}
+	}
+
+	// Rate limit check
+	if err := wc.server.allowRate(params.Name); err != nil {
+		span.SetAttributes(attribute.Bool(AttrRateLimited, true))
+		setSpanError(span, err)
+		accountID := ""
+		if account != nil {
+			accountID = account.ID
+		}
+		wc.server.audit(AuditRecord{
+			TraceID: traceID, Timestamp: time.Now(), Tool: params.Name,
+			AccountID: accountID, Allowed: false, DeniedReason: "rate limited",
+		})
+		wc.sendError(req.ID, InternalError, "Rate limit exceeded", params.Name)
+		return
+	}
+
+	span.SetAttributes(attribute.Bool(AttrAuthAllowed, true))
+
+	// Convert arguments to JSON bytes
+	inputBytes, err := json.Marshal(params.Arguments)
+	if err != nil {
+		wc.sendError(req.ID, InternalError, "Failed to marshal arguments", err.Error())
+		return
+	}
+
+	// Build context with tracing metadata
+	md, _ := metadata.FromContext(ctx)
+	if md == nil {
+		md = make(metadata.Metadata)
+	}
+	md.Set(TraceIDKey, traceID)
+	md.Set(ToolNameKey, params.Name)
+	if account != nil {
+		md.Set(AccountIDKey, account.ID)
+	}
+	ctx = metadata.NewContext(ctx, md)
+
+	// Make RPC call
+	start := time.Now()
+	rpcReq := wc.server.opts.Client.NewRequest(tool.Service, tool.Endpoint, &struct {
+		Data []byte
+	}{Data: inputBytes})
+
+	var rsp struct {
+		Data []byte
+	}
+
+	if err := wc.server.opts.Client.Call(ctx, rpcReq, &rsp); err != nil {
+		setSpanError(span, err)
+		accountID := ""
+		if account != nil {
+			accountID = account.ID
+		}
+		wc.server.audit(AuditRecord{
+			TraceID: traceID, Timestamp: time.Now(), Tool: params.Name,
+			AccountID: accountID, ScopesRequired: tool.Scopes,
+			Allowed: true, Duration: time.Since(start), Error: err.Error(),
+		})
+		wc.sendError(req.ID, InternalError, "RPC call failed", err.Error())
+		return
+	}
+
+	setSpanOK(span)
+
+	accountID := ""
+	if account != nil {
+		accountID = account.ID
+	}
+	wc.server.audit(AuditRecord{
+		TraceID: traceID, Timestamp: time.Now(), Tool: params.Name,
+		AccountID: accountID, ScopesRequired: tool.Scopes,
+		Allowed: true, Duration: time.Since(start),
+	})
+
+	// Parse response
+	var result interface{}
+	if err := json.Unmarshal(rsp.Data, &result); err != nil {
+		result = map[string]interface{}{
+			"data": string(rsp.Data),
+		}
+	}
+
+	wc.sendResponse(req.ID, map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "text",
+				"text": fmt.Sprintf("%v", result),
+			},
+		},
+		"trace_id": traceID,
+	})
+}
+
+// sendResponse sends a JSON-RPC success response.
+func (wc *wsConn) sendResponse(id interface{}, result interface{}) {
+	wc.writeJSON(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
+// sendError sends a JSON-RPC error response.
+func (wc *wsConn) sendError(id interface{}, code int, message string, data interface{}) {
+	wc.writeJSON(JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &RPCError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	})
+}
+
+// writeJSON serializes and sends a JSON message over the WebSocket.
+func (wc *wsConn) writeJSON(v interface{}) {
+	wc.writeMu.Lock()
+	defer wc.writeMu.Unlock()
+
+	if err := wc.conn.WriteJSON(v); err != nil {
+		wc.server.opts.Logger.Printf("[mcp] WebSocket write error: %v", err)
+	}
+}

--- a/gateway/mcp/websocket_test.go
+++ b/gateway/mcp/websocket_test.go
@@ -1,0 +1,444 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-micro.dev/v5/auth"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsDialer creates a WebSocket connection to the given test server URL.
+func wsDialer(t *testing.T, url string, headers http.Header) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(url, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+// sendJSONRPC sends a JSON-RPC request and reads the response.
+func sendJSONRPC(t *testing.T, conn *websocket.Conn, method string, id interface{}, params interface{}) JSONRPCResponse {
+	t.Helper()
+	raw, _ := json.Marshal(params)
+	req := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  raw,
+	}
+	if err := conn.WriteJSON(req); err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+
+	var resp JSONRPCResponse
+	if err := conn.ReadJSON(&resp); err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	return resp
+}
+
+func newWSTestServer(t *testing.T, opts Options) (*Server, *httptest.Server) {
+	t.Helper()
+	s := newTestServer(opts)
+	ws := NewWebSocketTransport(s)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp/ws", ws)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return s, ts
+}
+
+func TestWebSocket_Initialize(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	resp := sendJSONRPC(t, conn, "initialize", 1, nil)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("expected map result")
+	}
+	if result["protocolVersion"] != "2024-11-05" {
+		t.Errorf("protocolVersion = %v, want 2024-11-05", result["protocolVersion"])
+	}
+}
+
+func TestWebSocket_ToolsList(t *testing.T) {
+	s, ts := newWSTestServer(t, Options{})
+	s.tools["svc.Echo"] = &Tool{
+		Name:        "svc.Echo",
+		Description: "Echo a message",
+		InputSchema: map[string]interface{}{"type": "object"},
+		Service:     "svc",
+		Endpoint:    "Echo",
+	}
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+	resp := sendJSONRPC(t, conn, "tools/list", 1, nil)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	result, _ := resp.Result.(map[string]interface{})
+	tools, _ := result["tools"].([]interface{})
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+}
+
+func TestWebSocket_ToolsCall_NoAuth(t *testing.T) {
+	s, ts := newWSTestServer(t, Options{})
+	s.tools["svc.Echo"] = &Tool{
+		Name:     "svc.Echo",
+		Service:  "svc",
+		Endpoint: "Echo",
+	}
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+	resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+		"name":      "svc.Echo",
+		"arguments": map[string]interface{}{"msg": "hi"},
+	})
+
+	// RPC will fail (no backend), but auth should pass (no auth configured)
+	if resp.Error == nil {
+		t.Fatal("expected RPC error (no backend)")
+	}
+	if resp.Error.Code != InternalError {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, InternalError)
+	}
+}
+
+func TestWebSocket_ToolsCall_AuthRequired(t *testing.T) {
+	ma := &mockAuth{
+		accounts: map[string]*auth.Account{
+			"valid-token": {ID: "user-1", Scopes: []string{"blog:write"}},
+		},
+	}
+
+	s, ts := newWSTestServer(t, Options{Auth: ma})
+	s.tools["svc.Do"] = &Tool{
+		Name:     "svc.Do",
+		Service:  "svc",
+		Endpoint: "Do",
+		Scopes:   []string{"blog:write"},
+	}
+
+	t.Run("missing token", func(t *testing.T) {
+		conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+		resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+			"name":      "svc.Do",
+			"arguments": map[string]interface{}{},
+		})
+		if resp.Error == nil || resp.Error.Message != "Unauthorized" {
+			t.Errorf("expected Unauthorized, got %+v", resp.Error)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+		resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+			"name":      "svc.Do",
+			"arguments": map[string]interface{}{},
+			"_token":    "bad-token",
+		})
+		if resp.Error == nil || resp.Error.Message != "Unauthorized" {
+			t.Errorf("expected Unauthorized, got %+v", resp.Error)
+		}
+	})
+
+	t.Run("valid token via param", func(t *testing.T) {
+		conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+		resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+			"name":      "svc.Do",
+			"arguments": map[string]interface{}{},
+			"_token":    "valid-token",
+		})
+		// Auth passes, RPC fails (no backend)
+		if resp.Error == nil {
+			t.Fatal("expected RPC error")
+		}
+		if resp.Error.Code != InternalError {
+			t.Errorf("error code = %d, want %d (RPC fail, not auth fail)", resp.Error.Code, InternalError)
+		}
+	})
+
+	t.Run("valid token via header", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("Authorization", "Bearer valid-token")
+		conn := wsDialer(t, ts.URL+"/mcp/ws", headers)
+		resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+			"name":      "svc.Do",
+			"arguments": map[string]interface{}{},
+		})
+		// Auth passes via connection-level header, RPC fails (no backend)
+		if resp.Error == nil {
+			t.Fatal("expected RPC error")
+		}
+		if resp.Error.Code != InternalError {
+			t.Errorf("error code = %d, want %d (RPC fail, not auth fail)", resp.Error.Code, InternalError)
+		}
+	})
+}
+
+func TestWebSocket_ToolsCall_InsufficientScopes(t *testing.T) {
+	ma := &mockAuth{
+		accounts: map[string]*auth.Account{
+			"readonly": {ID: "user-2", Scopes: []string{"blog:read"}},
+		},
+	}
+
+	s, ts := newWSTestServer(t, Options{Auth: ma})
+	s.tools["svc.Do"] = &Tool{
+		Name:     "svc.Do",
+		Service:  "svc",
+		Endpoint: "Do",
+		Scopes:   []string{"blog:write"},
+	}
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+	resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+		"name":      "svc.Do",
+		"arguments": map[string]interface{}{},
+		"_token":    "readonly",
+	})
+	if resp.Error == nil || resp.Error.Message != "Forbidden" {
+		t.Errorf("expected Forbidden, got %+v", resp.Error)
+	}
+}
+
+func TestWebSocket_ToolsCall_Audit(t *testing.T) {
+	var mu sync.Mutex
+	var records []AuditRecord
+
+	s, ts := newWSTestServer(t, Options{
+		AuditFunc: func(r AuditRecord) {
+			mu.Lock()
+			records = append(records, r)
+			mu.Unlock()
+		},
+	})
+	s.tools["svc.Do"] = &Tool{
+		Name:     "svc.Do",
+		Service:  "svc",
+		Endpoint: "Do",
+	}
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+	sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+		"name":      "svc.Do",
+		"arguments": map[string]interface{}{},
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(records) == 0 {
+		t.Fatal("expected audit record")
+	}
+	r := records[len(records)-1]
+	if r.Tool != "svc.Do" {
+		t.Errorf("audit Tool = %q, want %q", r.Tool, "svc.Do")
+	}
+	if r.TraceID == "" {
+		t.Error("audit TraceID is empty")
+	}
+}
+
+func TestWebSocket_RateLimit(t *testing.T) {
+	s, ts := newWSTestServer(t, Options{
+		RateLimit: &RateLimitConfig{RequestsPerSecond: 1, Burst: 1},
+	})
+	s.tools["svc.Do"] = &Tool{
+		Name:     "svc.Do",
+		Service:  "svc",
+		Endpoint: "Do",
+	}
+	s.limiters["svc.Do"] = newRateLimiter(1, 1)
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	params := map[string]interface{}{
+		"name":      "svc.Do",
+		"arguments": map[string]interface{}{},
+	}
+
+	// First request passes rate limit (RPC may fail, that's ok)
+	resp1 := sendJSONRPC(t, conn, "tools/call", 1, params)
+	if resp1.Error != nil && resp1.Error.Message == "Rate limit exceeded" {
+		t.Error("first request should not be rate limited")
+	}
+
+	// Second request should be rate limited
+	resp2 := sendJSONRPC(t, conn, "tools/call", 2, params)
+	if resp2.Error == nil || resp2.Error.Message != "Rate limit exceeded" {
+		t.Errorf("expected rate limit error, got %+v", resp2.Error)
+	}
+}
+
+func TestWebSocket_MethodNotFound(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	resp := sendJSONRPC(t, conn, "nonexistent/method", 1, nil)
+	if resp.Error == nil || resp.Error.Code != MethodNotFound {
+		t.Errorf("expected MethodNotFound, got %+v", resp.Error)
+	}
+}
+
+func TestWebSocket_ToolNotFound(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	resp := sendJSONRPC(t, conn, "tools/call", 1, map[string]interface{}{
+		"name":      "nonexistent.Tool",
+		"arguments": map[string]interface{}{},
+	})
+	if resp.Error == nil || resp.Error.Message != "Tool not found" {
+		t.Errorf("expected Tool not found, got %+v", resp.Error)
+	}
+}
+
+func TestWebSocket_MultipleConcurrentRequests(t *testing.T) {
+	s, ts := newWSTestServer(t, Options{})
+	s.tools["svc.Echo"] = &Tool{
+		Name:     "svc.Echo",
+		Service:  "svc",
+		Endpoint: "Echo",
+	}
+
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	// Send multiple requests sequentially (gorilla client doesn't allow
+	// concurrent writes), but the server handles them concurrently.
+	const n = 5
+	for i := 0; i < n; i++ {
+		raw, _ := json.Marshal(map[string]interface{}{
+			"name":      "svc.Echo",
+			"arguments": map[string]interface{}{},
+		})
+		req := JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      i + 1,
+			Method:  "tools/call",
+			Params:  raw,
+		}
+		if err := conn.WriteJSON(req); err != nil {
+			t.Fatalf("WriteJSON %d failed: %v", i, err)
+		}
+	}
+
+	// Read all responses (order may vary due to concurrent server handling)
+	responses := make([]JSONRPCResponse, n)
+	for i := 0; i < n; i++ {
+		if err := conn.ReadJSON(&responses[i]); err != nil {
+			t.Fatalf("ReadJSON failed at %d: %v", i, err)
+		}
+	}
+
+	for i, resp := range responses {
+		if resp.JSONRPC != "2.0" {
+			t.Errorf("response %d: jsonrpc = %q, want '2.0'", i, resp.JSONRPC)
+		}
+	}
+}
+
+func TestWebSocket_MultipleConnections(t *testing.T) {
+	s, ts := newWSTestServer(t, Options{})
+	s.tools["svc.Echo"] = &Tool{
+		Name:        "svc.Echo",
+		Description: "Echo",
+		InputSchema: map[string]interface{}{"type": "object"},
+		Service:     "svc",
+		Endpoint:    "Echo",
+	}
+
+	// Connect multiple clients simultaneously
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+			resp := sendJSONRPC(t, conn, "tools/list", idx+1, nil)
+			if resp.Error != nil {
+				t.Errorf("client %d: unexpected error: %v", idx, resp.Error)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestWebSocket_InvalidJSON(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/mcp/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Send invalid JSON
+	conn.WriteMessage(websocket.TextMessage, []byte("not json"))
+
+	var resp JSONRPCResponse
+	if err := conn.ReadJSON(&resp); err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != ParseError {
+		t.Errorf("expected ParseError, got %+v", resp.Error)
+	}
+}
+
+func TestWebSocket_InvalidJSONRPCVersion(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	req := map[string]interface{}{
+		"jsonrpc": "1.0",
+		"id":      1,
+		"method":  "initialize",
+	}
+	conn.WriteJSON(req)
+
+	var resp JSONRPCResponse
+	conn.ReadJSON(&resp)
+	if resp.Error == nil || resp.Error.Code != InvalidRequest {
+		t.Errorf("expected InvalidRequest, got %+v", resp.Error)
+	}
+}
+
+func TestWebSocket_ConnectionPersistence(t *testing.T) {
+	_, ts := newWSTestServer(t, Options{})
+	conn := wsDialer(t, ts.URL+"/mcp/ws", nil)
+
+	// Send multiple sequential requests on the same connection
+	for i := 0; i < 3; i++ {
+		resp := sendJSONRPC(t, conn, "initialize", i+1, nil)
+		if resp.Error != nil {
+			t.Errorf("request %d: unexpected error: %v", i, resp.Error)
+		}
+	}
+
+	// Connection should still be alive after a short delay
+	time.Sleep(50 * time.Millisecond)
+	resp := sendJSONRPC(t, conn, "initialize", 99, nil)
+	if resp.Error != nil {
+		t.Errorf("request after delay: unexpected error: %v", resp.Error)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-tpm v0.9.3 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/consul/api v1.32.1 h1:0+osr/3t/aZNAdJX558crU3PEjVrG4x6715aZHRgceE=
 github.com/hashicorp/consul/api v1.32.1/go.mod h1:mXUWLnxftwTmDv4W3lzxYCPD199iNLLUyLfLGFJbtl4=
 github.com/hashicorp/consul/sdk v0.16.1 h1:V8TxTnImoPD5cj0U9Spl0TUxcytjcbbJeADFF07KdHg=


### PR DESCRIPTION
Add bidirectional WebSocket transport at /mcp/ws using JSON-RPC 2.0 protocol (same as stdio). This enables persistent connections for real-time AI agents that need streaming tool interactions.

New files:
- gateway/mcp/websocket.go: WebSocketTransport with connection-level auth, per-message auth fallback, write serialization, OTel tracing
- gateway/mcp/websocket_test.go: 14 tests covering initialize, tools/list, tool calls, auth (header + param), scopes, rate limiting, audit, concurrent requests, multiple connections, error handling, and connection persistence

Changes:
- gateway/mcp/mcp.go: Register /mcp/ws handler in serveHTTP
- go.mod: Added github.com/gorilla/websocket v1.5.3

Auth supports two modes:
- Connection-level: Bearer token in WebSocket upgrade request headers
- Per-message: _token field in JSON-RPC params (same as stdio)

https://claude.ai/code/session_01GkduEhcrqcG45rdfYh8dAc