### PR TITLE
feat(client): add WithConnectionTimeout call option

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -401,6 +401,12 @@ func WithMessageContentType(ct string) MessageOption {
 	}
 }
 
+func WithConnectionTimeout(d time.Duration) CallOption {
+	return func(o *CallOptions) {
+		o.ConnectionTimeout = d
+	}
+}
+
 // Request Options
 
 func WithContentType(ct string) RequestOption {


### PR DESCRIPTION
# What
Adds WithConnectionTimeout(d time.Duration) CallOption to the client package, allowing callers to override the connection timeout on a per-call basis.

# Why
The existing ConnectionTimeout(t time.Duration) Option sets the connection timeout at the client level (applies to all calls). There was no way to override this per-call, unlike other timeouts such as WithRequestTimeout or WithDialTimeout which already have their CallOption counterparts.

This follows the existing pattern where client-level options have a corresponding With* CallOption variant.